### PR TITLE
Bugfix/derivation update

### DIFF
--- a/hdwallet/README.md
+++ b/hdwallet/README.md
@@ -12,7 +12,7 @@ Hierarchical Deterministic (HD) wallet implementation for post-quantum ML-DSA ke
 
 ## Standard expected derivation path
 We use 189189 for purpose, 0 for coin type, and account index for account
-Example: "m/189189'/0'/{account_index}'/0/0"
+Example: "m/44'/189189'/{account_index}'/0/0"
 
 ## Usage
 

--- a/hdwallet/README.md
+++ b/hdwallet/README.md
@@ -10,6 +10,10 @@ Hierarchical Deterministic (HD) wallet implementation for post-quantum ML-DSA ke
 - **Post-Quantum** - Uses ML-DSA (Dilithium) signatures
 - **Hardened First 3 Levels** - Require hardened `purpose'`, `coin_type'`, `account'`; later levels optional
 
+## Standard expected derivation path
+We use 189189 for purpose, 0 for coin type, and account index for account
+Example: "m/189189'/0'/{account_index}'/0/0"
+
 ## Usage
 
 Add to your `Cargo.toml`:

--- a/hdwallet/README.md
+++ b/hdwallet/README.md
@@ -8,7 +8,7 @@ Hierarchical Deterministic (HD) wallet implementation for post-quantum ML-DSA ke
 - **BIP-32 HD Derivation** - Hierarchical deterministic key derivation
 - **BIP-44 Compatible** - Standard derivation paths
 - **Post-Quantum** - Uses ML-DSA (Dilithium) signatures
-- **Hardened Keys Only** - Secure key derivation (no non-hardened keys)
+- **Hardened First 3 Levels** - Require hardened `purpose'`, `coin_type'`, `account'`; later levels optional
 
 ## Usage
 
@@ -46,7 +46,7 @@ let signature = child_keys.sign(message);
 
 Standard BIP-44 derivation paths are supported:
 ```
-m / purpose' / coin_type' / account' / change' / address_index'
+m / purpose' / coin_type' / account' / change / address_index
 ```
 
 Example paths:
@@ -54,11 +54,11 @@ Example paths:
 - `m/44'/0'/1'/0'/0'` - First address of second account
 - `m/44'/0'/0'/1'/0'` - First change address
 
-**Note**: Only hardened derivation (`'`) is supported for security reasons.
+**Note**: For security, the first three indices must be hardened (`purpose'`, `coin_type'`, `account'`). Subsequent indices (`change`, `address_index`) may be unhardened.
 
 ## Why Hardened Keys Only?
 
-Non-hardened key derivation relies on elliptic curve properties not present in lattice-based cryptography. For security, this implementation only supports hardened derivation paths.
+Non-hardened key derivation relies on elliptic curve properties not present in lattice-based cryptography. For security, this implementation requires hardened derivation for the first three indices and permits flexibility for deeper levels.
 
 ## Testing
 

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -92,8 +92,11 @@ impl HDLattice {
 	pub fn check_path(&self, path: &str) -> Result<(), HDLatticeError> {
 		let p = nam_tiny_hderive::bip44::DerivationPath::from_str(path)
 			.map_err(HDLatticeError::GenericError)?;
-		for element in p.iter() {
-			if !element.is_hardened() {
+		for (index, element) in p.iter().enumerate() {
+			// Enforce hardened for the first three indices (purpose, coin_type, account) as per
+			// BIP44 standard. The reason being, we do not have derivable public keys anyway, it does
+			// not work for dilithium key pairs. 
+			if index < 3 && !element.is_hardened() {
 				return Err(HDLatticeError::HardenedPathsOnly());
 			}
 		}


### PR DESCRIPTION
**Needs to be released with version bump** 

Matching BIP 44 and our mobile wallet derivation path rules

the last 2 items of derivation path are expected to be non-hardened. 

This does not change the security envelope: Each path element applies its security, so effectively we hash 3 times, once for each hardened path, each hash is quantum secure.