### PR TITLE
chore: Align Rust toolchain with chain repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Principle of least privilege: all jobs only read the repo (checkout + cargo).
+# Per-job override is unnecessary because no job pushes, creates releases or PRs.
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Rust toolchain (from rust-toolchain file)
         run: |
-          rustup show active-toolchain || rustup toolchain install
+          rustup toolchain install
           rustup component add rustfmt --toolchain nightly
       - name: Install taplo
         run: cargo install taplo-cli --locked
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust toolchain (from rust-toolchain file)
-        run: rustup show active-toolchain || rustup toolchain install
+        run: rustup toolchain install
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust toolchain (from rust-toolchain file)
-        run: rustup show active-toolchain || rustup toolchain install
+        run: rustup toolchain install
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Rust toolchain (from rust-toolchain file)
         run: |
-          rustup show active-toolchain || rustup toolchain install
+          rustup toolchain install
           rustup component add clippy rust-src
       - name: Cache cargo registry
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: 🏁 Fast Checks (Format)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust toolchain (from rust-toolchain file)
         run: |
           rustup show active-toolchain || rustup toolchain install
@@ -56,11 +56,11 @@ jobs:
           - ubuntu-latest
           - macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust toolchain (from rust-toolchain file)
         run: rustup show active-toolchain || rustup toolchain install
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -77,11 +77,11 @@ jobs:
     needs: fast-checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust toolchain (from rust-toolchain file)
         run: rustup show active-toolchain || rustup toolchain install
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -101,13 +101,13 @@ jobs:
     needs: fast-checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust toolchain (from rust-toolchain file)
         run: |
           rustup show active-toolchain || rustup toolchain install
           rustup component add clippy rust-src
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -126,7 +126,7 @@ jobs:
     needs: fast-checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install required components
-        run: rustup component add rustfmt --toolchain nightly
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add rustfmt --toolchain nightly
       - name: Install taplo
         run: cargo install taplo-cli --locked
       - name: Run format checks
@@ -48,14 +50,10 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-        rust:
-          - stable
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust ${{ matrix.rust }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: rustup show active-toolchain || rustup toolchain install
       - name: Cache cargo registry
         uses: actions/cache@v3
         with:
@@ -69,16 +67,40 @@ jobs:
       - name: Test workspace
         run: cargo test --workspace --locked
 
+  no-std-build:
+    name: 📦 no_std Build (wasm32v1-none)
+    needs: fast-checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: rustup show active-toolchain || rustup toolchain install
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+      # wasm32v1-none is the target used by Substrate runtimes (chain, chain-update2512,
+      # libp2p-identity-pqc, qp-libp2p-identity) which depend on these crates as no_std.
+      # A regression here breaks the entire downstream stack.
+      - name: Build dilithium for wasm32v1-none (no_std)
+        run: cargo build --locked --target wasm32v1-none -p qp-rusty-crystals-dilithium --no-default-features
+      - name: Build hdwallet for wasm32v1-none (no_std)
+        run: cargo build --locked --target wasm32v1-none -p qp-rusty-crystals-hdwallet --no-default-features
+
   analysis:
     name: 🤖 Analysis (Clippy & Doc)
     needs: fast-checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rust-src
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add clippy rust-src
       - name: Cache cargo registry
         uses: actions/cache@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+---
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+# No scheduled scans by design: every code change reaches master via push or PR,
+# both of which trigger this workflow. Security advisories for Rust dependencies
+# are independently caught by `cargo audit` in ci.yml.
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # `actions` covers GitHub Actions workflow hygiene (e.g. the
+        # `actions/missing-workflow-permissions` rule that triggered this setup).
+        # `rust` can be added once you decide whether to scan source as well.
+        language: [actions]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,20 +20,29 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        # `actions` covers GitHub Actions workflow hygiene (e.g. the
-        # `actions/missing-workflow-permissions` rule that triggered this setup).
-        # `rust` can be added once you decide whether to scan source as well.
-        language: [actions]
+        include:
+          # `actions` covers GitHub Actions workflow hygiene (e.g. the
+          # `actions/missing-workflow-permissions` rule).
+          - language: actions
+            build-mode: none
+          # `rust` is GA since Oct 2025 and supports build-mode `none`,
+          # so we get source-level analysis without compiling the workspace.
+          # Note: `cargo audit` in ci.yml stays as the authoritative source
+          # for known CVEs in dependencies; CodeQL adds taint/quality checks
+          # on our own source.
+          - language: rust
+            build-mode: none
     steps:
       - uses: actions/checkout@v5
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/create-dilithium-release-proposal.yml
+++ b/.github/workflows/create-dilithium-release-proposal.yml
@@ -45,7 +45,7 @@ jobs:
       source_branch: ${{ steps.vars.outputs.source_branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -122,7 +122,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-dilithium-release-proposal.yml
+++ b/.github/workflows/create-dilithium-release-proposal.yml
@@ -30,6 +30,11 @@ on:
         type: boolean
         default: false
 
+# Default to read-only; the version-bump job overrides with `contents: write`
+# (it pushes a release branch and uses ADMIN_PAT for `gh pr create`).
+permissions:
+  contents: read
+
 jobs:
   calculate-next-version:
     name: 🧮 Calculate Next Dilithium Version

--- a/.github/workflows/create-dilithium-release-tag-and-publish.yml
+++ b/.github/workflows/create-dilithium-release-tag-and-publish.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - master
 
+# Default to read-only; jobs that need to push tags or create releases
+# override this with explicit `contents: write` (see create-tag, create-github-release).
+permissions:
+  contents: read
+
 jobs:
   create-tag:
     name: Create Dilithium Tag

--- a/.github/workflows/create-dilithium-release-tag-and-publish.yml
+++ b/.github/workflows/create-dilithium-release-tag-and-publish.yml
@@ -62,8 +62,10 @@ jobs:
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
-      - name: Install required components
-        run: rustup component add rustfmt --toolchain nightly
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add rustfmt --toolchain nightly
 
       - name: Install taplo
         run: cargo install taplo-cli --locked
@@ -83,10 +85,10 @@ jobs:
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rust-src
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add clippy rust-src
 
       - name: Cache cargo registry
         uses: actions/cache@v3

--- a/.github/workflows/create-dilithium-release-tag-and-publish.yml
+++ b/.github/workflows/create-dilithium-release-tag-and-publish.yml
@@ -27,7 +27,7 @@ jobs:
       is_draft: ${{ steps.extract_version.outputs.is_draft }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
@@ -96,7 +96,7 @@ jobs:
           rustup component add clippy rust-src
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
@@ -151,7 +151,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.version }}
           fetch-depth: 0

--- a/.github/workflows/create-dilithium-release-tag-and-publish.yml
+++ b/.github/workflows/create-dilithium-release-tag-and-publish.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install Rust toolchain (from rust-toolchain file)
         run: |
-          rustup show active-toolchain || rustup toolchain install
+          rustup toolchain install
           rustup component add rustfmt --toolchain nightly
 
       - name: Install taplo
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install Rust toolchain (from rust-toolchain file)
         run: |
-          rustup show active-toolchain || rustup toolchain install
+          rustup toolchain install
           rustup component add clippy rust-src
 
       - name: Cache cargo registry
@@ -156,6 +156,12 @@ jobs:
           ref: ${{ needs.create-tag.outputs.version }}
           fetch-depth: 0
           fetch-tags: true
+
+      # Required before `cargo publish` below: rustup does not auto-install the
+      # active toolchain anymore, so we must install the version pinned in
+      # `rust-toolchain` explicitly. Idempotent if already present.
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: rustup toolchain install
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/create-hdwallet-release-proposal.yml
+++ b/.github/workflows/create-hdwallet-release-proposal.yml
@@ -51,7 +51,7 @@ jobs:
       source_branch: ${{ steps.vars.outputs.source_branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -145,7 +145,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-hdwallet-release-proposal.yml
+++ b/.github/workflows/create-hdwallet-release-proposal.yml
@@ -35,6 +35,11 @@ on:
         type: boolean
         default: false
 
+# Default to read-only; the version-bump job overrides with `contents: write`
+# (it pushes a release branch and uses ADMIN_PAT for `gh pr create`).
+permissions:
+  contents: read
+
 jobs:
   calculate-next-version:
     name: 🧮 Calculate Next HDWallet Version

--- a/.github/workflows/create-hdwallet-release-tag-and-publish.yml
+++ b/.github/workflows/create-hdwallet-release-tag-and-publish.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - master
 
+# Default to read-only; jobs that need to push tags or create releases
+# override this with explicit `contents: write` (see create-tag, create-github-release).
+permissions:
+  contents: read
+
 jobs:
   create-tag:
     name: Create HDWallet Tag

--- a/.github/workflows/create-hdwallet-release-tag-and-publish.yml
+++ b/.github/workflows/create-hdwallet-release-tag-and-publish.yml
@@ -62,8 +62,10 @@ jobs:
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
-      - name: Install required components
-        run: rustup component add rustfmt --toolchain nightly
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add rustfmt --toolchain nightly
 
       - name: Install taplo
         run: cargo install taplo-cli --locked
@@ -83,10 +85,10 @@ jobs:
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rust-src
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add clippy rust-src
 
       - name: Cache cargo registry
         uses: actions/cache@v3

--- a/.github/workflows/create-hdwallet-release-tag-and-publish.yml
+++ b/.github/workflows/create-hdwallet-release-tag-and-publish.yml
@@ -27,7 +27,7 @@ jobs:
       is_draft: ${{ steps.extract_version.outputs.is_draft }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
@@ -96,7 +96,7 @@ jobs:
           rustup component add clippy rust-src
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
@@ -151,7 +151,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.version }}
           fetch-depth: 0

--- a/.github/workflows/create-hdwallet-release-tag-and-publish.yml
+++ b/.github/workflows/create-hdwallet-release-tag-and-publish.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install Rust toolchain (from rust-toolchain file)
         run: |
-          rustup show active-toolchain || rustup toolchain install
+          rustup toolchain install
           rustup component add rustfmt --toolchain nightly
 
       - name: Install taplo
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install Rust toolchain (from rust-toolchain file)
         run: |
-          rustup show active-toolchain || rustup toolchain install
+          rustup toolchain install
           rustup component add clippy rust-src
 
       - name: Cache cargo registry
@@ -156,6 +156,12 @@ jobs:
           ref: ${{ needs.create-tag.outputs.version }}
           fetch-depth: 0
           fetch-tags: true
+
+      # Required before `cargo publish` below: rustup does not auto-install the
+      # active toolchain anymore, so we must install the version pinned in
+      # `rust-toolchain` explicitly. Idempotent if already present.
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: rustup toolchain install
 
       - name: Create GitHub Release
         env:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.93.0"
 components = ["clippy", "rustfmt"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32v1-none"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Aligns this repository's Rust toolchain with the `chain` repo and hardens the CI / security baseline.

### Rust toolchain unification

- Pins `rust-toolchain` to **`1.93.0`** with target **`wasm32v1-none`**, matching the `chain` repo exactly.
- All workflows now honor `rust-toolchain` via `rustup` instead of forcing `stable` through `dtolnay/rust-toolchain@stable`.
- Adds a dedicated `no_std` build job that compiles `dilithium` and `hdwallet` for `wasm32v1-none --no-default-features` — the exact configuration the downstream Substrate runtime depends on. A regression here would have broken the entire downstream stack silently.

### CodeQL enabled correctly for `actions` and `rust`

- New `codeql.yml` (Advanced Setup) with no scheduled scans — every change reaches `master` via push or PR, so the schedule would only add noise.
- Matrix scans both:
  - **`actions`** — workflow hygiene rules (e.g. `actions/missing-workflow-permissions`).
  - **`rust`** — source-level taint and quality queries via `build-mode: none` (no full `cargo build` in the CodeQL job).
- Adds least-privilege `permissions:` blocks to all workflows, resolving the existing `actions/missing-workflow-permissions` alert.
- Rust dependency CVEs remain covered by `cargo audit` in `ci.yml` — `codeql.yml` is purposefully not duplicating that.

### Action dependencies bumped to Node.js 24

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v5` |
| `actions/cache` | `v3` | `v5` |
| `github/codeql-action/init` | `v3` | `v4` |
| `github/codeql-action/analyze` | `v3` | `v4` |

Clears the deprecation warning about Node.js 20 actions being forced to Node.js 24 in June 2026 and removed from runners in September 2026.