### PR TITLE
Fix issues in threshold 2

### DIFF
--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -21,16 +21,20 @@
 //!
 //! # Security
 //!
-//! The DKG contribution uses secret material from the master share, ensuring
-//! that outsiders cannot compute the derived shares even though the tweak
-//! is public.
+//! The contribution input is bound to the share's actual secret polynomials
+//! (`s1`, `s2`), which are the only true secret material in a `PrivateKeyShare`.
+//! The legacy `key` byte string is *not* used here, because in the DKG path it is
+//! derived deterministically from public values (`rho`, `party_id`) and therefore
+//! provides no secrecy.
+
+use alloc::vec::Vec;
 
 use qp_rusty_crystals_dilithium::fips202;
 
 use crate::keys::PrivateKeyShare;
 
 /// Domain separator for DKG contribution derivation.
-const DKG_CONTRIBUTION_DOMAIN: &[u8] = b"near-mpc-dilithium-dkg-contribution-v1";
+const DKG_CONTRIBUTION_DOMAIN: &[u8] = b"near-mpc-dilithium-dkg-contribution-v2";
 
 /// Derive a DKG contribution from a master share and tweak.
 ///
@@ -52,43 +56,60 @@ const DKG_CONTRIBUTION_DOMAIN: &[u8] = b"near-mpc-dilithium-dkg-contribution-v1"
 ///
 /// # Security
 ///
-/// The contribution uses SHAKE256 with domain separation. The input includes
-/// the master share's secret key material, ensuring that even though the tweak
-/// is public, only parties holding valid master shares can compute their DKG
-/// contributions.
-///
-/// # Example
-/// ```ignore
-/// use qp_rusty_crystals_threshold::derivation::derive_dkg_contribution;
-///
-/// // Tweak is computed by the caller (e.g., from NEAR MPC contract's derive_dilithium_tweak)
-/// let tweak: [u8; 32] = compute_tweak("alice.near", "ethereum");
-/// let contribution = derive_dkg_contribution(&my_master_share, &tweak);
-///
-/// // Use contribution as seed for DKG randomness
-/// ```
+/// The contribution is computed as
+/// `SHAKE256(domain || party_id || tweak || H(secret_shares))`,
+/// where `secret_shares` is the canonical serialization of every `(subset_mask, s1, s2)`
+/// triple in the share. The shares are the actual cryptographic secret of the threshold
+/// scheme, so an attacker who does not hold a valid `PrivateKeyShare` cannot compute
+/// `derive_dkg_contribution` for any party — even though `party_id`, `tweak`, and
+/// `rho` are public.
 pub fn derive_dkg_contribution(master_share: &PrivateKeyShare, tweak: &[u8; 32]) -> [u8; 32] {
-	// Get secret material from the master share
-	// We use the key field which contains the private key seed
-	let secret_material = master_share.key();
-
-	// Include party_id to ensure different parties get different contributions
-	// even if they somehow had the same key material
 	let party_id_bytes = master_share.party_id().to_le_bytes();
+	let shares_digest = hash_secret_shares(master_share);
 
-	// Use SHAKE256 for key derivation with domain separation
-	// Input: domain || secret || party_id || tweak
 	let mut state = fips202::KeccakState::default();
 	fips202::shake256_absorb(&mut state, DKG_CONTRIBUTION_DOMAIN, DKG_CONTRIBUTION_DOMAIN.len());
-	fips202::shake256_absorb(&mut state, secret_material, secret_material.len());
 	fips202::shake256_absorb(&mut state, &party_id_bytes, party_id_bytes.len());
 	fips202::shake256_absorb(&mut state, tweak, tweak.len());
+	fips202::shake256_absorb(&mut state, &shares_digest, shares_digest.len());
 	fips202::shake256_finalize(&mut state);
 
 	let mut contribution = [0u8; 32];
 	fips202::shake256_squeeze(&mut contribution, 32, &mut state);
 
 	contribution
+}
+
+/// Hash all secret share polynomials into a 64-byte digest for use as keying material.
+///
+/// `BTreeMap` iteration is deterministic by key, so the digest is stable across calls
+/// and across machines holding the same share data.
+pub(crate) fn hash_secret_shares(master_share: &PrivateKeyShare) -> [u8; 64] {
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, b"threshold-share-digest-v1", 25);
+	fips202::shake256_absorb(&mut state, &master_share.party_id().to_le_bytes(), 4);
+
+	let mut buf: Vec<u8> = Vec::new();
+	for (subset_mask, share_data) in master_share.shares() {
+		buf.clear();
+		buf.extend_from_slice(&subset_mask.to_le_bytes());
+		for poly in &share_data.s1 {
+			for coeff in poly {
+				buf.extend_from_slice(&coeff.to_le_bytes());
+			}
+		}
+		for poly in &share_data.s2 {
+			for coeff in poly {
+				buf.extend_from_slice(&coeff.to_le_bytes());
+			}
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+
+	fips202::shake256_finalize(&mut state);
+	let mut digest = [0u8; 64];
+	fips202::shake256_squeeze(&mut digest, 64, &mut state);
+	digest
 }
 
 /// Identifier for a derived key, used for storage lookup.
@@ -114,19 +135,32 @@ impl DerivedKeyId {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::participants::ParticipantList;
+	use crate::{keys::SecretShareData, participants::ParticipantList};
 
-	/// Helper to create a test PrivateKeyShare
-	fn create_test_share(party_id: u32, key: [u8; 32]) -> PrivateKeyShare {
+	/// Helper to create a test PrivateKeyShare with synthetic share data.
+	///
+	/// The `key_byte` value is fanned out into both the legacy `key` field and the
+	/// (now security-relevant) `s1`/`s2` polynomial coefficients, so callers that
+	/// previously distinguished shares by their `key` parameter still get distinct
+	/// derivation outputs under the new contribution function.
+	fn create_test_share(party_id: u32, key_byte: u8) -> PrivateKeyShare {
 		let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
+		let mut shares = std::collections::BTreeMap::new();
+		shares.insert(
+			0b011,
+			SecretShareData {
+				s1: vec![[key_byte as i32; 256]; 7],
+				s2: vec![[key_byte as i32; 256]; 8],
+			},
+		);
 		PrivateKeyShare::new(
 			party_id,
-			3, // total_parties
-			2, // threshold
-			key,
-			[0u8; 32],                         // rho
-			[0u8; 64],                         // tr
-			std::collections::BTreeMap::new(), // shares
+			3,
+			2,
+			[key_byte; 32],
+			[0u8; 32],
+			[0u8; 64],
+			shares,
 			dkg_participants,
 		)
 	}
@@ -147,7 +181,7 @@ mod tests {
 
 	#[test]
 	fn test_derive_dkg_contribution_deterministic() {
-		let share = create_test_share(0, [42u8; 32]);
+		let share = create_test_share(0, 42);
 		let tweak = test_tweak("alice.near", "ethereum");
 
 		let contribution1 = derive_dkg_contribution(&share, &tweak);
@@ -159,9 +193,8 @@ mod tests {
 	fn test_derive_dkg_contribution_different_parties() {
 		let tweak = test_tweak("alice.near", "ethereum");
 
-		// Different party IDs with same key should produce different contributions
-		let share0 = create_test_share(0, [42u8; 32]);
-		let share1 = create_test_share(1, [42u8; 32]);
+		let share0 = create_test_share(0, 42);
+		let share1 = create_test_share(1, 42);
 
 		let contribution0 = derive_dkg_contribution(&share0, &tweak);
 		let contribution1 = derive_dkg_contribution(&share1, &tweak);
@@ -172,9 +205,8 @@ mod tests {
 	fn test_derive_dkg_contribution_different_keys() {
 		let tweak = test_tweak("alice.near", "ethereum");
 
-		// Different key material should produce different contributions
-		let share_a = create_test_share(0, [1u8; 32]);
-		let share_b = create_test_share(0, [2u8; 32]);
+		let share_a = create_test_share(0, 1);
+		let share_b = create_test_share(0, 2);
 
 		let contribution_a = derive_dkg_contribution(&share_a, &tweak);
 		let contribution_b = derive_dkg_contribution(&share_b, &tweak);
@@ -183,7 +215,7 @@ mod tests {
 
 	#[test]
 	fn test_derive_dkg_contribution_different_tweaks() {
-		let share = create_test_share(0, [42u8; 32]);
+		let share = create_test_share(0, 42);
 
 		let tweak_eth = test_tweak("alice.near", "ethereum");
 		let tweak_btc = test_tweak("alice.near", "bitcoin");
@@ -191,6 +223,46 @@ mod tests {
 		let contribution_eth = derive_dkg_contribution(&share, &tweak_eth);
 		let contribution_btc = derive_dkg_contribution(&share, &tweak_btc);
 		assert_ne!(contribution_eth, contribution_btc);
+	}
+
+	#[test]
+	fn test_contribution_independent_of_legacy_key_field() {
+		// Two shares that differ ONLY in the publicly-derivable `key` byte string
+		// must still produce the same contribution, because security comes from the
+		// secret polynomial shares, not from `key`.
+		let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
+		let mut shares = std::collections::BTreeMap::new();
+		shares.insert(
+			0b011,
+			SecretShareData { s1: vec![[7i32; 256]; 7], s2: vec![[7i32; 256]; 8] },
+		);
+		let share_a = PrivateKeyShare::new(
+			0,
+			3,
+			2,
+			[1u8; 32],
+			[0u8; 32],
+			[0u8; 64],
+			shares.clone(),
+			dkg_participants.clone(),
+		);
+		let share_b = PrivateKeyShare::new(
+			0,
+			3,
+			2,
+			[2u8; 32], // different `key`, same shares
+			[0u8; 32],
+			[0u8; 64],
+			shares,
+			dkg_participants,
+		);
+
+		let tweak = test_tweak("alice.near", "ethereum");
+		assert_eq!(
+			derive_dkg_contribution(&share_a, &tweak),
+			derive_dkg_contribution(&share_b, &tweak),
+			"contribution must depend on secret share polynomials, not on `key` field"
+		);
 	}
 
 	#[test]

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -232,10 +232,8 @@ mod tests {
 		// secret polynomial shares, not from `key`.
 		let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
 		let mut shares = std::collections::BTreeMap::new();
-		shares.insert(
-			0b011,
-			SecretShareData { s1: vec![[7i32; 256]; 7], s2: vec![[7i32; 256]; 8] },
-		);
+		shares
+			.insert(0b011, SecretShareData { s1: vec![[7i32; 256]; 7], s2: vec![[7i32; 256]; 8] });
 		let share_a = PrivateKeyShare::new(
 			0,
 			3,

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -875,12 +875,32 @@ fn build_private_share<S: TranscriptSigner>(
 		);
 	}
 
-	// Generate a deterministic key for this party
+	// Derive `party_key` from the actual secret share polynomials so that this byte
+	// string carries real entropy, not just a hash of the public `rho` and `party_id`.
+	// We still mix in `rho` and `party_id` for domain separation, but the security of
+	// `party_key` now depends on knowing the secret subset shares.
 	let mut party_key = [0u8; 32];
 	{
 		let mut h = fips202::KeccakState::default();
+		fips202::shake256_absorb(&mut h, b"dkg-party-key-v2", 16);
 		fips202::shake256_absorb(&mut h, &state.rho, 32);
 		fips202::shake256_absorb(&mut h, &state.config.my_party_id.to_le_bytes(), 4);
+		let mut buf: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+		for (subset_mask, contribution) in &state.my_contributions {
+			buf.clear();
+			buf.extend_from_slice(&subset_mask.to_le_bytes());
+			for poly in &contribution.s1 {
+				for coeff in poly {
+					buf.extend_from_slice(&coeff.to_le_bytes());
+				}
+			}
+			for poly in &contribution.s2 {
+				for coeff in poly {
+					buf.extend_from_slice(&coeff.to_le_bytes());
+				}
+			}
+			fips202::shake256_absorb(&mut h, &buf, buf.len());
+		}
 		fips202::shake256_finalize(&mut h);
 		fips202::shake256_squeeze(&mut party_key, 32, &mut h);
 	}

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -27,8 +27,7 @@ use super::{
 		derive_subset_contribution, h_commit, h_commit_pk, h_keygen, h_seed, MithrilDkgConfig,
 		MithrilDkgMessage, MithrilRound1Broadcast, MithrilRound1Private, MithrilRound2Broadcast,
 		MithrilRound3Broadcast, MithrilRound4Broadcast, PartialPublicKey, ParticipantId,
-		SubsetContribution, SubsetMask, TranscriptSigner, RANDOMNESS_SIZE,
-		SHARED_SECRET_SIZE,
+		SubsetContribution, SubsetMask, TranscriptSigner, RANDOMNESS_SIZE, SHARED_SECRET_SIZE,
 	},
 };
 
@@ -791,11 +790,8 @@ fn compute_partial_pk(
 	contribution: &SubsetContribution,
 	subset_mask: SubsetMask,
 ) -> PartialPublicKey {
-	let t = crate::protocol::partial_pk::compute_partial_pk_t(
-		rho,
-		&contribution.s1,
-		&contribution.s2,
-	);
+	let t =
+		crate::protocol::partial_pk::compute_partial_pk_t(rho, &contribution.s1, &contribution.s2);
 	PartialPublicKey { subset_mask, t }
 }
 
@@ -803,10 +799,7 @@ fn combine_partial_pks(
 	rho: &[u8; 32],
 	partial_pks: &BTreeMap<SubsetMask, PartialPublicKey>,
 ) -> Result<PublicKey, MithrilDkgError> {
-	Ok(crate::protocol::partial_pk::pack_combined_pk(
-		rho,
-		partial_pks.values().map(|pk| &pk.t),
-	))
+	Ok(crate::protocol::partial_pk::pack_combined_pk(rho, partial_pks.values().map(|pk| &pk.t)))
 }
 
 fn build_private_share<S: TranscriptSigner>(

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -27,17 +27,14 @@ use super::{
 		derive_subset_contribution, h_commit, h_commit_pk, h_keygen, h_seed, MithrilDkgConfig,
 		MithrilDkgMessage, MithrilRound1Broadcast, MithrilRound1Private, MithrilRound2Broadcast,
 		MithrilRound3Broadcast, MithrilRound4Broadcast, PartialPublicKey, ParticipantId,
-		SubsetContribution, SubsetMask, TranscriptSigner, K, N, RANDOMNESS_SIZE,
+		SubsetContribution, SubsetMask, TranscriptSigner, RANDOMNESS_SIZE,
 		SHARED_SECRET_SIZE,
 	},
 };
 
-use qp_rusty_crystals_dilithium::{fips202, packing, polyvec};
+use qp_rusty_crystals_dilithium::fips202;
 
 const ETA: i32 = 2; // ML-DSA-87 eta parameter
-const Q: i32 = 8380417;
-const PUBLIC_KEY_SIZE: usize = 2592; // ML-DSA-87
-const TR_SIZE: usize = 64;
 
 // ============================================================================
 // Error Types
@@ -122,6 +119,10 @@ impl fmt::Display for MithrilDkgError {
 /// - `SendMany`: Broadcast the data to all other participants
 /// - `SendPrivate`: Send the data to a specific participant via secure channel
 /// - `Return`: The DKG is complete, the output contains the keys
+///
+/// `Return` carries a boxed [`MithrilDkgOutput`] because the output is ~2.8 KB
+/// (full Dilithium key material) and inlining it would balloon every other
+/// variant. See `clippy::large_enum_variant`.
 #[derive(Debug)]
 pub enum MithrilAction {
 	/// Wait for more messages before proceeding.
@@ -131,7 +132,7 @@ pub enum MithrilAction {
 	/// Send data privately to a specific participant.
 	SendPrivate(ParticipantId, Vec<u8>),
 	/// DKG is complete, return the output.
-	Return(MithrilDkgOutput),
+	Return(Box<MithrilDkgOutput>),
 }
 
 // ============================================================================
@@ -774,7 +775,8 @@ impl<S: TranscriptSigner, R: RngCore + CryptoRng> MithrilDkg<S, R> {
 		// Build private key share
 		let private_share = build_private_share(&state, &public_key)?;
 
-		self.state = MithrilDkgState::Complete(MithrilDkgOutput { public_key, private_share });
+		self.state =
+			MithrilDkgState::Complete(Box::new(MithrilDkgOutput { public_key, private_share }));
 
 		Ok(())
 	}
@@ -789,75 +791,22 @@ fn compute_partial_pk(
 	contribution: &SubsetContribution,
 	subset_mask: SubsetMask,
 ) -> PartialPublicKey {
-	// Create and expand matrix A row by row to avoid Copy requirement
-	let mut mat: Vec<polyvec::Polyvecl> = (0..K).map(|_| polyvec::Polyvecl::default()).collect();
-	polyvec::matrix_expand(&mut mat, rho);
-
-	let mut s1 = polyvec::Polyvecl::default();
-	for (i, poly_coeffs) in contribution.s1.iter().enumerate() {
-		for (j, &coeff) in poly_coeffs.iter().enumerate() {
-			s1.vec[i].coeffs[j] = coeff;
-		}
-	}
-
-	let mut s2 = polyvec::Polyveck::default();
-	for (i, poly_coeffs) in contribution.s2.iter().enumerate() {
-		for (j, &coeff) in poly_coeffs.iter().enumerate() {
-			s2.vec[i].coeffs[j] = coeff;
-		}
-	}
-
-	let mut s1_hat = s1.clone();
-	polyvec::l_ntt(&mut s1_hat);
-
-	let mut t = polyvec::Polyveck::default();
-	polyvec::matrix_pointwise_montgomery(&mut t, &mat, &s1_hat);
-	polyvec::k_invntt_tomont(&mut t);
-	polyvec::k_add(&mut t, &s2);
-	polyvec::k_reduce(&mut t);
-	polyvec::k_caddq(&mut t);
-
-	let mut t_coeffs = vec![[0i32; N]; K];
-	for (i, poly) in t.vec.iter().enumerate() {
-		for (j, &coeff) in poly.coeffs.iter().enumerate() {
-			t_coeffs[i][j] = coeff;
-		}
-	}
-
-	PartialPublicKey { subset_mask, t: t_coeffs }
+	let t = crate::protocol::partial_pk::compute_partial_pk_t(
+		rho,
+		&contribution.s1,
+		&contribution.s2,
+	);
+	PartialPublicKey { subset_mask, t }
 }
 
 fn combine_partial_pks(
 	rho: &[u8; 32],
 	partial_pks: &BTreeMap<SubsetMask, PartialPublicKey>,
 ) -> Result<PublicKey, MithrilDkgError> {
-	let mut t = polyvec::Polyveck::default();
-
-	for pk in partial_pks.values() {
-		for (i, poly_coeffs) in pk.t.iter().enumerate() {
-			for (j, &coeff) in poly_coeffs.iter().enumerate() {
-				t.vec[i].coeffs[j] = (t.vec[i].coeffs[j] + coeff) % Q;
-			}
-		}
-	}
-
-	polyvec::k_reduce(&mut t);
-	polyvec::k_caddq(&mut t);
-
-	let mut t0 = polyvec::Polyveck::default();
-	let mut t1 = t.clone();
-	polyvec::k_power2round(&mut t1, &mut t0);
-
-	let mut pk_packed = [0u8; PUBLIC_KEY_SIZE];
-	packing::pack_pk(&mut pk_packed, rho, &t1);
-
-	let mut tr = [0u8; TR_SIZE];
-	let mut h_tr = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut h_tr, &pk_packed, pk_packed.len());
-	fips202::shake256_finalize(&mut h_tr);
-	fips202::shake256_squeeze(&mut tr, TR_SIZE, &mut h_tr);
-
-	Ok(PublicKey::new(pk_packed, tr))
+	Ok(crate::protocol::partial_pk::pack_combined_pk(
+		rho,
+		partial_pks.values().map(|pk| &pk.t),
+	))
 }
 
 fn build_private_share<S: TranscriptSigner>(
@@ -1038,7 +987,7 @@ where
 					},
 					MithrilAction::Return(output) => {
 						made_progress = true;
-						outputs[party_id] = Some(output);
+						outputs[party_id] = Some(*output);
 					},
 				}
 			}
@@ -1375,7 +1324,7 @@ mod tests {
 						},
 						Ok(MithrilAction::Return(output)) => {
 							made_progress = true;
-							outputs[party_id] = Some(output);
+							outputs[party_id] = Some(*output);
 						},
 						Err(e) => {
 							errors[party_id] = Some(e);
@@ -1502,7 +1451,7 @@ mod tests {
 						},
 						Ok(MithrilAction::Return(output)) => {
 							made_progress = true;
-							outputs[party_id] = Some(output);
+							outputs[party_id] = Some(*output);
 						},
 						Err(e) => {
 							errors[party_id] = Some(e);
@@ -1630,7 +1579,7 @@ mod tests {
 						},
 						Ok(MithrilAction::Return(output)) => {
 							made_progress = true;
-							outputs[party_id] = Some(output);
+							outputs[party_id] = Some(*output);
 						},
 						Err(e) => {
 							errors[party_id] = Some(e);

--- a/threshold/src/keygen/dkg/state.rs
+++ b/threshold/src/keygen/dkg/state.rs
@@ -119,13 +119,18 @@ pub struct MithrilDkgOutput {
 }
 
 /// DKG state machine.
+///
+/// `Complete` carries a boxed `MithrilDkgOutput` because the output is ~2.8 KB
+/// (full Dilithium key material), and inlining it would force every other
+/// variant — and every callsite holding a `MithrilDkgState` — to reserve that
+/// space. See `clippy::large_enum_variant`.
 pub enum MithrilDkgState<S: TranscriptSigner> {
 	Initialized(MithrilDkgConfig<S>),
 	Round1(MithrilRound1State<S>),
 	Round2(MithrilRound2State<S>),
 	Round3(MithrilRound3State<S>),
 	Round4(MithrilRound4State<S>),
-	Complete(MithrilDkgOutput),
+	Complete(Box<MithrilDkgOutput>),
 	Failed(String),
 }
 
@@ -158,7 +163,7 @@ impl<S: TranscriptSigner> MithrilDkgState<S> {
 
 	pub fn output(&self) -> Option<&MithrilDkgOutput> {
 		match self {
-			MithrilDkgState::Complete(output) => Some(output),
+			MithrilDkgState::Complete(output) => Some(output.as_ref()),
 			_ => None,
 		}
 	}

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -199,17 +199,6 @@ impl PrivateKeyShare {
 		&self.tr
 	}
 
-	/// Get the private key seed (for internal use).
-	///
-	/// This field is no longer used for key derivation (see `derivation.rs`); secret
-	/// material is now sourced from the secret share polynomials directly. The field
-	/// is retained for serialization compatibility and may be removed in a future
-	/// breaking release.
-	#[allow(dead_code)]
-	pub(crate) fn key(&self) -> &[u8; 32] {
-		&self.key
-	}
-
 	/// Get the secret shares (for internal use).
 	pub(crate) fn shares(&self) -> &BTreeMap<u16, SecretShareData> {
 		&self.shares

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -200,6 +200,12 @@ impl PrivateKeyShare {
 	}
 
 	/// Get the private key seed (for internal use).
+	///
+	/// This field is no longer used for key derivation (see `derivation.rs`); secret
+	/// material is now sourced from the secret share polynomials directly. The field
+	/// is retained for serialization compatibility and may be removed in a future
+	/// breaking release.
+	#[allow(dead_code)]
 	pub(crate) fn key(&self) -> &[u8; 32] {
 		&self.key
 	}

--- a/threshold/src/protocol/mod.rs
+++ b/threshold/src/protocol/mod.rs
@@ -4,6 +4,7 @@
 //! signing protocol. These are internal implementation details and are not
 //! part of the public API.
 
+pub(crate) mod partial_pk;
 pub(crate) mod primitives;
 pub(crate) mod secret_sharing;
 pub(crate) mod signing;

--- a/threshold/src/protocol/partial_pk.rs
+++ b/threshold/src/protocol/partial_pk.rs
@@ -1,0 +1,153 @@
+//! Partial public-key arithmetic shared by DKG and resharing.
+//!
+//! Both protocols need to (1) derive a per-subset partial public-key contribution
+//! `t_J = A·s1_J + s2_J mod Q` from a pair of polynomial vectors and (2) sum these
+//! partial contributions and pack them into the canonical ML-DSA-87 public-key
+//! encoding (`rho || t1`).
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use qp_rusty_crystals_dilithium::{fips202, packing, polyvec};
+
+use crate::keys::{PublicKey, PUBLIC_KEY_SIZE, TR_SIZE};
+
+const Q: i32 = 8_380_417;
+pub const N: usize = 256;
+pub const K: usize = 8;
+
+/// Compute the unrounded partial PK polynomial vector `t = A·s1 + s2 mod Q`.
+///
+/// `s1` must contain `L` polynomials and `s2` must contain `K` polynomials, each
+/// of length `N`. Coefficients of `s1` and `s2` need not be `eta`-bounded; they
+/// only need to live in `i32` and the final result is reduced into `[0, Q)`.
+pub fn compute_partial_pk_t(
+	rho: &[u8; 32],
+	s1: &[[i32; N]],
+	s2: &[[i32; N]],
+) -> Vec<[i32; N]> {
+	let mut mat: Vec<polyvec::Polyvecl> =
+		(0..K).map(|_| polyvec::Polyvecl::default()).collect();
+	polyvec::matrix_expand(&mut mat, rho);
+
+	let mut s1_pv = polyvec::Polyvecl::default();
+	for (i, poly_coeffs) in s1.iter().enumerate() {
+		s1_pv.vec[i].coeffs.copy_from_slice(poly_coeffs);
+	}
+
+	let mut s2_pv = polyvec::Polyveck::default();
+	for (i, poly_coeffs) in s2.iter().enumerate() {
+		s2_pv.vec[i].coeffs.copy_from_slice(poly_coeffs);
+	}
+
+	let mut s1_hat = s1_pv.clone();
+	polyvec::l_ntt(&mut s1_hat);
+
+	let mut t = polyvec::Polyveck::default();
+	polyvec::matrix_pointwise_montgomery(&mut t, &mat, &s1_hat);
+	polyvec::k_invntt_tomont(&mut t);
+	polyvec::k_add(&mut t, &s2_pv);
+	polyvec::k_reduce(&mut t);
+	polyvec::k_caddq(&mut t);
+
+	let mut t_coeffs = vec![[0i32; N]; K];
+	for (i, poly) in t.vec.iter().enumerate() {
+		t_coeffs[i].copy_from_slice(&poly.coeffs);
+	}
+	t_coeffs
+}
+
+/// Sum a collection of partial-PK polynomial vectors and pack into the canonical
+/// ML-DSA-87 public-key encoding (`rho || t1`).
+pub fn pack_combined_pk<'a, I>(rho: &[u8; 32], partial_ts: I) -> PublicKey
+where
+	I: IntoIterator<Item = &'a Vec<[i32; N]>>,
+{
+	let mut t = polyvec::Polyveck::default();
+	for partial in partial_ts {
+		for (i, poly_coeffs) in partial.iter().enumerate() {
+			for (j, &coeff) in poly_coeffs.iter().enumerate() {
+				t.vec[i].coeffs[j] = (t.vec[i].coeffs[j] + coeff) % Q;
+			}
+		}
+	}
+	polyvec::k_reduce(&mut t);
+	polyvec::k_caddq(&mut t);
+
+	let mut t0 = polyvec::Polyveck::default();
+	let mut t1 = t.clone();
+	polyvec::k_power2round(&mut t1, &mut t0);
+
+	let mut pk_packed = [0u8; PUBLIC_KEY_SIZE];
+	packing::pack_pk(&mut pk_packed, rho, &t1);
+
+	let mut tr = [0u8; TR_SIZE];
+	let mut h_tr = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut h_tr, &pk_packed, pk_packed.len());
+	fips202::shake256_finalize(&mut h_tr);
+	fips202::shake256_squeeze(&mut tr, TR_SIZE, &mut h_tr);
+
+	PublicKey::new(pk_packed, tr)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use alloc::vec;
+
+	const L: usize = 7;
+
+	#[test]
+	fn pack_combined_pk_is_additive() {
+		let rho = [3u8; 32];
+		let s1_a: Vec<[i32; N]> = vec![[1i32; N]; L];
+		let s2_a: Vec<[i32; N]> = vec![[2i32; N]; K];
+		let s1_b: Vec<[i32; N]> = vec![[5i32; N]; L];
+		let s2_b: Vec<[i32; N]> = vec![[7i32; N]; K];
+
+		let mut s1_sum: Vec<[i32; N]> = vec![[0i32; N]; L];
+		let mut s2_sum: Vec<[i32; N]> = vec![[0i32; N]; K];
+		for i in 0..L {
+			for j in 0..N {
+				s1_sum[i][j] = s1_a[i][j] + s1_b[i][j];
+			}
+		}
+		for i in 0..K {
+			for j in 0..N {
+				s2_sum[i][j] = s2_a[i][j] + s2_b[i][j];
+			}
+		}
+
+		let t_a = compute_partial_pk_t(&rho, &s1_a, &s2_a);
+		let t_b = compute_partial_pk_t(&rho, &s1_b, &s2_b);
+		let t_sum = compute_partial_pk_t(&rho, &s1_sum, &s2_sum);
+
+		let combined = pack_combined_pk(&rho, [&t_a, &t_b]);
+		let expected = pack_combined_pk(&rho, [&t_sum]);
+
+		assert_eq!(
+			combined.as_bytes(),
+			expected.as_bytes(),
+			"sum of partial PKs must match PK of summed shares"
+		);
+	}
+
+	#[test]
+	fn pack_combined_pk_detects_tampering() {
+		// Tamper by enough to flip a high bit (the low 13 bits get rounded away
+		// by `power2round`, so we shift by `1 << 13` to guarantee the packed PK
+		// differs).
+		let rho = [9u8; 32];
+		let s1: Vec<[i32; N]> = vec![[1i32; N]; L];
+		let s2: Vec<[i32; N]> = vec![[2i32; N]; K];
+		let mut t = compute_partial_pk_t(&rho, &s1, &s2);
+		let honest = pack_combined_pk(&rho, [&t]);
+		t[0][0] = (t[0][0] + (1 << 13)) % Q;
+		let tampered = pack_combined_pk(&rho, [&t]);
+		assert_ne!(
+			honest.as_bytes(),
+			tampered.as_bytes(),
+			"high-bit tamper must change the packed PK"
+		);
+	}
+}

--- a/threshold/src/protocol/partial_pk.rs
+++ b/threshold/src/protocol/partial_pk.rs
@@ -5,8 +5,7 @@
 //! partial contributions and pack them into the canonical ML-DSA-87 public-key
 //! encoding (`rho || t1`).
 
-use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 
 use qp_rusty_crystals_dilithium::{fips202, packing, polyvec};
 
@@ -21,13 +20,8 @@ pub const K: usize = 8;
 /// `s1` must contain `L` polynomials and `s2` must contain `K` polynomials, each
 /// of length `N`. Coefficients of `s1` and `s2` need not be `eta`-bounded; they
 /// only need to live in `i32` and the final result is reduced into `[0, Q)`.
-pub fn compute_partial_pk_t(
-	rho: &[u8; 32],
-	s1: &[[i32; N]],
-	s2: &[[i32; N]],
-) -> Vec<[i32; N]> {
-	let mut mat: Vec<polyvec::Polyvecl> =
-		(0..K).map(|_| polyvec::Polyvecl::default()).collect();
+pub fn compute_partial_pk_t(rho: &[u8; 32], s1: &[[i32; N]], s2: &[[i32; N]]) -> Vec<[i32; N]> {
+	let mut mat: Vec<polyvec::Polyvecl> = (0..K).map(|_| polyvec::Polyvecl::default()).collect();
 	polyvec::matrix_expand(&mut mat, rho);
 
 	let mut s1_pv = polyvec::Polyvecl::default();

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -22,41 +22,54 @@ Without resharing, any change would require generating a new key and migrating a
 
 ### Phases
 
-```
-Round 1: Blinded Reconstruction
-├── Old committee members broadcast blinded contributions
-└── Reconstruct secret in blinded form (never exposed in clear)
+This module uses **distributed per-subset re-sharing** — at no point does any
+party ever assemble the full secret `s`, and at no point is any individual
+share exposed in clear on the wire.
 
-Round 2: Re-dealing  
-├── Designated dealer generates fresh RSS shares
-└── Distributes shares to new committee via secure channels
-
-Round 3: Verification
-├── New committee members broadcast share commitments
-└── Verify all parties in same subset have consistent shares
 ```
+Round 1: Per-subset commitments
+├── For each old subset I, the designated dealer D_I (lowest-ID old participant in I)
+│   deterministically derives sub-shares  r_{I→J}  for every new subset J such that
+│   Σ_J r_{I→J} = s_I^old   (where s_I^old is the η-bounded share that all members of
+│   I already hold).
+└── D_I broadcasts H(r_{I→J}) for each (I, J).  Members of I can independently
+    recompute the same r_{I→J} from s_I^old and verify D_I's commitments.
+
+Round 2: Private sub-share reveal
+├── D_I privately delivers r_{I→J} to each member of new subset J.
+└── No public traffic carries any share material.
+
+Round 3: Verification + accusations
+├── Each new party verifies received r_{I→J} against the Round 1 commitment, then
+│   sums  s_J^new = Σ_I r_{I→J}  for each new subset J they're in, and broadcasts
+│   a commitment to s_J^new so that the membership of J can cross-verify.
+└── Old subset members file DealerAccusation if any dealer's broadcast commitment
+    doesn't match their independent recomputation.
+```
+
+Because `Σ_J s_J^new = Σ_J Σ_I r_{I→J} = Σ_I s_I^old = s`, the secret — and
+hence the public key `t = A·s1 + s2` — is preserved.
 
 ## Security Properties
 
 | Property | Guarantee |
 |----------|-----------|
-| **Secrecy** | Secret `s` never exposed during resharing |
-| **Consistency** | All honest parties get shares of same secret |
-| **Freshness** | Old shares unusable after protocol completes |
-| **PK Preservation** | Public key `t = A·s1 + s2` unchanged |
+| **Secrecy of `s`** | No party — not even any dealer — ever holds `s` in clear. Each `D_I` only handles `s_I^old`, which they already had. |
+| **Confidentiality of contributions** | Round 1 broadcasts only hash commitments; Round 2 sub-shares travel privately. Even an unbounded eavesdropper learns nothing about any `s_I^old` from the public transcript. |
+| **Cheating-dealer detection** | Other members of `I` independently recompute `r_{I→J}` from `s_I^old` and accuse `D_I` if the broadcast commitment differs; new-subset members cross-verify computed `s_J^new`. |
+| **PK Preservation** | Public key `t = A·s1 + s2` unchanged. |
 
 ## Why Custom Protocol?
 
 Standard resharing protocols (CHURP, MPSS) assume Shamir polynomial secret sharing where shares are points on a polynomial. Our implementation uses **Replicated Secret Sharing (RSS)** with subset-indexed additive shares:
 
 ```
-secret = Σ share[S]  for all subsets S containing party i
+secret = Σ share[S]  for all subsets S of size n - t + 1
 ```
 
-This structure requires a different approach:
-1. Blinded reconstruction using additive homomorphism
-2. Fresh RSS share generation for new subset structure
-3. Commitment-based verification for consistency
+The custom design lets each old RSS subset re-share *its own* η-bounded share
+to the new committee independently, without anyone ever combining the
+sub-shares back into `s`.
 
 ## Usage
 
@@ -103,18 +116,19 @@ Each party has a role determined by committee membership:
 
 | Role | Old Committee | New Committee | Actions |
 |------|--------------|---------------|---------|
-| `OldOnly` | ✓ | ✗ | Contribute to reconstruction |
-| `NewOnly` | ✗ | ✓ | Receive and verify new shares |
-| `Both` | ✓ | ✓ | Contribute + receive |
+| `OldOnly` | ✓ | ✗ | Deal sub-shares for old subsets they own; file dealer accusations |
+| `NewOnly` | ✗ | ✓ | Receive sub-shares; verify against commitments; aggregate `s_J^new` |
+| `Both`    | ✓ | ✓ | Deal + receive + verify |
 
 ## Message Types
 
-- `Round1Broadcast`: Blinded share contributions from old committee
-- `Round2Message`: New share distributions (private, point-to-point)
-- `Round3Broadcast`: Share commitments from new committee for verification
+- `Round1Broadcast`: per-subset commitment hashes  `H(r_{I→J})`  (no plaintext shares)
+- `Round2Message`: private sub-share reveal — one message per (dealer, recipient) carrying every `r_{I→J}` the dealer owes that recipient
+- `Round3Broadcast`: commitments to computed `s_J^new` + any `DealerAccusation`s
 
 ## Limitations
 
-- Maximum 12 parties (due to u16 subset masks)
-- Requires `t_old` responsive old committee members
+- Maximum 16 parties (due to u16 subset masks)
+- Requires every designated dealer to be online; if a dealer is offline or
+  cheats, the protocol aborts (no recovery / re-deal in this implementation)
 - Secure channels required for Round 2 private messages

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -39,10 +39,17 @@ Round 2: Private sub-share reveal
 ├── D_I privately delivers r_{I→J} to each member of new subset J.
 └── No public traffic carries any share material.
 
-Round 3: Verification + accusations
+Round 3: Verification + accusations + public-key invariant
 ├── Each new party verifies received r_{I→J} against the Round 1 commitment, then
 │   sums  s_J^new = Σ_I r_{I→J}  for each new subset J they're in, and broadcasts
 │   a commitment to s_J^new so that the membership of J can cross-verify.
+├── Each new party also broadcasts t_J^new = A·s1_J^new + s2_J^new (mod Q) for
+│   every J they hold. After Round 3, anyone can sum these and confirm
+│   Σ_J t_J^new = T (the original public key). This is the only line of defense
+│   against a malicious dealer that owns a *size-1* old subset (e.g. t = n
+│   configurations), where there is no other I-member to cross-verify the
+│   dealer's commitments. Publishing t_J^new is safe — recovering s_J^new from
+│   t_J^new is the LWE problem.
 └── Old subset members file DealerAccusation if any dealer's broadcast commitment
     doesn't match their independent recomputation.
 ```
@@ -56,8 +63,8 @@ hence the public key `t = A·s1 + s2` — is preserved.
 |----------|-----------|
 | **Secrecy of `s`** | No party — not even any dealer — ever holds `s` in clear. Each `D_I` only handles `s_I^old`, which they already had. |
 | **Confidentiality of contributions** | Round 1 broadcasts only hash commitments; Round 2 sub-shares travel privately. Even an unbounded eavesdropper learns nothing about any `s_I^old` from the public transcript. |
-| **Cheating-dealer detection** | Other members of `I` independently recompute `r_{I→J}` from `s_I^old` and accuse `D_I` if the broadcast commitment differs; new-subset members cross-verify computed `s_J^new`. |
-| **PK Preservation** | Public key `t = A·s1 + s2` unchanged. |
+| **Cheating-dealer detection** | Other members of `I` independently recompute `r_{I→J}` from `s_I^old` and accuse `D_I` if the broadcast commitment differs; new-subset members cross-verify computed `s_J^new`; and a final partial-public-key sum check reconstructs `T` from `Σ_J t_J^new`, catching any dealer that lied about a residual even when their old subset has size 1. |
+| **PK Preservation** | Public key `t = A·s1 + s2` unchanged, verified at the end of Round 3 via a deterministic byte-equality check against the original PK. |
 
 ## Why Custom Protocol?
 
@@ -123,8 +130,8 @@ Each party has a role determined by committee membership:
 ## Message Types
 
 - `Round1Broadcast`: per-subset commitment hashes  `H(r_{I→J})`  (no plaintext shares)
-- `Round2Message`: private sub-share reveal — one message per (dealer, recipient) carrying every `r_{I→J}` the dealer owes that recipient
-- `Round3Broadcast`: commitments to computed `s_J^new` + any `DealerAccusation`s
+- `Round2Message`: private sub-share reveal — one message per (dealer, recipient) carrying every `r_{I→J}` the dealer owes that recipient. Dealers handle self-deals locally and never emit `SendPrivate(self, _)`.
+- `Round3Broadcast`: commitments to computed `s_J^new`, partial public-key contributions `t_J^new`, and any `DealerAccusation`s
 
 ## Limitations
 

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -95,7 +95,7 @@ let config = ResharingConfig::new(
     my_existing_share,  // Some(share) if in old committee, None if joining
 )?;
 
-let mut protocol = ResharingProtocol::new(config, random_seed)?;
+let mut protocol = ResharingProtocol::new(config);
 
 // Run protocol loop
 loop {

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -6,25 +6,44 @@
 //!
 //! # Overview
 //!
-//! Resharing consists of four phases:
-//! 1. **Blinded Reconstruction**: Threshold of old committee members reconstruct the secret in
-//!    blinded form
-//! 2. **Re-dealing**: Generate fresh RSS shares for the new committee structure
-//! 3. **Distribution**: Send new shares to new committee members
-//! 4. **Verification**: New committee verifies share consistency
+//! Resharing uses **distributed per-subset re-sharing**: for each old RSS subset
+//! `I` (a `k_old`-subset of the old committee whose members all hold the
+//! η-bounded share `s_I^old`), the lowest-ID member of `I` (the "designated
+//! dealer" `D_I`) re-shares `s_I^old` to the new committee:
+//!
+//! 1. `D_I` deterministically derives sub-shares `r_{I→J}` for every new RSS
+//!    subset `J`, such that `Σ_J r_{I→J} = s_I^old` (so reassembling all
+//!    sub-shares for `I` reconstructs only the *old* subset share, not the
+//!    full secret).
+//! 2. `D_I` broadcasts a hash commitment to each `r_{I→J}` (Round 1) and
+//!    privately delivers `r_{I→J}` to every member of new subset `J` (Round 2).
+//! 3. New committee members verify each received `r_{I→J}` against `D_I`'s
+//!    commitment, sum `s_J^new = Σ_I r_{I→J}` for each new subset `J`
+//!    containing them, and broadcast a commitment to `s_J^new` (Round 3) so
+//!    the membership of `J` can cross-verify consistency. Other members of
+//!    the same old subset `I` independently recompute `r_{I→J}` and accuse
+//!    `D_I` if any commitment is wrong.
+//!
+//! Because `Σ_J s_J^new = Σ_J Σ_I r_{I→J} = Σ_I s_I^old = s_total`, the
+//! secret (and hence the public key `t = A·s1 + s2`) is preserved.
+//!
+//! # Security Properties
+//!
+//! - **Secrecy of `s`**: No party — not even the designated dealers — ever
+//!   reconstructs the full secret `s`. Each `D_I` only handles `s_I^old`,
+//!   which they already had.
+//! - **Confidentiality of share contributions**: Round 1 broadcasts only hash
+//!   commitments (hiding under SHAKE256 when committed values come from a
+//!   high-entropy distribution); Round 2 sub-shares travel privately.
+//! - **Cheating-dealer detection**: Old subset members cross-verify dealers'
+//!   commitments; new subset members cross-verify computed `s_J^new` values.
+//! - **Public key preservation**: `t = A·s1 + s2` is unchanged.
 //!
 //! # Why Custom Protocol?
 //!
 //! Existing resharing protocols (CHURP, MPSS) are designed for Shamir polynomial
 //! secret sharing. Our implementation uses Replicated Secret Sharing (RSS) with
 //! subset-indexed additive shares, requiring a custom approach.
-//!
-//! # Security Properties
-//!
-//! - **Secrecy**: The secret is never exposed in clear during resharing
-//! - **Consistency**: All honest parties end up with shares of the same secret
-//! - **Freshness**: Old shares become useless after resharing completes
-//! - **Public Key Preservation**: The public key `t = A·s1 + s2` remains unchanged
 //!
 //! # Usage
 //!
@@ -66,8 +85,9 @@ mod types;
 
 // Re-export public types
 pub use types::{
-	ResharingConfig, ResharingMessage, ResharingOutput, ResharingRole, ResharingRound1Broadcast,
-	ResharingRound2Message, ResharingRound3Broadcast,
+	DealerAccusation, NewShareData, ResharingConfig, ResharingMessage, ResharingOutput,
+	ResharingRole, ResharingRound1Broadcast, ResharingRound2Message, ResharingRound3Broadcast,
+	SubsetMask, SubsetPair,
 };
 
 pub use protocol::{Action, ResharingProtocol, ResharingProtocolError, ResharingState};

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -11,32 +11,29 @@
 //! η-bounded share `s_I^old`), the lowest-ID member of `I` (the "designated
 //! dealer" `D_I`) re-shares `s_I^old` to the new committee:
 //!
-//! 1. `D_I` deterministically derives sub-shares `r_{I→J}` for every new RSS
-//!    subset `J`, such that `Σ_J r_{I→J} = s_I^old` (so reassembling all
-//!    sub-shares for `I` reconstructs only the *old* subset share, not the
-//!    full secret).
-//! 2. `D_I` broadcasts a hash commitment to each `r_{I→J}` (Round 1) and
-//!    privately delivers `r_{I→J}` to every member of new subset `J` (Round 2).
-//! 3. New committee members verify each received `r_{I→J}` against `D_I`'s
-//!    commitment, sum `s_J^new = Σ_I r_{I→J}` for each new subset `J`
-//!    containing them, and broadcast a commitment to `s_J^new` (Round 3) so
-//!    the membership of `J` can cross-verify consistency. Other members of
-//!    the same old subset `I` independently recompute `r_{I→J}` and accuse
-//!    `D_I` if any commitment is wrong.
+//! 1. `D_I` deterministically derives sub-shares `r_{I→J}` for every new RSS subset `J`, such that
+//!    `Σ_J r_{I→J} = s_I^old` (so reassembling all sub-shares for `I` reconstructs only the *old*
+//!    subset share, not the full secret).
+//! 2. `D_I` broadcasts a hash commitment to each `r_{I→J}` (Round 1) and privately delivers
+//!    `r_{I→J}` to every member of new subset `J` (Round 2).
+//! 3. New committee members verify each received `r_{I→J}` against `D_I`'s commitment, sum `s_J^new
+//!    = Σ_I r_{I→J}` for each new subset `J` containing them, and broadcast a commitment to
+//!    `s_J^new` (Round 3) so the membership of `J` can cross-verify consistency. Other members of
+//!    the same old subset `I` independently recompute `r_{I→J}` and accuse `D_I` if any commitment
+//!    is wrong.
 //!
 //! Because `Σ_J s_J^new = Σ_J Σ_I r_{I→J} = Σ_I s_I^old = s_total`, the
 //! secret (and hence the public key `t = A·s1 + s2`) is preserved.
 //!
 //! # Security Properties
 //!
-//! - **Secrecy of `s`**: No party — not even the designated dealers — ever
-//!   reconstructs the full secret `s`. Each `D_I` only handles `s_I^old`,
-//!   which they already had.
-//! - **Confidentiality of share contributions**: Round 1 broadcasts only hash
-//!   commitments (hiding under SHAKE256 when committed values come from a
-//!   high-entropy distribution); Round 2 sub-shares travel privately.
-//! - **Cheating-dealer detection**: Old subset members cross-verify dealers'
-//!   commitments; new subset members cross-verify computed `s_J^new` values.
+//! - **Secrecy of `s`**: No party — not even the designated dealers — ever reconstructs the full
+//!   secret `s`. Each `D_I` only handles `s_I^old`, which they already had.
+//! - **Confidentiality of share contributions**: Round 1 broadcasts only hash commitments (hiding
+//!   under SHAKE256 when committed values come from a high-entropy distribution); Round 2
+//!   sub-shares travel privately.
+//! - **Cheating-dealer detection**: Old subset members cross-verify dealers' commitments; new
+//!   subset members cross-verify computed `s_J^new` values.
 //! - **Public key preservation**: `t = A·s1 + s2` is unchanged.
 //!
 //! # Why Custom Protocol?

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -60,7 +60,7 @@
 //! )?;
 //!
 //! // Create and run the protocol
-//! let mut protocol = ResharingProtocol::new(config, seed)?;
+//! let mut protocol = ResharingProtocol::new(config);
 //!
 //! loop {
 //!     match protocol.poke()? {

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -527,9 +527,21 @@ impl ResharingProtocol {
 			}
 		}
 
+		// Compute partial public-key contributions `t_J = A·s1_J + s2_J mod Q`
+		// for every new subset we hold. These are summed and checked against the
+		// original public key in Combining; this catches a malicious dealer that
+		// lies about a residual `r_{I→J}` in a size-1 old subset, where there is
+		// no peer in the old subset to cross-verify the commitment.
+		let partial_pks = if self.config.role.is_new_committee() && success {
+			self.compute_my_partial_pks()
+		} else {
+			BTreeMap::new()
+		};
+
 		let broadcast = ResharingRound3Broadcast {
 			party_id: self.config.my_party_id,
 			share_commitments,
+			partial_pks,
 			accusations,
 			success,
 			error_message,
@@ -606,6 +618,12 @@ impl ResharingProtocol {
 		// New committee members must agree on every shared new subset.
 		self.verify_new_share_consistency()?;
 
+		// Verify the resharing preserved the public key invariant. This is the
+		// only line of defense against a malicious dealer that owns a size-1 old
+		// subset (`t = n` configurations), since `collect_accusations` cannot
+		// catch them — there is nobody else in the old subset to cross-check.
+		self.verify_public_key_preservation()?;
+
 		let output = self.build_output()?;
 		self.completed_output = Some(output.clone());
 		self.state = ResharingState::Done;
@@ -660,6 +678,11 @@ impl ResharingProtocol {
 	}
 
 	/// Build the per-recipient Round 2 messages we will emit one-by-one in `poke`.
+	///
+	/// Self-deals (when this party is also a member of `J`) are inserted directly
+	/// into `round2_messages`; only outbound messages are queued in `pending_round2`.
+	/// This mirrors the DKG pattern (`process_round1` skips self) and removes the
+	/// implicit "network must loopback SendPrivate(self, _)" requirement.
 	fn build_pending_round2_messages(&mut self) {
 		let mut by_recipient: BTreeMap<ParticipantId, BTreeMap<SubsetPair, NewShareData>> =
 			BTreeMap::new();
@@ -671,12 +694,18 @@ impl ResharingProtocol {
 				}
 			}
 		}
+		let me = self.config.my_party_id;
 		for (recipient, contributions) in by_recipient {
-			self.pending_round2.push(ResharingRound2Message {
-				from_party_id: self.config.my_party_id,
+			let msg = ResharingRound2Message {
+				from_party_id: me,
 				to_party_id: recipient,
 				contributions,
-			});
+			};
+			if recipient == me {
+				self.round2_messages.insert(me, msg);
+			} else {
+				self.pending_round2.push(msg);
+			}
 		}
 	}
 
@@ -858,6 +887,73 @@ impl ResharingProtocol {
 		Ok(())
 	}
 
+	/// Extract `rho` (matrix-A seed). Old/Both parties take it from their existing
+	/// share; NewOnly parties extract it from the public key prefix.
+	fn derive_rho(&self) -> [u8; 32] {
+		if let Some(ref existing) = self.config.existing_share {
+			*existing.rho()
+		} else {
+			let mut rho = [0u8; 32];
+			rho.copy_from_slice(&self.config.public_key.as_bytes()[..32]);
+			rho
+		}
+	}
+
+	/// Compute `t_J = A·s1_J^new + s2_J^new mod Q` for every new subset we hold.
+	fn compute_my_partial_pks(&self) -> BTreeMap<SubsetMask, Vec<[i32; N]>> {
+		let rho = self.derive_rho();
+		self.new_shares
+			.iter()
+			.map(|(j_mask, share)| {
+				let t = crate::protocol::partial_pk::compute_partial_pk_t(
+					&rho, &share.s1, &share.s2,
+				);
+				(*j_mask, t)
+			})
+			.collect()
+	}
+
+	/// Cross-check the broadcast partial PKs and sum them to confirm the
+	/// resharing reconstructs the original public key.
+	fn verify_public_key_preservation(&self) -> Result<(), ResharingProtocolError> {
+		let mut canonical: BTreeMap<SubsetMask, Vec<[i32; N]>> = BTreeMap::new();
+		for broadcast in self.round3_broadcasts.values() {
+			for (j_mask, t_partial) in &broadcast.partial_pks {
+				match canonical.get(j_mask) {
+					None => {
+						canonical.insert(*j_mask, t_partial.clone());
+					},
+					Some(existing) =>
+						if existing != t_partial {
+							return Err(ResharingProtocolError::ShareVerificationFailed(format!(
+								"members of new subset {:b} disagree on partial PK t_J",
+								j_mask
+							)));
+						},
+				}
+			}
+		}
+		for j_mask in &self.new_subset_order {
+			if !canonical.contains_key(j_mask) {
+				return Err(ResharingProtocolError::ShareVerificationFailed(format!(
+					"missing partial PK contribution for new subset {:b}",
+					j_mask
+				)));
+			}
+		}
+		let rho = self.derive_rho();
+		let recovered =
+			crate::protocol::partial_pk::pack_combined_pk(&rho, canonical.values());
+		if recovered.as_bytes() != self.config.public_key.as_bytes() {
+			return Err(ResharingProtocolError::ShareVerificationFailed(
+				"recovered public key does not match the original — a dealer corrupted at \
+				 least one sub-share contribution"
+					.to_string(),
+			));
+		}
+		Ok(())
+	}
+
 	fn build_output(&self) -> Result<ResharingOutput, ResharingProtocolError> {
 		if !self.config.role.is_new_committee() {
 			return Ok(ResharingOutput {
@@ -881,13 +977,11 @@ impl ResharingProtocol {
 				.insert(*j_mask, SecretShareData { s1: share.s1.clone(), s2: share.s2.clone() });
 		}
 
-		let (rho, tr) = if let Some(ref existing) = self.config.existing_share {
-			(*existing.rho(), *existing.tr())
+		let rho = self.derive_rho();
+		let tr = if let Some(ref existing) = self.config.existing_share {
+			*existing.tr()
 		} else {
-			let pk_bytes = self.config.public_key.as_bytes();
-			let mut rho = [0u8; 32];
-			rho.copy_from_slice(&pk_bytes[..32]);
-			(rho, *self.config.public_key.tr())
+			*self.config.public_key.tr()
 		};
 
 		// Derive `party_key` from the actual share polynomials so it carries real

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -3,13 +3,21 @@
 //! This module implements the resharing protocol using the poke/message pattern
 //! compatible with NEAR MPC's `run_protocol` infrastructure.
 //!
-//! # Protocol Overview
+//! See `resharing/mod.rs` for a full description of the cryptographic protocol.
+//! In short:
 //!
-//! The resharing protocol has 3 rounds:
-//! 1. **Round 1 (Blinded Reconstruction)**: Old committee members broadcast blinded contributions
-//!    to reconstruct the secret
-//! 2. **Round 2 (Re-dealing)**: Dealers generate and distribute new shares to new committee
-//! 3. **Round 3 (Verification)**: New committee members verify share consistency
+//! - **Round 1 (Commitments)**: Each old committee member that is the
+//!   designated dealer for one or more old RSS subsets broadcasts hash
+//!   commitments to the per-subset sub-shares `r_{I→J}` they will deliver in
+//!   Round 2. Sub-shares are derived deterministically from `s_I^old`, so all
+//!   members of `I` can independently recompute and verify these commitments.
+//! - **Round 2 (Reveal)**: Each designated dealer privately delivers
+//!   `r_{I→J}` to every member of new subset `J`.
+//! - **Round 3 (Verification)**: Each new committee member verifies received
+//!   sub-shares against the broadcast commitments, sums them into new shares
+//!   `s_J^new`, and broadcasts a commitment to each computed `s_J^new` so the
+//!   members of `J` can cross-verify. Old committee members file dealer
+//!   accusations if any broadcast commitment fails their independent recomputation.
 //!
 //! # State Machine
 //!
@@ -30,29 +38,37 @@ use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{keys::PrivateKeyShare, participants::ParticipantId};
+use qp_rusty_crystals_dilithium::fips202;
 
-use super::types::{
-	BlindedContribution, NewShareData, ResharingConfig, ResharingMessage, ResharingOutput,
-	ResharingRound1Broadcast, ResharingRound2Message, ResharingRound3Broadcast, SubsetMask,
-	COMMITMENT_HASH_SIZE, K, L, N,
+use crate::{
+	keys::{PrivateKeyShare, SecretShareData},
+	participants::ParticipantId,
 };
 
-// Q is the prime modulus for ML-DSA-87
+use super::types::{
+	DealerAccusation, NewShareData, ResharingConfig, ResharingMessage, ResharingOutput,
+	ResharingRound1Broadcast, ResharingRound2Message, ResharingRound3Broadcast, SubsetMask,
+	SubsetPair, COMMITMENT_HASH_SIZE, K, L, N,
+};
+
+/// ML-DSA-87 prime modulus.
 const Q: i32 = 8380417;
 
-/// Type alias for secret coefficient pairs (s1 coefficients, s2 coefficients).
-/// Used to simplify complex return types in resharing operations.
-type SecretCoefficients = (Vec<[i32; N]>, Vec<[i32; N]>);
+/// Eta bound for ML-DSA-87 share sampling.
+const ETA: i32 = 2;
+
+/// Domain separator for the per-subset PRF seed.
+const SUBSET_SEED_DOMAIN: &[u8] = b"resharing-subset-prf-v2";
+/// Domain separator for sub-share commitments.
+const COMMIT_DOMAIN: &[u8] = b"resharing-commit-v2";
+/// Domain separator for new share commitments (Round 3).
+const NEW_SHARE_COMMIT_DOMAIN: &[u8] = b"resharing-new-share-commit-v2";
 
 // ============================================================================
 // Action Enum
 // ============================================================================
 
 /// Actions returned by the protocol's `poke` method.
-///
-/// This enum matches the pattern used by NEAR MPC's cait-sith protocols,
-/// enabling integration with `run_protocol`.
 #[derive(Debug, Clone)]
 pub enum Action<T> {
 	/// Do nothing, waiting for more messages from other participants.
@@ -84,7 +100,7 @@ pub enum ResharingProtocolError {
 	ShareVerificationFailed(String),
 	/// Serialization error.
 	SerializationError(String),
-	/// A party reported failure.
+	/// A party reported failure (or was accused as a dealer).
 	PartyFailure(Vec<ParticipantId>),
 	/// Not enough parties participated.
 	InsufficientParties {
@@ -96,9 +112,6 @@ pub enum ResharingProtocolError {
 	/// Internal error.
 	InternalError(String),
 	/// A malformed message was received from a party.
-	///
-	/// This indicates the message could not be deserialized, which could
-	/// indicate a bug, network corruption, or malicious behavior.
 	MalformedMessage {
 		/// The party that sent the malformed message.
 		from: ParticipantId,
@@ -146,17 +159,17 @@ impl fmt::Display for ResharingProtocolError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ResharingState {
-	/// Generating Round 1 message (blinded contribution).
+	/// Generating Round 1 message (commitments to per-subset sub-shares).
 	Round1Generate,
-	/// Waiting for Round 1 messages from other old committee members.
+	/// Waiting for Round 1 messages from old committee members.
 	Round1Waiting,
-	/// Generating Round 2 messages (new share distribution).
+	/// Generating Round 2 messages (private sub-share reveals).
 	Round2Generate,
-	/// Waiting for Round 2 messages (receiving new shares).
+	/// Waiting for Round 2 messages (receiving sub-shares).
 	Round2Waiting,
-	/// Generating Round 3 message (verification commitment).
+	/// Generating Round 3 message (verification commitments + accusations).
 	Round3Generate,
-	/// Waiting for Round 3 messages from other new committee members.
+	/// Waiting for Round 3 messages.
 	Round3Waiting,
 	/// Combining shares and finalizing.
 	Combining,
@@ -171,93 +184,61 @@ pub enum ResharingState {
 // ============================================================================
 
 /// The main resharing protocol state machine.
-///
-/// Implements the committee handoff protocol for RSS-based threshold Dilithium.
-/// Uses the poke/message pattern compatible with NEAR MPC.
-///
-/// # Usage
-///
-/// ```ignore
-/// let mut protocol = ResharingProtocol::new(config, seed)?;
-///
-/// loop {
-///     match protocol.poke()? {
-///         Action::Wait => { /* wait for messages */ }
-///         Action::SendMany(data) => { /* broadcast */ }
-///         Action::SendPrivate(to, data) => { /* send to specific party */ }
-///         Action::Return(output) => {
-///             // Done!
-///             break;
-///         }
-///     }
-///     // When messages arrive: protocol.message(from, data);
-/// }
-/// ```
 pub struct ResharingProtocol {
-	/// Configuration for this resharing.
 	config: ResharingConfig,
-	/// Current protocol state.
 	state: ResharingState,
-	/// Random seed for generating blinding values.
+	#[allow(dead_code)] // reserved for future per-session nonce mixing
 	seed: [u8; 32],
 
-	// Round 1 data
-	/// Our blinding values for s1 (if we're in old committee).
-	my_blinding_s1: Option<Vec<[i32; N]>>,
-	/// Our blinding values for s2 (if we're in old committee).
-	my_blinding_s2: Option<Vec<[i32; N]>>,
-	/// Our Round 1 broadcast (if we're in old committee).
+	/// Old subset masks (from the existing share's stored shares), in canonical
+	/// (BTreeMap) order. Indexed by `old_subset_index`.
+	old_subset_order: Vec<SubsetMask>,
+	/// New subset masks for the new committee, in canonical order. Indexed by
+	/// `new_subset_index`. Used to assign per-old-subset "residual" new subsets.
+	new_subset_order: Vec<SubsetMask>,
+
+	/// Pre-computed sub-shares we are responsible for dealing.
+	/// Keyed by `(old_subset, new_subset)`.
+	my_subshares: BTreeMap<SubsetPair, NewShareData>,
+	/// Our Round 1 broadcast (commitments for subsets we deal).
 	my_round1: Option<ResharingRound1Broadcast>,
-	/// Collected Round 1 broadcasts from old committee.
+	/// Round 1 broadcasts received from other old committee members.
 	round1_broadcasts: BTreeMap<ParticipantId, ResharingRound1Broadcast>,
 
-	// Round 2 data
-	/// Our Round 2 messages to send (if we're THE designated dealer).
-	/// Only the party with the smallest ID among old committee is the dealer.
-	my_round2_messages: Vec<ResharingRound2Message>,
-	/// Collected Round 2 messages we received (if we're in new committee).
-	/// We only receive from the designated dealer.
-	round2_messages: BTreeMap<ParticipantId, ResharingRound2Message>,
-	/// Number of Round 2 messages sent.
+	/// Round 2 messages we have queued to send (each addressed to a specific recipient).
+	pending_round2: Vec<ResharingRound2Message>,
+	/// Index of the next pending Round 2 message to emit.
 	round2_sent_count: usize,
+	/// Round 2 messages we received, keyed by sender.
+	/// Each value is the merged set of `(I, J) -> r` from that sender.
+	round2_messages: BTreeMap<ParticipantId, ResharingRound2Message>,
 
-	// Round 3 data
-	/// Our Round 3 broadcast (if we're in new committee).
-	my_round3: Option<ResharingRound3Broadcast>,
-	/// Collected Round 3 broadcasts from new committee.
+	/// Round 3 broadcasts.
 	round3_broadcasts: BTreeMap<ParticipantId, ResharingRound3Broadcast>,
 
-	// Final output
-	/// The new shares we've received/computed (if we're in new committee).
+	/// Computed new shares: `new_subset -> s_J^new`. Populated in Round 3.
 	new_shares: BTreeMap<SubsetMask, NewShareData>,
-	/// The completed output (stored when protocol finishes).
+	/// Final output (cached so `take_output` can return it after Combining).
 	completed_output: Option<ResharingOutput>,
 }
 
 impl ResharingProtocol {
 	/// Create a new resharing protocol instance.
-	///
-	/// # Arguments
-	///
-	/// * `config` - The resharing configuration
-	/// * `seed` - Random seed for blinding value generation
-	///
-	/// # Returns
-	///
-	/// A new protocol instance ready to run.
 	pub fn new(config: ResharingConfig, seed: [u8; 32]) -> Self {
+		let old_subset_order = compute_old_subset_order(&config);
+		let new_subset_order = compute_new_subset_order(&config);
 		Self {
 			config,
 			state: ResharingState::Round1Generate,
 			seed,
-			my_blinding_s1: None,
-			my_blinding_s2: None,
+			old_subset_order,
+			new_subset_order,
+			my_subshares: BTreeMap::new(),
 			my_round1: None,
 			round1_broadcasts: BTreeMap::new(),
-			my_round2_messages: Vec::new(),
-			round2_messages: BTreeMap::new(),
+			pending_round2: Vec::new(),
 			round2_sent_count: 0,
-			my_round3: None,
+			round2_messages: BTreeMap::new(),
 			round3_broadcasts: BTreeMap::new(),
 			new_shares: BTreeMap::new(),
 			completed_output: None,
@@ -280,15 +261,6 @@ impl ResharingProtocol {
 	}
 
 	/// Take the completed output from the protocol.
-	///
-	/// This can only be called after the protocol has completed successfully
-	/// (state is `Done`). Returns `None` if the protocol hasn't completed
-	/// or if the output has already been taken.
-	///
-	/// # Returns
-	///
-	/// The resharing output containing the new private key share (if this
-	/// party is in the new committee), the public key, and new configuration.
 	pub fn take_output(&mut self) -> Option<ResharingOutput> {
 		if matches!(self.state, ResharingState::Done) {
 			self.completed_output.take()
@@ -307,36 +279,12 @@ impl ResharingProtocol {
 		matches!(self.state, ResharingState::Failed(_))
 	}
 
-	/// Check if we have enough Round 1 messages.
-	fn have_enough_round1(&self) -> bool {
-		self.round1_broadcasts.len() >= self.config.old_threshold as usize
-	}
-
-	/// Check if we have enough Round 2 messages.
-	fn have_enough_round2(&self) -> bool {
-		// We only need to receive from the designated dealer (1 message)
-		// The designated dealer is the first party in the sorted old_participants list
-		let designated_dealer = self.config.old_participants.get(0);
-		if let Some(dealer_id) = designated_dealer {
-			self.round2_messages.contains_key(&dealer_id)
-		} else {
-			false
-		}
-	}
-
-	/// Check if we have all Round 3 messages.
-	fn have_all_round3(&self) -> bool {
-		self.round3_broadcasts.len() >= self.config.new_participants.len()
-	}
-
-	/// Serialize a message for transmission.
 	fn serialize_message(msg: &ResharingMessage) -> Result<Vec<u8>, ResharingProtocolError> {
 		bincode::serialize(msg).map_err(|e| {
 			ResharingProtocolError::SerializationError(format!("Failed to serialize: {}", e))
 		})
 	}
 
-	/// Deserialize a message from bytes.
 	fn deserialize_message(data: &[u8]) -> Result<ResharingMessage, ResharingProtocolError> {
 		bincode::deserialize(data).map_err(|e| {
 			ResharingProtocolError::SerializationError(format!("Failed to deserialize: {}", e))
@@ -344,9 +292,6 @@ impl ResharingProtocol {
 	}
 
 	/// Advance the protocol state machine.
-	///
-	/// Call this method repeatedly to drive the protocol forward.
-	/// It returns an action indicating what to do next.
 	pub fn poke(&mut self) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
 		match &self.state {
 			ResharingState::Round1Generate => self.handle_round1_generate(),
@@ -364,108 +309,63 @@ impl ResharingProtocol {
 	}
 
 	/// Handle an incoming message from another party.
-	///
-	/// # Arguments
-	///
-	/// * `from` - The party ID that sent the message
-	/// * `data` - The serialized message data
-	///
-	/// # Errors
-	///
-	/// Returns `Err(ResharingProtocolError::MalformedMessage)` if the message
-	/// cannot be deserialized. This allows callers to detect and log
-	/// malformed messages from participants.
-	///
-	/// # Returns
-	///
-	/// * `Ok(())` - Message was processed (or legitimately ignored)
-	/// * `Err(_)` - Message was malformed and could not be deserialized
 	pub fn message(
 		&mut self,
 		from: ParticipantId,
 		data: Vec<u8>,
 	) -> Result<(), ResharingProtocolError> {
-		// Ignore messages if protocol is done or failed
 		if matches!(self.state, ResharingState::Done | ResharingState::Failed(_)) {
 			return Ok(());
 		}
 
-		// Deserialize and route the message
 		let msg = match Self::deserialize_message(&data) {
 			Ok(m) => m,
-			Err(e) => {
+			Err(e) =>
 				return Err(ResharingProtocolError::MalformedMessage {
 					from,
 					reason: e.to_string(),
-				});
-			},
+				}),
 		};
 
-		// Verify sender matches message
 		if msg.party_id() != from {
-			// Message party_id doesn't match sender - ignore it (not an error, just bad actor)
 			return Ok(());
 		}
 
 		match msg {
-			ResharingMessage::Round1(broadcast) => {
-				self.handle_round1_message(from, broadcast);
-			},
-			ResharingMessage::Round2(msg) => {
-				self.handle_round2_message(from, msg);
-			},
-			ResharingMessage::Round3(broadcast) => {
-				self.handle_round3_message(from, broadcast);
-			},
+			ResharingMessage::Round1(broadcast) => self.handle_round1_message(from, broadcast),
+			ResharingMessage::Round2(m) => self.handle_round2_message(from, m),
+			ResharingMessage::Round3(broadcast) => self.handle_round3_message(from, broadcast),
 		}
 
 		Ok(())
 	}
 
 	// ========================================================================
-	// Round 1: Blinded Reconstruction
+	// Round 1: Commitments
 	// ========================================================================
 
 	fn handle_round1_generate(
 		&mut self,
 	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		// Only old committee members participate in Round 1
+		// Only old committee members participate in Round 1.
 		if !self.config.role.is_old_committee() {
-			// New-only parties skip to waiting for Round 2
 			self.state = ResharingState::Round2Waiting;
 			return Ok(Action::Wait);
 		}
 
-		// Generate blinding values
-		let (blinding_s1, blinding_s2) = self.generate_blinding_values();
-		self.my_blinding_s1 = Some(blinding_s1.clone());
-		self.my_blinding_s2 = Some(blinding_s2.clone());
+		self.compute_my_subshares()?;
+		let commitments = self.commit_to_my_subshares();
 
-		// Compute blinded contribution: recovered_share + blinding
-		let (blinded_s1, blinded_s2) =
-			self.compute_blinded_contribution(&blinding_s1, &blinding_s2)?;
-
-		// Compute commitment to blinding values
-		let blinding_commitment = self.compute_blinding_commitment(&blinding_s1, &blinding_s2);
-
-		// Create Round 1 broadcast (includes blinding values for other dealers)
-		let broadcast = ResharingRound1Broadcast {
-			party_id: self.config.my_party_id,
-			blinded_s1_contribution: BlindedContribution { coefficients: blinded_s1 },
-			blinded_s2_contribution: BlindedContribution { coefficients: blinded_s2 },
-			blinding_s1: BlindedContribution { coefficients: blinding_s1.clone() },
-			blinding_s2: BlindedContribution { coefficients: blinding_s2.clone() },
-			blinding_commitment,
-		};
-
-		// Store our broadcast
+		let broadcast =
+			ResharingRound1Broadcast { party_id: self.config.my_party_id, commitments };
 		self.my_round1 = Some(broadcast.clone());
 		self.round1_broadcasts.insert(self.config.my_party_id, broadcast.clone());
 
-		// Serialize and broadcast
-		let msg = ResharingMessage::Round1(broadcast);
-		let data = Self::serialize_message(&msg)?;
+		// Pre-build the per-recipient Round 2 messages so we can stream them in
+		// later pokes without re-deriving anything.
+		self.build_pending_round2_messages();
 
+		let data = Self::serialize_message(&ResharingMessage::Round1(broadcast))?;
 		self.state = ResharingState::Round1Waiting;
 		Ok(Action::SendMany(data))
 	}
@@ -480,103 +380,66 @@ impl ResharingProtocol {
 	}
 
 	fn handle_round1_message(&mut self, from: ParticipantId, broadcast: ResharingRound1Broadcast) {
-		// Ignore if not in expected state
 		if !matches!(self.state, ResharingState::Round1Generate | ResharingState::Round1Waiting) {
 			return;
 		}
-
-		// Verify sender is in old committee
 		if !self.config.old_participants.contains(from) {
-			// Round 1 message from non-old-committee member - ignore it
 			return;
 		}
-
-		// Ignore duplicates
 		if self.round1_broadcasts.contains_key(&from) {
 			return;
 		}
-
-		// Verify that the revealed blinding values match the commitment
-		let expected_commitment = self.compute_blinding_commitment(
-			&broadcast.blinding_s1.coefficients,
-			&broadcast.blinding_s2.coefficients,
-		);
-		if expected_commitment != broadcast.blinding_commitment {
-			// Blinding commitment mismatch - party may be cheating, ignore message
-			return;
-		}
-
-		// Store the broadcast
 		self.round1_broadcasts.insert(from, broadcast);
 	}
 
-	// ========================================================================
-	// Round 2: Re-dealing
-	// ========================================================================
-
-	/// Check if this party is the designated dealer.
-	/// Only the party with the smallest ID among old committee members is the dealer.
-	/// This ensures only ONE party generates and distributes new shares, avoiding
-	/// the shares being multiplied by the number of dealers.
-	fn is_designated_dealer(&self) -> bool {
-		if !self.config.role.is_old_committee() {
-			return false;
-		}
-		// The designated dealer is the first party in the sorted old_participants list
-		self.config.old_participants.get(0) == Some(self.config.my_party_id)
+	fn have_enough_round1(&self) -> bool {
+		// We need a Round 1 broadcast from every party that is a designated dealer for at
+		// least one old subset. With the assumption that `old_participants ==
+		// dkg_participants` this is exactly the set of old committee members that own at
+		// least one subset. Conservative requirement: all old participants.
+		self.round1_broadcasts.len() >= self.config.old_participants.len()
 	}
+
+	// ========================================================================
+	// Round 2: Private Reveal
+	// ========================================================================
 
 	fn handle_round2_generate(
 		&mut self,
 	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		// Only the designated dealer generates and distributes new shares
-		// Other old committee members participated in reconstruction but don't deal
-		if !self.is_designated_dealer() {
+		// Old-only parties without dealer responsibilities and new-only parties simply
+		// wait for inbound traffic.
+		if !self.config.role.is_old_committee() || self.pending_round2.is_empty() {
 			self.state = ResharingState::Round2Waiting;
-			return Ok(Action::Wait);
+			return self.poke();
 		}
 
-		// Generate new shares for the new committee
-		self.generate_new_shares()?;
-
-		// If we have messages to send, start sending them
-		if !self.my_round2_messages.is_empty() {
-			self.state = ResharingState::Round2Waiting;
-			return self.send_next_round2_message();
-		}
-
-		// No messages to send (shouldn't happen if we're a dealer)
 		self.state = ResharingState::Round2Waiting;
-		Ok(Action::Wait)
+		self.send_next_round2_message()
 	}
 
 	fn handle_round2_waiting(&mut self) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		// If we're the dealer and still have Round 2 messages to send, send them
-		if self.is_designated_dealer() && self.round2_sent_count < self.my_round2_messages.len() {
+		// Old-committee dealers continue to drain pending Round 2 messages.
+		if self.config.role.is_old_committee() &&
+			self.round2_sent_count < self.pending_round2.len()
+		{
 			return self.send_next_round2_message();
 		}
 
-		// Check if we've received enough messages (for new committee members)
-		// We only need to receive from the designated dealer (1 message)
-		if self.config.role.is_new_committee() && self.have_enough_round2() {
+		// New committee members proceed to Round 3 once they have received from every
+		// expected dealer.
+		if self.config.role.is_new_committee() && self.have_all_expected_round2() {
 			self.state = ResharingState::Round3Generate;
 			return self.poke();
 		}
 
-		// Old-only parties go straight to waiting for completion
-		// (either after dealing if designated dealer, or immediately otherwise)
-		if !self.config.role.is_new_committee() {
-			if self.is_designated_dealer() {
-				// Dealer waits until all messages are sent
-				if self.round2_sent_count >= self.my_round2_messages.len() {
-					self.state = ResharingState::Combining;
-					return self.poke();
-				}
-			} else {
-				// Non-dealer old-only parties skip to combining immediately
-				self.state = ResharingState::Combining;
-				return self.poke();
-			}
+		// Old-only parties advance to Round 3 generation (they will broadcast accusations
+		// only).
+		if !self.config.role.is_new_committee() &&
+			self.round2_sent_count >= self.pending_round2.len()
+		{
+			self.state = ResharingState::Round3Generate;
+			return self.poke();
 		}
 
 		Ok(Action::Wait)
@@ -585,110 +448,101 @@ impl ResharingProtocol {
 	fn send_next_round2_message(
 		&mut self,
 	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		if self.round2_sent_count >= self.my_round2_messages.len() {
+		if self.round2_sent_count >= self.pending_round2.len() {
 			return Ok(Action::Wait);
 		}
-
-		let msg = &self.my_round2_messages[self.round2_sent_count];
+		let msg = &self.pending_round2[self.round2_sent_count];
 		let to_party = msg.to_party_id;
-		let resharing_msg = ResharingMessage::Round2(msg.clone());
-		let data = Self::serialize_message(&resharing_msg)?;
-
+		let data = Self::serialize_message(&ResharingMessage::Round2(msg.clone()))?;
 		self.round2_sent_count += 1;
-
 		Ok(Action::SendPrivate(to_party, data))
 	}
 
 	fn handle_round2_message(&mut self, from: ParticipantId, msg: ResharingRound2Message) {
-		// Accept Round2 messages even if we're still finishing Round1, since messages may arrive
-		// before we've transitioned to Round2. We just store them for later processing.
-		// Only reject if we're already past Round2 or done/failed.
-		if matches!(
-			self.state,
-			ResharingState::Round3Generate |
-				ResharingState::Round3Waiting |
-				ResharingState::Combining |
-				ResharingState::Done
-		) {
+		if matches!(self.state, ResharingState::Done | ResharingState::Failed(_)) {
 			return;
 		}
-		if matches!(self.state, ResharingState::Failed(_)) {
+		if !self.config.role.is_new_committee() {
 			return;
 		}
-
-		// Verify sender is the designated dealer (first party in old_participants)
-		let designated_dealer = self.config.old_participants.get(0);
-		if designated_dealer != Some(from) {
-			// Round 2 message from non-dealer - ignore it
+		if !self.config.old_participants.contains(from) {
 			return;
 		}
-
-		// Verify message is for us
 		if msg.to_party_id != self.config.my_party_id {
-			// Round 2 message intended for another party - ignore it
 			return;
 		}
-
-		// Ignore duplicates
+		// Reject duplicates from the same dealer.
 		if self.round2_messages.contains_key(&from) {
 			return;
 		}
-
-		// Store the message and accumulate shares
-		// Note: With single dealer, we only receive from one party, so no accumulation needed
-		// But we still reduce modulo Q for safety
-		for (subset_mask, share_data) in &msg.shares {
-			let entry = self.new_shares.entry(*subset_mask).or_default();
-			// Add the share data and reduce modulo Q
-			for (entry_poly, share_poly) in entry.s1.iter_mut().zip(share_data.s1.iter()) {
-				for (entry_coeff, share_coeff) in entry_poly.iter_mut().zip(share_poly.iter()) {
-					*entry_coeff = entry_coeff.wrapping_add(*share_coeff);
-					*entry_coeff = reduce_coeff_mod_q(*entry_coeff);
-				}
-			}
-			for (entry_poly, share_poly) in entry.s2.iter_mut().zip(share_data.s2.iter()) {
-				for (entry_coeff, share_coeff) in entry_poly.iter_mut().zip(share_poly.iter()) {
-					*entry_coeff = entry_coeff.wrapping_add(*share_coeff);
-					*entry_coeff = reduce_coeff_mod_q(*entry_coeff);
-				}
-			}
-		}
-
 		self.round2_messages.insert(from, msg);
 	}
 
+	fn have_all_expected_round2(&self) -> bool {
+		// Expected senders = the set of designated dealers for each old subset.
+		let expected: BTreeMap<ParticipantId, ()> =
+			self.designated_dealer_set().into_iter().map(|p| (p, ())).collect();
+		expected.keys().all(|d| self.round2_messages.contains_key(d))
+	}
+
+	fn designated_dealer_set(&self) -> Vec<ParticipantId> {
+		let mut set: alloc::collections::BTreeSet<ParticipantId> =
+			alloc::collections::BTreeSet::new();
+		for &i_mask in &self.old_subset_order {
+			if let Some(d) = self.designated_dealer_for(i_mask) {
+				set.insert(d);
+			}
+		}
+		set.into_iter().collect()
+	}
+
 	// ========================================================================
-	// Round 3: Verification
+	// Round 3: Verification + Accusations
 	// ========================================================================
 
 	fn handle_round3_generate(
 		&mut self,
 	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		// Only new committee members participate in Round 3
-		if !self.config.role.is_new_committee() {
-			self.state = ResharingState::Combining;
-			return self.poke();
+		let mut accusations: Vec<DealerAccusation> = Vec::new();
+		let mut share_commitments: BTreeMap<SubsetMask, [u8; COMMITMENT_HASH_SIZE]> =
+			BTreeMap::new();
+		let mut success = true;
+		let mut error_message: Option<String> = None;
+
+		// Old committee members independently recompute every commitment for every old
+		// subset they belong to and accuse the dealer if the dealer's commitment differs
+		// from their independent computation.
+		if self.config.role.is_old_committee() {
+			match self.collect_accusations() {
+				Ok(a) => accusations = a,
+				Err(e) => {
+					success = false;
+					error_message = Some(e.to_string());
+				},
+			}
 		}
 
-		// Compute commitments to our new shares
-		let share_commitments = self.compute_share_commitments();
+		// New committee members verify privately-received sub-shares against the
+		// broadcast commitments, sum them into new subset shares, and commit.
+		if self.config.role.is_new_committee() && success {
+			match self.verify_and_aggregate_new_shares() {
+				Ok(commits) => share_commitments = commits,
+				Err(e) => {
+					success = false;
+					error_message = Some(e.to_string());
+				},
+			}
+		}
 
-		// Create Round 3 broadcast
 		let broadcast = ResharingRound3Broadcast {
 			party_id: self.config.my_party_id,
 			share_commitments,
-			success: true,
-			error_message: None,
+			accusations,
+			success,
+			error_message,
 		};
-
-		// Store our broadcast
-		self.my_round3 = Some(broadcast.clone());
 		self.round3_broadcasts.insert(self.config.my_party_id, broadcast.clone());
-
-		// Serialize and broadcast
-		let msg = ResharingMessage::Round3(broadcast);
-		let data = Self::serialize_message(&msg)?;
-
+		let data = Self::serialize_message(&ResharingMessage::Round3(broadcast))?;
 		self.state = ResharingState::Round3Waiting;
 		Ok(Action::SendMany(data))
 	}
@@ -703,604 +557,318 @@ impl ResharingProtocol {
 	}
 
 	fn handle_round3_message(&mut self, from: ParticipantId, broadcast: ResharingRound3Broadcast) {
-		// Accept Round3 messages even if we're still in Round2, since messages may arrive
-		// before we've transitioned to Round3. We just store them for later processing.
-		// Only reject if we're in very early states or already done/failed.
-		if matches!(
-			self.state,
-			ResharingState::Round1Generate | ResharingState::Round1Waiting | ResharingState::Done
-		) {
+		if matches!(self.state, ResharingState::Done | ResharingState::Failed(_)) {
 			return;
 		}
-		if matches!(self.state, ResharingState::Failed(_)) {
+		if !self.config.all_participants().contains(&from) {
 			return;
 		}
-
-		// Verify sender is in new committee
-		if !self.config.new_participants.contains(from) {
-			// Round 3 message from non-new-committee member - ignore it
-			return;
-		}
-
-		// Ignore duplicates
 		if self.round3_broadcasts.contains_key(&from) {
 			return;
 		}
-
-		// Store the broadcast
 		self.round3_broadcasts.insert(from, broadcast);
 	}
 
+	fn have_all_round3(&self) -> bool {
+		// Round 3 has contributions from BOTH old and new committee members
+		// (old members file accusations; new members commit to new shares),
+		// so we need broadcasts from every party that is in either committee.
+		let union = self.config.all_participants();
+		union.iter().all(|p| self.round3_broadcasts.contains_key(p))
+	}
+
 	// ========================================================================
-	// Combining and Finalization
+	// Combining
 	// ========================================================================
 
 	fn handle_combining(&mut self) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		// Verify Round 3 results (check for failures)
+		// Surface any explicit failure flags from Round 3.
 		let failed_parties: Vec<ParticipantId> = self
 			.round3_broadcasts
 			.iter()
 			.filter(|(_, b)| !b.success)
 			.map(|(id, _)| *id)
 			.collect();
-
 		if !failed_parties.is_empty() {
-			self.state =
-				ResharingState::Failed(format!("Parties reported failure: {:?}", failed_parties));
+			let reason = format!("Parties reported failure: {:?}", failed_parties);
+			self.state = ResharingState::Failed(reason);
 			return Err(ResharingProtocolError::PartyFailure(failed_parties));
 		}
 
-		// Verify share commitments are consistent
-		// (Parties sharing the same subset should have matching commitments)
-		self.verify_share_consistency()?;
+		// Surface any dealer accusations.
+		let mut accused: alloc::collections::BTreeSet<ParticipantId> =
+			alloc::collections::BTreeSet::new();
+		for broadcast in self.round3_broadcasts.values() {
+			for accusation in &broadcast.accusations {
+				accused.insert(accusation.dealer);
+			}
+		}
+		if !accused.is_empty() {
+			let accused_vec: Vec<ParticipantId> = accused.into_iter().collect();
+			let reason = format!("Dealers accused of misbehavior: {:?}", accused_vec);
+			self.state = ResharingState::Failed(reason);
+			return Err(ResharingProtocolError::PartyFailure(accused_vec));
+		}
 
-		// Build the output
+		// New committee members must agree on every shared new subset.
+		self.verify_new_share_consistency()?;
+
 		let output = self.build_output()?;
-
-		// Store a copy of the output for later retrieval via take_output()
 		self.completed_output = Some(output.clone());
-
 		self.state = ResharingState::Done;
 		Ok(Action::Return(output))
 	}
 
 	// ========================================================================
-	// Helper Methods
+	// Cryptographic Helpers
 	// ========================================================================
 
-	/// Generate random blinding values for s1 and s2.
-	fn generate_blinding_values(&self) -> (Vec<[i32; N]>, Vec<[i32; N]>) {
-		use qp_rusty_crystals_dilithium::fips202;
-
-		let mut state = fips202::KeccakState::default();
-		fips202::shake256_absorb(&mut state, &self.seed, 32);
-		fips202::shake256_absorb(&mut state, &self.config.my_party_id.to_le_bytes(), 4);
-		fips202::shake256_absorb(&mut state, b"blinding", 8);
-		fips202::shake256_finalize(&mut state);
-
-		let mut blinding_s1 = vec![[0i32; N]; L];
-		let mut blinding_s2 = vec![[0i32; N]; K];
-
-		// Sample η-bounded blinding values
-		let eta = 2i32; // ML-DSA-87 uses η=2
-
-		for poly in blinding_s1.iter_mut() {
-			for coeff in poly.iter_mut() {
-				let mut buf = [0u8; 1];
-				loop {
-					fips202::shake256_squeeze(&mut buf, 1, &mut state);
-					let b = buf[0] as i32;
-					let bound = 2 * eta + 1;
-					if b < (256 / bound) * bound {
-						*coeff = (b % bound) - eta;
-						break;
-					}
-				}
-			}
-		}
-
-		for poly in blinding_s2.iter_mut() {
-			for coeff in poly.iter_mut() {
-				let mut buf = [0u8; 1];
-				loop {
-					fips202::shake256_squeeze(&mut buf, 1, &mut state);
-					let b = buf[0] as i32;
-					let bound = 2 * eta + 1;
-					if b < (256 / bound) * bound {
-						*coeff = (b % bound) - eta;
-						break;
-					}
-				}
-			}
-		}
-
-		(blinding_s1, blinding_s2)
-	}
-
-	/// Compute blinded contribution: recovered_share + blinding.
-	///
-	/// IMPORTANT: To avoid double-counting shared subsets in RSS, each subset
-	/// is assigned to exactly one contributing party. A party only contributes
-	/// a subset if they are the "owner" - the party with the smallest ID among
-	/// those holding the subset who are participating in resharing.
-	fn compute_blinded_contribution(
-		&self,
-		blinding_s1: &[[i32; N]],
-		blinding_s2: &[[i32; N]],
-	) -> Result<SecretCoefficients, ResharingProtocolError> {
-		// Get existing share
-		let existing_share = self.config.existing_share.as_ref().ok_or_else(|| {
+	/// Pre-compute every sub-share `r_{I→J}` we are responsible for dealing.
+	fn compute_my_subshares(&mut self) -> Result<(), ResharingProtocolError> {
+		let existing = self.config.existing_share.as_ref().ok_or_else(|| {
 			ResharingProtocolError::InternalError("Missing existing share".to_string())
 		})?;
-
-		let shares = existing_share.shares();
-		let my_party_id = self.config.my_party_id;
-
-		// Get my index within the old participants list
-		let my_index = self.config.old_participants.index_of(my_party_id).ok_or_else(|| {
-			ResharingProtocolError::InternalError("Party not in old participants".to_string())
-		})?;
-
-		// Sum only the subset shares we are responsible for
-		// A party is responsible for a subset if they have the smallest index
-		// among all old committee members holding that subset
-		let mut contribution_s1 = vec![[0i32; N]; L];
-		let mut contribution_s2 = vec![[0i32; N]; K];
-
-		for (&subset_mask, share_data) in shares {
-			// Determine who owns this subset (smallest index among holders)
-			let owner_index = self.find_subset_owner(subset_mask);
-
-			// Only contribute if we are the owner
-			if owner_index == Some(my_index) {
-				for (contrib_poly, share_poly) in contribution_s1
-					.iter_mut()
-					.zip(share_data.s1.iter())
-					.take(L.min(share_data.s1.len()))
-				{
-					for (contrib_coeff, share_coeff) in
-						contrib_poly.iter_mut().zip(share_poly.iter())
-					{
-						*contrib_coeff = contrib_coeff.wrapping_add(*share_coeff);
-					}
-				}
-				for (contrib_poly, share_poly) in contribution_s2
-					.iter_mut()
-					.zip(share_data.s2.iter())
-					.take(K.min(share_data.s2.len()))
-				{
-					for (contrib_coeff, share_coeff) in
-						contrib_poly.iter_mut().zip(share_poly.iter())
-					{
-						*contrib_coeff = contrib_coeff.wrapping_add(*share_coeff);
-					}
-				}
-			}
+		let shares = existing.shares();
+		let new_subsets = self.new_subset_order.clone();
+		let n_new = new_subsets.len();
+		if n_new == 0 {
+			return Err(ResharingProtocolError::InternalError(
+				"No new subsets to deal to".to_string(),
+			));
 		}
 
-		// Add blinding (all parties add their blinding, regardless of subset ownership)
-		// and reduce modulo Q to keep coefficients in valid range
-		for (contrib_poly, blind_poly) in contribution_s1.iter_mut().zip(blinding_s1.iter()) {
-			for (contrib_coeff, blind_coeff) in contrib_poly.iter_mut().zip(blind_poly.iter()) {
-				*contrib_coeff = contrib_coeff.wrapping_add(*blind_coeff);
-				*contrib_coeff = reduce_coeff_mod_q(*contrib_coeff);
+		for (i_idx, &i_mask) in self.old_subset_order.clone().iter().enumerate() {
+			// Only compute for subsets where we are the designated dealer.
+			if self.designated_dealer_for(i_mask) != Some(self.config.my_party_id) {
+				continue;
+			}
+			let s_i = shares.get(&i_mask).ok_or_else(|| {
+				ResharingProtocolError::InternalError(format!(
+					"Designated dealer for subset {:b} but no share data",
+					i_mask
+				))
+			})?;
+			let residual_idx = i_idx % n_new;
+			let subshares = derive_subshares(i_mask, s_i, &new_subsets, residual_idx);
+			for (j_idx, j_mask) in new_subsets.iter().enumerate() {
+				self.my_subshares.insert((i_mask, *j_mask), subshares[j_idx].clone());
 			}
 		}
-		for (contrib_poly, blind_poly) in contribution_s2.iter_mut().zip(blinding_s2.iter()) {
-			for (contrib_coeff, blind_coeff) in contrib_poly.iter_mut().zip(blind_poly.iter()) {
-				*contrib_coeff = contrib_coeff.wrapping_add(*blind_coeff);
-				*contrib_coeff = reduce_coeff_mod_q(*contrib_coeff);
-			}
-		}
-
-		Ok((contribution_s1, contribution_s2))
-	}
-
-	/// Find the owner of a subset - the party with the smallest index among
-	/// all old committee members who hold this subset.
-	///
-	/// The subset mask uses bit positions corresponding to indices in the
-	/// old participants list (from the original keygen).
-	fn find_subset_owner(&self, subset_mask: u16) -> Option<usize> {
-		// Get the DKG participants from the existing share to understand the
-		// original subset indexing
-		let existing_share = self.config.existing_share.as_ref()?;
-		let dkg_participants = existing_share.dkg_participants();
-
-		// Find the smallest index among parties that:
-		// 1. Hold this subset (bit is set in mask)
-		// 2. Are in the old committee (participating in resharing)
-		let mut min_index: Option<usize> = None;
-
-		for (bit_pos, party_id) in dkg_participants.iter().enumerate() {
-			// Check if this party holds the subset
-			if (subset_mask & (1 << bit_pos)) != 0 {
-				// Check if this party is in the old committee
-				if self.config.old_participants.contains(party_id) {
-					// Get their index in old_participants
-					if let Some(old_idx) = self.config.old_participants.index_of(party_id) {
-						match min_index {
-							None => min_index = Some(old_idx),
-							Some(current_min) if old_idx < current_min => min_index = Some(old_idx),
-							_ => {},
-						}
-					}
-				}
-			}
-		}
-
-		min_index
-	}
-
-	/// Compute commitment to blinding values.
-	fn compute_blinding_commitment(
-		&self,
-		blinding_s1: &[[i32; N]],
-		blinding_s2: &[[i32; N]],
-	) -> [u8; COMMITMENT_HASH_SIZE] {
-		use qp_rusty_crystals_dilithium::fips202;
-
-		let mut state = fips202::KeccakState::default();
-		fips202::shake256_absorb(&mut state, b"blinding_commitment", 19);
-
-		// Hash all blinding coefficients
-		for poly in blinding_s1 {
-			for coeff in poly {
-				fips202::shake256_absorb(&mut state, &coeff.to_le_bytes(), 4);
-			}
-		}
-		for poly in blinding_s2 {
-			for coeff in poly {
-				fips202::shake256_absorb(&mut state, &coeff.to_le_bytes(), 4);
-			}
-		}
-
-		fips202::shake256_finalize(&mut state);
-		let mut commitment = [0u8; COMMITMENT_HASH_SIZE];
-		fips202::shake256_squeeze(&mut commitment, COMMITMENT_HASH_SIZE, &mut state);
-		commitment
-	}
-
-	/// Generate new shares for the new committee.
-	fn generate_new_shares(&mut self) -> Result<(), ResharingProtocolError> {
-		// Aggregate blinded contributions from Round 1
-		let (blinded_s1_total, blinded_s2_total) = self.aggregate_round1_contributions()?;
-
-		// Compute total blinding to remove
-		let (total_blinding_s1, total_blinding_s2) = self.compute_total_blinding();
-
-		// Generate fresh RSS shares for the new committee
-		// The shares should sum to: blinded_total - total_blinding = original_secret
-		self.my_round2_messages = self.deal_new_shares(
-			&blinded_s1_total,
-			&blinded_s2_total,
-			&total_blinding_s1,
-			&total_blinding_s2,
-		)?;
-
 		Ok(())
 	}
 
-	/// Aggregate Round 1 contributions to get blinded total secret.
-	/// Coefficients are reduced modulo Q after aggregation to prevent overflow.
-	fn aggregate_round1_contributions(&self) -> Result<SecretCoefficients, ResharingProtocolError> {
-		let mut total_s1 = vec![[0i32; N]; L];
-		let mut total_s2 = vec![[0i32; N]; K];
-
-		for broadcast in self.round1_broadcasts.values() {
-			for (total_poly, bcast_poly) in
-				total_s1.iter_mut().zip(broadcast.blinded_s1_contribution.coefficients.iter())
-			{
-				for (total_coeff, bcast_coeff) in total_poly.iter_mut().zip(bcast_poly.iter()) {
-					*total_coeff = total_coeff.wrapping_add(*bcast_coeff);
-				}
-			}
-			for (total_poly, bcast_poly) in
-				total_s2.iter_mut().zip(broadcast.blinded_s2_contribution.coefficients.iter())
-			{
-				for (total_coeff, bcast_coeff) in total_poly.iter_mut().zip(bcast_poly.iter()) {
-					*total_coeff = total_coeff.wrapping_add(*bcast_coeff);
-				}
-			}
+	/// Compute hash commitments to every sub-share we will deal.
+	fn commit_to_my_subshares(&self) -> BTreeMap<SubsetPair, [u8; COMMITMENT_HASH_SIZE]> {
+		let mut out = BTreeMap::new();
+		for (pair, share) in &self.my_subshares {
+			out.insert(*pair, commit_subshare(pair.0, pair.1, share));
 		}
-
-		// Reduce coefficients modulo Q to keep them in valid range
-		for total_poly in total_s1.iter_mut() {
-			for total_coeff in total_poly.iter_mut() {
-				*total_coeff = reduce_coeff_mod_q(*total_coeff);
-			}
-		}
-		for total_poly in total_s2.iter_mut() {
-			for total_coeff in total_poly.iter_mut() {
-				*total_coeff = reduce_coeff_mod_q(*total_coeff);
-			}
-		}
-
-		Ok((total_s1, total_s2))
+		out
 	}
 
-	/// Compute the total blinding value to remove from the aggregated contributions.
-	///
-	/// This sums the blinding values from ALL Round 1 participants, which are
-	/// included in each Round 1 broadcast. This ensures all dealers can compute
-	/// the same total blinding to remove.
-	fn compute_total_blinding(&self) -> (Vec<[i32; N]>, Vec<[i32; N]>) {
-		let mut total_s1 = vec![[0i32; N]; L];
-		let mut total_s2 = vec![[0i32; N]; K];
-
-		// Sum blinding values from all Round 1 broadcasts
-		for broadcast in self.round1_broadcasts.values() {
-			// Add blinding_s1 from this participant
-			for (total_poly, bcast_poly) in total_s1
-				.iter_mut()
-				.zip(broadcast.blinding_s1.coefficients.iter())
-				.take(L.min(broadcast.blinding_s1.coefficients.len()))
-			{
-				for (total_coeff, bcast_coeff) in total_poly.iter_mut().zip(bcast_poly.iter()) {
-					*total_coeff = total_coeff.wrapping_add(*bcast_coeff);
-				}
-			}
-			// Add blinding_s2 from this participant
-			for (total_poly, bcast_poly) in total_s2
-				.iter_mut()
-				.zip(broadcast.blinding_s2.coefficients.iter())
-				.take(K.min(broadcast.blinding_s2.coefficients.len()))
-			{
-				for (total_coeff, bcast_coeff) in total_poly.iter_mut().zip(bcast_poly.iter()) {
-					*total_coeff = total_coeff.wrapping_add(*bcast_coeff);
-				}
-			}
-		}
-
-		// Reduce coefficients modulo Q
-		for total_poly in total_s1.iter_mut() {
-			for total_coeff in total_poly.iter_mut() {
-				*total_coeff = reduce_coeff_mod_q(*total_coeff);
-			}
-		}
-		for total_poly in total_s2.iter_mut() {
-			for total_coeff in total_poly.iter_mut() {
-				*total_coeff = reduce_coeff_mod_q(*total_coeff);
-			}
-		}
-
-		(total_s1, total_s2)
-	}
-
-	/// Deal new shares to the new committee.
-	fn deal_new_shares(
-		&self,
-		blinded_s1_total: &[[i32; N]],
-		blinded_s2_total: &[[i32; N]],
-		total_blinding_s1: &[[i32; N]],
-		total_blinding_s2: &[[i32; N]],
-	) -> Result<Vec<ResharingRound2Message>, ResharingProtocolError> {
-		use qp_rusty_crystals_dilithium::fips202;
-
-		let new_t = self.config.new_threshold;
-		let new_n = self.config.new_participants.len() as u32;
-
-		// Compute the actual secret: blinded_total - total_blinding
-		// Reduce modulo Q to ensure coefficients are in valid range
-		let mut secret_s1 = vec![[0i32; N]; L];
-		let mut secret_s2 = vec![[0i32; N]; K];
-
-		for (secret_poly, (blinded_poly, blind_poly)) in
-			secret_s1.iter_mut().zip(blinded_s1_total.iter().zip(total_blinding_s1.iter()))
-		{
-			for (secret_coeff, (blinded_coeff, blind_coeff)) in
-				secret_poly.iter_mut().zip(blinded_poly.iter().zip(blind_poly.iter()))
-			{
-				let diff = blinded_coeff.wrapping_sub(*blind_coeff);
-				*secret_coeff = reduce_coeff_mod_q(diff);
-			}
-		}
-		for (secret_poly, (blinded_poly, blind_poly)) in
-			secret_s2.iter_mut().zip(blinded_s2_total.iter().zip(total_blinding_s2.iter()))
-		{
-			for (secret_coeff, (blinded_coeff, blind_coeff)) in
-				secret_poly.iter_mut().zip(blinded_poly.iter().zip(blind_poly.iter()))
-			{
-				let diff = blinded_coeff.wrapping_sub(*blind_coeff);
-				*secret_coeff = reduce_coeff_mod_q(diff);
-			}
-		}
-
-		// Generate subset structure for new committee
-		// Subsets have size (n - t + 1)
-		let subset_size = new_n - new_t + 1;
-		let subsets = generate_subsets(new_n as usize, subset_size as usize);
-
-		// Initialize share accumulator for each new party
-		let mut party_shares: BTreeMap<ParticipantId, BTreeMap<SubsetMask, NewShareData>> =
+	/// Build the per-recipient Round 2 messages we will emit one-by-one in `poke`.
+	fn build_pending_round2_messages(&mut self) {
+		let mut by_recipient: BTreeMap<ParticipantId, BTreeMap<SubsetPair, NewShareData>> =
 			BTreeMap::new();
-		for party_id in self.config.new_participants.iter() {
-			party_shares.insert(party_id, BTreeMap::new());
+		for (pair, share) in &self.my_subshares {
+			let j_mask = pair.1;
+			for (idx, party) in self.config.new_participants.iter().enumerate() {
+				if (j_mask & (1 << idx)) != 0 {
+					by_recipient.entry(party).or_default().insert(*pair, share.clone());
+				}
+			}
+		}
+		for (recipient, contributions) in by_recipient {
+			self.pending_round2.push(ResharingRound2Message {
+				from_party_id: self.config.my_party_id,
+				to_party_id: recipient,
+				contributions,
+			});
+		}
+	}
+
+	/// Find the designated dealer for an old subset: the lowest-ID old
+	/// participant that is a member of the subset.
+	///
+	/// Bit positions in `i_mask` correspond to indices in the (sorted)
+	/// `old_participants` list, so the dealer is the party at the lowest
+	/// set bit. Works for every party — in particular NewOnly parties that
+	/// don't hold an `existing_share`.
+	fn designated_dealer_for(&self, i_mask: SubsetMask) -> Option<ParticipantId> {
+		for (bit, party) in self.config.old_participants.iter().enumerate() {
+			if (i_mask & (1 << bit)) != 0 {
+				return Some(party);
+			}
+		}
+		None
+	}
+
+	/// Old committee post-Round-1 verification: re-derive sub-shares for every old
+	/// subset we belong to, compare against the dealer's broadcast commitments, and
+	/// produce accusations for any mismatches.
+	fn collect_accusations(&self) -> Result<Vec<DealerAccusation>, ResharingProtocolError> {
+		let existing = self.config.existing_share.as_ref().ok_or_else(|| {
+			ResharingProtocolError::InternalError("Missing existing share".to_string())
+		})?;
+		let shares = existing.shares();
+		let new_subsets = &self.new_subset_order;
+		let n_new = new_subsets.len();
+		if n_new == 0 {
+			return Ok(Vec::new());
 		}
 
-		// Generate random shares for all but the last subset
-		let mut state = fips202::KeccakState::default();
-		fips202::shake256_absorb(&mut state, &self.seed, 32);
-		fips202::shake256_absorb(&mut state, b"new_shares", 10);
-		fips202::shake256_finalize(&mut state);
-
-		let eta = 2i32;
-		let mut shares_sum_s1 = vec![[0i32; N]; L];
-		let mut shares_sum_s2 = vec![[0i32; N]; K];
-
-		for (idx, &subset_mask) in subsets.iter().enumerate() {
-			let is_last = idx == subsets.len() - 1;
-
-			let share = if is_last {
-				// Last subset: compute to make sum equal to secret
-				let mut s1 = vec![[0i32; N]; L];
-				let mut s2 = vec![[0i32; N]; K];
-				for (s1_poly, (secret_poly, sum_poly)) in
-					s1.iter_mut().zip(secret_s1.iter().zip(shares_sum_s1.iter()))
-				{
-					for (s1_coeff, (secret_coeff, sum_coeff)) in
-						s1_poly.iter_mut().zip(secret_poly.iter().zip(sum_poly.iter()))
-					{
-						*s1_coeff = secret_coeff.wrapping_sub(*sum_coeff);
-					}
-				}
-				for (s2_poly, (secret_poly, sum_poly)) in
-					s2.iter_mut().zip(secret_s2.iter().zip(shares_sum_s2.iter()))
-				{
-					for (s2_coeff, (secret_coeff, sum_coeff)) in
-						s2_poly.iter_mut().zip(secret_poly.iter().zip(sum_poly.iter()))
-					{
-						*s2_coeff = secret_coeff.wrapping_sub(*sum_coeff);
-					}
-				}
-				NewShareData { s1, s2 }
-			} else {
-				// Random η-bounded share
-				let mut s1 = vec![[0i32; N]; L];
-				let mut s2 = vec![[0i32; N]; K];
-
-				for poly in s1.iter_mut() {
-					for coeff in poly.iter_mut() {
-						let mut buf = [0u8; 1];
-						loop {
-							fips202::shake256_squeeze(&mut buf, 1, &mut state);
-							let b = buf[0] as i32;
-							let bound = 2 * eta + 1;
-							if b < (256 / bound) * bound {
-								*coeff = (b % bound) - eta;
-								break;
-							}
-						}
-					}
-				}
-				for poly in s2.iter_mut() {
-					for coeff in poly.iter_mut() {
-						let mut buf = [0u8; 1];
-						loop {
-							fips202::shake256_squeeze(&mut buf, 1, &mut state);
-							let b = buf[0] as i32;
-							let bound = 2 * eta + 1;
-							if b < (256 / bound) * bound {
-								*coeff = (b % bound) - eta;
-								break;
-							}
-						}
-					}
-				}
-
-				// Add to running sum
-				for (sum_poly, s1_poly) in shares_sum_s1.iter_mut().zip(s1.iter()) {
-					for (sum_coeff, s1_coeff) in sum_poly.iter_mut().zip(s1_poly.iter()) {
-						*sum_coeff = sum_coeff.wrapping_add(*s1_coeff);
-					}
-				}
-				for (sum_poly, s2_poly) in shares_sum_s2.iter_mut().zip(s2.iter()) {
-					for (sum_coeff, s2_coeff) in sum_poly.iter_mut().zip(s2_poly.iter()) {
-						*sum_coeff = sum_coeff.wrapping_add(*s2_coeff);
-					}
-				}
-
-				NewShareData { s1, s2 }
+		let mut accusations = Vec::new();
+		for (i_idx, &i_mask) in self.old_subset_order.iter().enumerate() {
+			let dealer = match self.designated_dealer_for(i_mask) {
+				Some(d) => d,
+				None => continue,
 			};
-
-			// Distribute to all parties in this subset
-			for (party_idx, party_id) in self.config.new_participants.iter().enumerate() {
-				if (subset_mask & (1 << party_idx)) != 0 {
-					if let Some(shares) = party_shares.get_mut(&party_id) {
-						shares.insert(subset_mask, share.clone());
-					}
+			// Skip subsets we are not in (we can't recompute their secret share data).
+			let s_i = match shares.get(&i_mask) {
+				Some(s) => s,
+				None => continue,
+			};
+			// We don't accuse ourselves.
+			if dealer == self.config.my_party_id {
+				continue;
+			}
+			let dealer_broadcast = self.round1_broadcasts.get(&dealer).ok_or_else(|| {
+				ResharingProtocolError::InternalError(format!(
+					"Missing Round 1 broadcast from designated dealer {} for subset {:b}",
+					dealer, i_mask
+				))
+			})?;
+			let residual_idx = i_idx % n_new;
+			let expected = derive_subshares(i_mask, s_i, new_subsets, residual_idx);
+			for (j_idx, &j_mask) in new_subsets.iter().enumerate() {
+				let expected_commit = commit_subshare(i_mask, j_mask, &expected[j_idx]);
+				match dealer_broadcast.commitments.get(&(i_mask, j_mask)) {
+					Some(c) if *c == expected_commit => {},
+					_ => {
+						accusations.push(DealerAccusation {
+							dealer,
+							old_subset: i_mask,
+							new_subset: j_mask,
+						});
+					},
 				}
 			}
 		}
+		Ok(accusations)
+	}
 
-		// Create Round 2 messages for each new party
-		let mut messages = Vec::new();
-		for party_id in self.config.new_participants.iter() {
-			if let Some(shares) = party_shares.remove(&party_id) {
-				messages.push(ResharingRound2Message {
-					from_party_id: self.config.my_party_id,
-					to_party_id: party_id,
-					shares,
-				});
+	/// New committee post-Round-2 work: verify each received `r_{I→J}` against the
+	/// matching Round 1 commitment, then sum them into `s_J^new` and produce a
+	/// commitment per new subset we are in.
+	fn verify_and_aggregate_new_shares(
+		&mut self,
+	) -> Result<BTreeMap<SubsetMask, [u8; COMMITMENT_HASH_SIZE]>, ResharingProtocolError> {
+		let my_idx = self
+			.config
+			.new_participants
+			.index_of(self.config.my_party_id)
+			.ok_or_else(|| ResharingProtocolError::InternalError("not in new committee".into()))?;
+
+		// Collect every (I, J, dealer, r) we expect to use.
+		let new_subsets = &self.new_subset_order;
+		let mut s_new: BTreeMap<SubsetMask, NewShareData> = BTreeMap::new();
+		for &j_mask in new_subsets {
+			if (j_mask & (1 << my_idx)) == 0 {
+				continue;
+			}
+			s_new.insert(j_mask, NewShareData::new());
+		}
+
+		for &i_mask in &self.old_subset_order {
+			let dealer = match self.designated_dealer_for(i_mask) {
+				Some(d) => d,
+				None =>
+					return Err(ResharingProtocolError::ShareVerificationFailed(format!(
+						"no designated dealer found for old subset {:b}",
+						i_mask
+					))),
+			};
+			let dealer_r1 = self.round1_broadcasts.get(&dealer).ok_or_else(|| {
+				ResharingProtocolError::ShareVerificationFailed(format!(
+					"missing Round 1 commitment from dealer {} for subset {:b}",
+					dealer, i_mask
+				))
+			})?;
+			let dealer_r2 = self.round2_messages.get(&dealer).ok_or_else(|| {
+				ResharingProtocolError::ShareVerificationFailed(format!(
+					"missing Round 2 message from dealer {} for subset {:b}",
+					dealer, i_mask
+				))
+			})?;
+			for &j_mask in new_subsets {
+				if (j_mask & (1 << my_idx)) == 0 {
+					continue;
+				}
+				let r = dealer_r2.contributions.get(&(i_mask, j_mask)).ok_or_else(|| {
+					ResharingProtocolError::ShareVerificationFailed(format!(
+						"dealer {} did not deliver r_{{{:b}->{:b}}}",
+						dealer, i_mask, j_mask
+					))
+				})?;
+				let expected_commit = commit_subshare(i_mask, j_mask, r);
+				let dealer_commit =
+					dealer_r1.commitments.get(&(i_mask, j_mask)).ok_or_else(|| {
+						ResharingProtocolError::ShareVerificationFailed(format!(
+							"dealer {} did not commit to r_{{{:b}->{:b}}}",
+							dealer, i_mask, j_mask
+						))
+					})?;
+				if *dealer_commit != expected_commit {
+					return Err(ResharingProtocolError::ShareVerificationFailed(format!(
+						"dealer {} sent r_{{{:b}->{:b}}} that doesn't match their commitment",
+						dealer, i_mask, j_mask
+					)));
+				}
+				let acc = s_new.get_mut(&j_mask).unwrap();
+				add_share_into(acc, r);
 			}
 		}
 
-		Ok(messages)
-	}
-
-	/// Compute commitments to our new shares.
-	fn compute_share_commitments(&self) -> BTreeMap<SubsetMask, [u8; COMMITMENT_HASH_SIZE]> {
-		use qp_rusty_crystals_dilithium::fips202;
-
+		// Reduce mod Q and stash.
 		let mut commitments = BTreeMap::new();
-
-		for (subset_mask, share_data) in &self.new_shares {
-			let mut state = fips202::KeccakState::default();
-			fips202::shake256_absorb(&mut state, b"share_commitment", 16);
-			fips202::shake256_absorb(&mut state, &subset_mask.to_le_bytes(), 2);
-
-			// Hash share coefficients
-			for poly in &share_data.s1 {
-				for coeff in poly {
-					fips202::shake256_absorb(&mut state, &coeff.to_le_bytes(), 4);
-				}
-			}
-			for poly in &share_data.s2 {
-				for coeff in poly {
-					fips202::shake256_absorb(&mut state, &coeff.to_le_bytes(), 4);
-				}
-			}
-
-			fips202::shake256_finalize(&mut state);
-			let mut commitment = [0u8; COMMITMENT_HASH_SIZE];
-			fips202::shake256_squeeze(&mut commitment, COMMITMENT_HASH_SIZE, &mut state);
-
-			commitments.insert(*subset_mask, commitment);
+		for (j_mask, mut share) in s_new {
+			reduce_share_mod_q(&mut share);
+			commitments.insert(j_mask, commit_new_share(j_mask, &share));
+			self.new_shares.insert(j_mask, share);
 		}
-
-		commitments
+		Ok(commitments)
 	}
 
-	/// Verify that parties sharing the same subset have consistent commitments.
-	fn verify_share_consistency(&self) -> Result<(), ResharingProtocolError> {
-		// Group commitments by subset
-		let mut subset_commitments: BTreeMap<
+	/// All members of new subset J must produce identical `s_J^new` (and thus identical
+	/// commitments). Cross-verify that.
+	fn verify_new_share_consistency(&self) -> Result<(), ResharingProtocolError> {
+		let mut by_subset: BTreeMap<
 			SubsetMask,
 			Vec<(ParticipantId, [u8; COMMITMENT_HASH_SIZE])>,
 		> = BTreeMap::new();
-
-		for (party_id, broadcast) in &self.round3_broadcasts {
-			for (subset_mask, commitment) in &broadcast.share_commitments {
-				subset_commitments
-					.entry(*subset_mask)
-					.or_default()
-					.push((*party_id, *commitment));
+		for (party, broadcast) in &self.round3_broadcasts {
+			for (j_mask, commit) in &broadcast.share_commitments {
+				by_subset.entry(*j_mask).or_default().push((*party, *commit));
 			}
 		}
-
-		// For each subset, verify all parties have the same commitment
-		for (subset_mask, commitments) in &subset_commitments {
-			if commitments.len() < 2 {
+		for (j_mask, commits) in &by_subset {
+			if commits.len() < 2 {
 				continue;
 			}
-
-			let first_commitment = &commitments[0].1;
-			for (party_id, commitment) in &commitments[1..] {
-				if commitment != first_commitment {
+			let first = commits[0].1;
+			for (party, commit) in &commits[1..] {
+				if *commit != first {
 					return Err(ResharingProtocolError::ShareVerificationFailed(format!(
-						"Commitment mismatch for subset {:b}: party {} differs from party {}",
-						subset_mask, party_id, commitments[0].0
+						"members of new subset {:b} disagree: party {} differs from party {}",
+						j_mask, party, commits[0].0
 					)));
 				}
 			}
 		}
-
 		Ok(())
 	}
 
-	/// Build the final resharing output.
 	fn build_output(&self) -> Result<ResharingOutput, ResharingProtocolError> {
-		// If we're not in the new committee, we don't get a new share
 		if !self.config.role.is_new_committee() {
 			return Ok(ResharingOutput {
 				private_share: None,
@@ -1308,10 +876,7 @@ impl ResharingProtocol {
 				new_config: self.config.new_config(),
 			});
 		}
-
-		// Build new private key share from accumulated shares
 		let new_share = self.build_private_key_share()?;
-
 		Ok(ResharingOutput {
 			private_share: Some(new_share),
 			public_key: self.config.public_key.clone(),
@@ -1319,42 +884,50 @@ impl ResharingProtocol {
 		})
 	}
 
-	/// Build a new PrivateKeyShare from accumulated Round 2 data.
 	fn build_private_key_share(&self) -> Result<PrivateKeyShare, ResharingProtocolError> {
-		use crate::keys::SecretShareData;
-
-		// Convert new_shares to SecretShareData format
 		let mut shares_data: BTreeMap<u16, SecretShareData> = BTreeMap::new();
-		for (subset_mask, share) in &self.new_shares {
-			let s1_data: Vec<[i32; 256]> = share.s1.clone();
-			let s2_data: Vec<[i32; 256]> = share.s2.clone();
-			shares_data.insert(*subset_mask, SecretShareData { s1: s1_data, s2: s2_data });
+		for (j_mask, share) in &self.new_shares {
+			shares_data.insert(
+				*j_mask,
+				SecretShareData { s1: share.s1.clone(), s2: share.s2.clone() },
+			);
 		}
 
-		// Get rho and tr from existing share or public key
-		// rho is the first 32 bytes of the packed public key (used for matrix A expansion)
-		// tr is the hash of the public key (used in signing)
 		let (rho, tr) = if let Some(ref existing) = self.config.existing_share {
 			(*existing.rho(), *existing.tr())
 		} else {
-			// For new parties, extract rho from public key bytes
-			// In ML-DSA-87, pk = (rho || packed_t1), so rho is the first 32 bytes
 			let pk_bytes = self.config.public_key.as_bytes();
 			let mut rho = [0u8; 32];
 			rho.copy_from_slice(&pk_bytes[..32]);
 			(rho, *self.config.public_key.tr())
 		};
 
-		// Generate a new party key
+		// Derive `party_key` from the actual share polynomials so it carries real
+		// entropy (mirrors the C3 fix in the DKG path).
 		let mut party_key = [0u8; 32];
 		{
-			use qp_rusty_crystals_dilithium::fips202;
-			let mut state = fips202::KeccakState::default();
-			fips202::shake256_absorb(&mut state, &self.seed, 32);
-			fips202::shake256_absorb(&mut state, b"party_key", 9);
-			fips202::shake256_absorb(&mut state, &self.config.my_party_id.to_le_bytes(), 4);
-			fips202::shake256_finalize(&mut state);
-			fips202::shake256_squeeze(&mut party_key, 32, &mut state);
+			let mut h = fips202::KeccakState::default();
+			fips202::shake256_absorb(&mut h, b"reshare-party-key-v2", 20);
+			fips202::shake256_absorb(&mut h, &rho, 32);
+			fips202::shake256_absorb(&mut h, &self.config.my_party_id.to_le_bytes(), 4);
+			let mut buf: Vec<u8> = Vec::new();
+			for (j_mask, share) in &self.new_shares {
+				buf.clear();
+				buf.extend_from_slice(&j_mask.to_le_bytes());
+				for poly in &share.s1 {
+					for c in poly {
+						buf.extend_from_slice(&c.to_le_bytes());
+					}
+				}
+				for poly in &share.s2 {
+					for c in poly {
+						buf.extend_from_slice(&c.to_le_bytes());
+					}
+				}
+				fips202::shake256_absorb(&mut h, &buf, buf.len());
+			}
+			fips202::shake256_finalize(&mut h);
+			fips202::shake256_squeeze(&mut party_key, 32, &mut h);
 		}
 
 		Ok(PrivateKeyShare::new(
@@ -1371,43 +944,246 @@ impl ResharingProtocol {
 }
 
 // ============================================================================
-// Helper Functions
+// Free Functions: subset enumeration and sub-share derivation
 // ============================================================================
 
-/// Generate all subsets of size `size` from `n` elements.
-/// Returns subset masks as u16.
-/// Reduce a coefficient to the range [0, Q).
-/// Handles both positive values that exceed Q and negative values.
-#[inline]
-fn reduce_coeff_mod_q(x: i32) -> i32 {
-	let mut r = x % Q;
-	if r < 0 {
-		r += Q;
-	}
-	r
+/// Canonical enumeration of all old RSS subsets: every `k_old`-subset of the
+/// `n_old` old committee positions. **Identical for every party**, so the
+/// `i_idx` used to pick a residual `J` in `derive_subshares` is consistent
+/// across all parties — without this consistency, dealers' commitments would
+/// not match the verifiers' independent recomputations.
+fn compute_old_subset_order(config: &ResharingConfig) -> Vec<SubsetMask> {
+	let n = config.old_participants.len();
+	let k = n - config.old_threshold as usize + 1;
+	generate_subset_masks(n, k)
 }
 
-fn generate_subsets(n: usize, size: usize) -> Vec<SubsetMask> {
-	if size > n || size == 0 {
+fn compute_new_subset_order(config: &ResharingConfig) -> Vec<SubsetMask> {
+	let n = config.new_participants.len();
+	let k = n - config.new_threshold as usize + 1;
+	generate_subset_masks(n, k)
+}
+
+/// Enumerate subset masks of size `k` over `n` bits in canonical (numerically
+/// ascending) order using Gosper's hack.
+fn generate_subset_masks(n: usize, k: usize) -> Vec<SubsetMask> {
+	if k == 0 || k > n {
 		return Vec::new();
 	}
+	let mut out = Vec::new();
+	let max_val: u32 = 1u32 << n;
+	let mut mask: u32 = (1u32 << k) - 1;
+	while mask < max_val {
+		out.push(mask as SubsetMask);
+		let c = mask & mask.wrapping_neg();
+		let r = mask + c;
+		mask = (((r ^ mask) >> 2) / c) | r;
+	}
+	out
+}
 
-	let mut subsets = Vec::new();
-	let max_val: u16 = 1 << n;
+/// Derive sub-shares `r_{I→J}` for every new subset `J` such that
+/// `Σ_J r_{I→J} = s_I` (mod Q), where `s_I` is the (η-bounded) old subset
+/// share. The sub-share for `new_subsets[residual_idx]` absorbs the sum
+/// adjustment; all others are sampled deterministically η-bounded from a PRF
+/// seeded by `s_I` and the subset masks.
+fn derive_subshares(
+	i_mask: SubsetMask,
+	s_i: &SecretShareData,
+	new_subsets: &[SubsetMask],
+	residual_idx: usize,
+) -> Vec<NewShareData> {
+	debug_assert!(new_subsets.len() > residual_idx);
+	let mut out: Vec<NewShareData> = (0..new_subsets.len()).map(|_| NewShareData::new()).collect();
 
-	// Start with the smallest subset of the given size
-	let mut subset: u16 = (1 << size) - 1;
+	// Build a PRF seed from (domain || I_mask || s1 || s2). All members of subset I
+	// know `s_i` and so derive the same seed.
+	let prf_seed = build_subset_seed(i_mask, s_i);
 
-	while subset < max_val {
-		subsets.push(subset);
+	// Track running sums to compute the residual.
+	let mut sum_s1: Vec<[i32; N]> = vec![[0i32; N]; L];
+	let mut sum_s2: Vec<[i32; N]> = vec![[0i32; N]; K];
 
-		// Gosper's hack to get next subset of same size
-		let c = subset & (!subset + 1);
-		let r = subset + c;
-		subset = (((r ^ subset) >> 2) / c) | r;
+	for (j_idx, &j_mask) in new_subsets.iter().enumerate() {
+		if j_idx == residual_idx {
+			continue;
+		}
+		let mut state = fips202::KeccakState::default();
+		fips202::shake256_absorb(&mut state, &prf_seed, prf_seed.len());
+		fips202::shake256_absorb(&mut state, &j_mask.to_le_bytes(), 2);
+		fips202::shake256_finalize(&mut state);
+
+		for poly in out[j_idx].s1.iter_mut() {
+			sample_eta_poly(&mut state, poly);
+		}
+		for poly in out[j_idx].s2.iter_mut() {
+			sample_eta_poly(&mut state, poly);
+		}
+		add_share_into_sum(&mut sum_s1, &mut sum_s2, &out[j_idx]);
 	}
 
-	subsets
+	// Residual: r_{I→J_residual} = s_I - Σ.
+	let residual = &mut out[residual_idx];
+	for (poly_idx, poly) in residual.s1.iter_mut().enumerate() {
+		for (coeff_idx, c) in poly.iter_mut().enumerate() {
+			let s = s_i.s1[poly_idx][coeff_idx];
+			let r = sum_s1[poly_idx][coeff_idx];
+			*c = mod_q(s.wrapping_sub(r));
+		}
+	}
+	for (poly_idx, poly) in residual.s2.iter_mut().enumerate() {
+		for (coeff_idx, c) in poly.iter_mut().enumerate() {
+			let s = s_i.s2[poly_idx][coeff_idx];
+			let r = sum_s2[poly_idx][coeff_idx];
+			*c = mod_q(s.wrapping_sub(r));
+		}
+	}
+	out
+}
+
+fn build_subset_seed(i_mask: SubsetMask, s_i: &SecretShareData) -> [u8; 64] {
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, SUBSET_SEED_DOMAIN, SUBSET_SEED_DOMAIN.len());
+	fips202::shake256_absorb(&mut state, &i_mask.to_le_bytes(), 2);
+	let mut buf: Vec<u8> = Vec::new();
+	for poly in &s_i.s1 {
+		buf.clear();
+		for c in poly {
+			buf.extend_from_slice(&c.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+	for poly in &s_i.s2 {
+		buf.clear();
+		for c in poly {
+			buf.extend_from_slice(&c.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+	fips202::shake256_finalize(&mut state);
+	let mut out = [0u8; 64];
+	fips202::shake256_squeeze(&mut out, 64, &mut state);
+	out
+}
+
+fn sample_eta_poly(state: &mut fips202::KeccakState, poly: &mut [i32; N]) {
+	let bound: i32 = 2 * ETA + 1;
+	let cutoff: i32 = (256 / bound) * bound;
+	for c in poly.iter_mut() {
+		let mut buf = [0u8; 1];
+		loop {
+			fips202::shake256_squeeze(&mut buf, 1, state);
+			let b = buf[0] as i32;
+			if b < cutoff {
+				*c = (b % bound) - ETA;
+				break;
+			}
+		}
+	}
+}
+
+fn commit_subshare(
+	i_mask: SubsetMask,
+	j_mask: SubsetMask,
+	r: &NewShareData,
+) -> [u8; COMMITMENT_HASH_SIZE] {
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, COMMIT_DOMAIN, COMMIT_DOMAIN.len());
+	fips202::shake256_absorb(&mut state, &i_mask.to_le_bytes(), 2);
+	fips202::shake256_absorb(&mut state, &j_mask.to_le_bytes(), 2);
+	let mut buf: Vec<u8> = Vec::new();
+	for poly in &r.s1 {
+		buf.clear();
+		for c in poly {
+			buf.extend_from_slice(&c.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+	for poly in &r.s2 {
+		buf.clear();
+		for c in poly {
+			buf.extend_from_slice(&c.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+	fips202::shake256_finalize(&mut state);
+	let mut out = [0u8; COMMITMENT_HASH_SIZE];
+	fips202::shake256_squeeze(&mut out, COMMITMENT_HASH_SIZE, &mut state);
+	out
+}
+
+fn commit_new_share(j_mask: SubsetMask, share: &NewShareData) -> [u8; COMMITMENT_HASH_SIZE] {
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, NEW_SHARE_COMMIT_DOMAIN, NEW_SHARE_COMMIT_DOMAIN.len());
+	fips202::shake256_absorb(&mut state, &j_mask.to_le_bytes(), 2);
+	let mut buf: Vec<u8> = Vec::new();
+	for poly in &share.s1 {
+		buf.clear();
+		for c in poly {
+			buf.extend_from_slice(&c.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+	for poly in &share.s2 {
+		buf.clear();
+		for c in poly {
+			buf.extend_from_slice(&c.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+	fips202::shake256_finalize(&mut state);
+	let mut out = [0u8; COMMITMENT_HASH_SIZE];
+	fips202::shake256_squeeze(&mut out, COMMITMENT_HASH_SIZE, &mut state);
+	out
+}
+
+fn add_share_into(acc: &mut NewShareData, r: &NewShareData) {
+	for (a, b) in acc.s1.iter_mut().zip(r.s1.iter()) {
+		for (ac, bc) in a.iter_mut().zip(b.iter()) {
+			*ac = ac.wrapping_add(*bc);
+		}
+	}
+	for (a, b) in acc.s2.iter_mut().zip(r.s2.iter()) {
+		for (ac, bc) in a.iter_mut().zip(b.iter()) {
+			*ac = ac.wrapping_add(*bc);
+		}
+	}
+}
+
+fn add_share_into_sum(sum_s1: &mut [[i32; N]], sum_s2: &mut [[i32; N]], r: &NewShareData) {
+	for (a, b) in sum_s1.iter_mut().zip(r.s1.iter()) {
+		for (ac, bc) in a.iter_mut().zip(b.iter()) {
+			*ac = ac.wrapping_add(*bc);
+		}
+	}
+	for (a, b) in sum_s2.iter_mut().zip(r.s2.iter()) {
+		for (ac, bc) in a.iter_mut().zip(b.iter()) {
+			*ac = ac.wrapping_add(*bc);
+		}
+	}
+}
+
+fn reduce_share_mod_q(share: &mut NewShareData) {
+	for poly in share.s1.iter_mut() {
+		for c in poly.iter_mut() {
+			*c = mod_q(*c);
+		}
+	}
+	for poly in share.s2.iter_mut() {
+		for c in poly.iter_mut() {
+			*c = mod_q(*c);
+		}
+	}
+}
+
+#[inline]
+fn mod_q(x: i32) -> i32 {
+	let r = x % Q;
+	if r < 0 {
+		r + Q
+	} else {
+		r
+	}
 }
 
 // ============================================================================
@@ -1419,26 +1195,101 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn test_generate_subsets() {
-		// C(3, 2) = 3 subsets of size 2
-		let subsets = generate_subsets(3, 2);
-		assert_eq!(subsets.len(), 3);
-		assert!(subsets.contains(&0b011)); // {0, 1}
-		assert!(subsets.contains(&0b101)); // {0, 2}
-		assert!(subsets.contains(&0b110)); // {1, 2}
+	fn test_generate_subset_masks() {
+		let s = generate_subset_masks(3, 2);
+		assert_eq!(s, vec![0b011, 0b101, 0b110]);
 
-		// C(4, 2) = 6 subsets of size 2
-		let subsets = generate_subsets(4, 2);
-		assert_eq!(subsets.len(), 6);
+		let s = generate_subset_masks(4, 2);
+		assert_eq!(s.len(), 6);
+		// Canonical ascending order.
+		for i in 1..s.len() {
+			assert!(s[i - 1] < s[i]);
+		}
 
-		// C(5, 3) = 10 subsets of size 3
-		let subsets = generate_subsets(5, 3);
-		assert_eq!(subsets.len(), 10);
+		let s = generate_subset_masks(5, 3);
+		assert_eq!(s.len(), 10);
+		for i in 1..s.len() {
+			assert!(s[i - 1] < s[i]);
+		}
+	}
+
+	#[test]
+	fn test_generate_subset_masks_edge_cases() {
+		assert!(generate_subset_masks(0, 0).is_empty());
+		assert!(generate_subset_masks(3, 0).is_empty());
+		assert!(generate_subset_masks(3, 4).is_empty());
+		assert_eq!(generate_subset_masks(4, 4), vec![0b1111]);
+	}
+
+	#[test]
+	fn test_subset_seed_is_deterministic_for_same_share() {
+		let s = SecretShareData { s1: vec![[3i32; N]; L], s2: vec![[5i32; N]; K] };
+		assert_eq!(build_subset_seed(0b011, &s), build_subset_seed(0b011, &s));
+	}
+
+	#[test]
+	fn test_derive_subshares_sums_to_original_share() {
+		let s = SecretShareData { s1: vec![[1i32; N]; L], s2: vec![[2i32; N]; K] };
+		let new_subsets = generate_subset_masks(3, 2);
+		for residual_idx in 0..new_subsets.len() {
+			let subshares = derive_subshares(0b011, &s, &new_subsets, residual_idx);
+			let mut sum_s1 = vec![[0i64; N]; L];
+			let mut sum_s2 = vec![[0i64; N]; K];
+			for sub in &subshares {
+				for (a, b) in sum_s1.iter_mut().zip(sub.s1.iter()) {
+					for (ac, bc) in a.iter_mut().zip(b.iter()) {
+						*ac += *bc as i64;
+					}
+				}
+				for (a, b) in sum_s2.iter_mut().zip(sub.s2.iter()) {
+					for (ac, bc) in a.iter_mut().zip(b.iter()) {
+						*ac += *bc as i64;
+					}
+				}
+			}
+			for (poly_idx, poly) in sum_s1.iter().enumerate() {
+				for (c_idx, &v) in poly.iter().enumerate() {
+					let expected = s.s1[poly_idx][c_idx] as i64;
+					let q = Q as i64;
+					assert_eq!((v % q + q) % q, (expected % q + q) % q);
+				}
+			}
+			for (poly_idx, poly) in sum_s2.iter().enumerate() {
+				for (c_idx, &v) in poly.iter().enumerate() {
+					let expected = s.s2[poly_idx][c_idx] as i64;
+					let q = Q as i64;
+					assert_eq!((v % q + q) % q, (expected % q + q) % q);
+				}
+			}
+		}
+	}
+
+	#[test]
+	fn test_derive_subshares_is_deterministic() {
+		let s = SecretShareData { s1: vec![[1i32; N]; L], s2: vec![[2i32; N]; K] };
+		let new_subsets = generate_subset_masks(3, 2);
+		let a = derive_subshares(0b011, &s, &new_subsets, 0);
+		let b = derive_subshares(0b011, &s, &new_subsets, 0);
+		for (x, y) in a.iter().zip(b.iter()) {
+			assert_eq!(x.s1, y.s1);
+			assert_eq!(x.s2, y.s2);
+		}
+	}
+
+	#[test]
+	fn test_commit_subshare_distinguishes_inputs() {
+		let r1 = NewShareData { s1: vec![[1i32; N]; L], s2: vec![[2i32; N]; K] };
+		let r2 = NewShareData { s1: vec![[1i32; N]; L], s2: vec![[3i32; N]; K] };
+		let c1 = commit_subshare(0b011, 0b101, &r1);
+		let c2 = commit_subshare(0b011, 0b101, &r2);
+		assert_ne!(c1, c2);
+		// Different subsets should also differ.
+		let c3 = commit_subshare(0b011, 0b110, &r1);
+		assert_ne!(c1, c3);
 	}
 
 	#[test]
 	fn test_resharing_state_transitions() {
-		// Test that state enum variants are distinct
 		assert_ne!(ResharingState::Round1Generate, ResharingState::Round1Waiting);
 		assert_ne!(ResharingState::Round2Generate, ResharingState::Round2Waiting);
 		assert_ne!(ResharingState::Round3Generate, ResharingState::Round3Waiting);
@@ -1452,7 +1303,6 @@ mod tests {
 		let send_private: Action<()> = Action::SendPrivate(42, vec![4, 5, 6]);
 		let ret: Action<i32> = Action::Return(123);
 
-		// Just verify they compile and can be matched
 		match wait {
 			Action::Wait => {},
 			_ => panic!("Expected Wait"),
@@ -1475,116 +1325,56 @@ mod tests {
 	}
 
 	#[test]
-	fn test_reduce_coeff_mod_q() {
-		// Test positive values within range
-		assert_eq!(reduce_coeff_mod_q(0), 0);
-		assert_eq!(reduce_coeff_mod_q(1), 1);
-		assert_eq!(reduce_coeff_mod_q(Q - 1), Q - 1);
-
-		// Test values equal to Q
-		assert_eq!(reduce_coeff_mod_q(Q), 0);
-
-		// Test values greater than Q
-		assert_eq!(reduce_coeff_mod_q(Q + 1), 1);
-		assert_eq!(reduce_coeff_mod_q(2 * Q), 0);
-		assert_eq!(reduce_coeff_mod_q(2 * Q + 100), 100);
-
-		// Test negative values
-		assert_eq!(reduce_coeff_mod_q(-1), Q - 1);
-		assert_eq!(reduce_coeff_mod_q(-Q), 0);
-		assert_eq!(reduce_coeff_mod_q(-Q - 1), Q - 1);
-		assert_eq!(reduce_coeff_mod_q(-100), Q - 100);
-
-		// Test with various random-ish values
-		assert_eq!(reduce_coeff_mod_q(12345678), 12345678 % Q);
-		assert_eq!(reduce_coeff_mod_q(-12345678), (Q - (12345678 % Q)) % Q);
+	fn test_mod_q() {
+		assert_eq!(mod_q(0), 0);
+		assert_eq!(mod_q(1), 1);
+		assert_eq!(mod_q(Q - 1), Q - 1);
+		assert_eq!(mod_q(Q), 0);
+		assert_eq!(mod_q(Q + 1), 1);
+		assert_eq!(mod_q(-1), Q - 1);
+		assert_eq!(mod_q(-Q), 0);
+		assert_eq!(mod_q(-Q - 1), Q - 1);
 	}
 
 	#[test]
-	fn test_reduce_coeff_mod_q_randomized() {
-		// Test with a range of values to ensure consistency
-		for i in -1000..1000 {
-			let result = reduce_coeff_mod_q(i);
-			assert!(result >= 0, "Result should be non-negative for input {}", i);
-			assert!(result < Q, "Result should be less than Q for input {}", i);
-
-			// Verify the result is congruent to the input mod Q
-			let expected = ((i % Q) + Q) % Q;
-			assert_eq!(result, expected, "Mismatch for input {}", i);
-		}
-
-		// Test edge cases around Q boundaries
-		for offset in -10..10 {
-			let input = Q + offset;
-			let result = reduce_coeff_mod_q(input);
-			assert!((0..Q).contains(&result));
-
-			let input2 = -Q + offset;
-			let result2 = reduce_coeff_mod_q(input2);
-			assert!((0..Q).contains(&result2));
-		}
+	fn test_subshares_for_disjoint_share_data_diverge() {
+		// Two different `s_I^old` values must produce different sub-share splits
+		// (otherwise an attacker who saw them couldn't distinguish secrets).
+		let s_a = SecretShareData { s1: vec![[1i32; N]; L], s2: vec![[2i32; N]; K] };
+		let s_b = SecretShareData { s1: vec![[3i32; N]; L], s2: vec![[5i32; N]; K] };
+		let new_subsets = generate_subset_masks(3, 2);
+		let a = derive_subshares(0b011, &s_a, &new_subsets, 0);
+		let b = derive_subshares(0b011, &s_b, &new_subsets, 0);
+		// Even the *first* sub-share (which is sampled, not residual) must differ
+		// because the PRF seed depends on `s_i`.
+		assert_ne!(a[1].s1, b[1].s1);
 	}
 
 	#[test]
-	fn test_generate_subsets_edge_cases() {
-		// Empty cases
-		assert!(generate_subsets(0, 0).is_empty());
-		assert!(generate_subsets(0, 1).is_empty());
-		assert!(generate_subsets(3, 0).is_empty());
-		assert!(generate_subsets(3, 4).is_empty()); // size > n
-
-		// Single element subsets
-		let subsets = generate_subsets(3, 1);
-		assert_eq!(subsets.len(), 3);
-		assert!(subsets.contains(&0b001));
-		assert!(subsets.contains(&0b010));
-		assert!(subsets.contains(&0b100));
-
-		// Full set (n choose n = 1)
-		let subsets = generate_subsets(4, 4);
-		assert_eq!(subsets.len(), 1);
-		assert!(subsets.contains(&0b1111));
-
-		// Verify binomial coefficients for various (n, k)
-		assert_eq!(generate_subsets(5, 2).len(), 10); // C(5,2) = 10
-		assert_eq!(generate_subsets(6, 3).len(), 20); // C(6,3) = 20
-		assert_eq!(generate_subsets(7, 4).len(), 35); // C(7,4) = 35
+	fn test_subshares_independent_per_old_subset() {
+		// Different old subsets sharing the same `s_I^old` value must still produce
+		// different sub-shares, because the PRF seed mixes `i_mask`.
+		let s = SecretShareData { s1: vec![[1i32; N]; L], s2: vec![[2i32; N]; K] };
+		let new_subsets = generate_subset_masks(3, 2);
+		let a = derive_subshares(0b011, &s, &new_subsets, 0);
+		let b = derive_subshares(0b101, &s, &new_subsets, 0);
+		// The *non-residual* sub-shares are PRF outputs keyed on (s, i_mask, j_mask),
+		// so they must differ.
+		assert_ne!(a[1].s1, b[1].s1);
 	}
 
 	#[test]
-	fn test_generate_subsets_correctness() {
-		// For each generated subset, verify it has exactly 'size' bits set
-		for n in 2..8 {
-			for size in 1..=n {
-				let subsets = generate_subsets(n, size);
-				for &subset in &subsets {
-					let bit_count = (0..n).filter(|&i| (subset & (1 << i)) != 0).count();
-					assert_eq!(
-						bit_count, size,
-						"Subset {:b} should have {} bits set, has {}",
-						subset, size, bit_count
-					);
-				}
-			}
-		}
-	}
-
-	#[test]
-	fn test_generate_subsets_no_duplicates() {
-		// Verify no duplicate subsets are generated
-		for n in 2..8 {
-			for size in 1..=n {
-				let subsets = generate_subsets(n, size);
-				let unique: std::collections::HashSet<_> = subsets.iter().collect();
-				assert_eq!(
-					subsets.len(),
-					unique.len(),
-					"Found duplicates for n={}, size={}",
-					n,
-					size
-				);
-			}
-		}
+	fn test_round1_broadcast_does_not_leak_subshares() {
+		// Sanity: a Round 1 broadcast carries hash commitments and nothing else.
+		// In particular it must not contain any plaintext NewShareData fields.
+		let mut commitments = BTreeMap::new();
+		commitments.insert((0b011u16, 0b101u16), [9u8; COMMITMENT_HASH_SIZE]);
+		let r1 = ResharingRound1Broadcast { party_id: 7, commitments };
+		// The struct only has `party_id` (u32) and `commitments` (BTreeMap of hashes).
+		// If anyone ever adds back leaky plaintext fields, this test should be
+		// updated alongside the security review.
+		assert_eq!(r1.party_id, 7);
+		assert_eq!(r1.commitments.len(), 1);
 	}
 
 	#[test]

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -696,11 +696,8 @@ impl ResharingProtocol {
 		}
 		let me = self.config.my_party_id;
 		for (recipient, contributions) in by_recipient {
-			let msg = ResharingRound2Message {
-				from_party_id: me,
-				to_party_id: recipient,
-				contributions,
-			};
+			let msg =
+				ResharingRound2Message { from_party_id: me, to_party_id: recipient, contributions };
 			if recipient == me {
 				self.round2_messages.insert(me, msg);
 			} else {
@@ -905,9 +902,8 @@ impl ResharingProtocol {
 		self.new_shares
 			.iter()
 			.map(|(j_mask, share)| {
-				let t = crate::protocol::partial_pk::compute_partial_pk_t(
-					&rho, &share.s1, &share.s2,
-				);
+				let t =
+					crate::protocol::partial_pk::compute_partial_pk_t(&rho, &share.s1, &share.s2);
 				(*j_mask, t)
 			})
 			.collect()
@@ -942,8 +938,7 @@ impl ResharingProtocol {
 			}
 		}
 		let rho = self.derive_rho();
-		let recovered =
-			crate::protocol::partial_pk::pack_combined_pk(&rho, canonical.values());
+		let recovered = crate::protocol::partial_pk::pack_combined_pk(&rho, canonical.values());
 		if recovered.as_bytes() != self.config.public_key.as_bytes() {
 			return Err(ResharingProtocolError::ShareVerificationFailed(
 				"recovered public key does not match the original — a dealer corrupted at \

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -185,8 +185,6 @@ pub enum ResharingState {
 pub struct ResharingProtocol {
 	config: ResharingConfig,
 	state: ResharingState,
-	#[allow(dead_code)] // reserved for future per-session nonce mixing
-	seed: [u8; 32],
 
 	/// Old subset masks (from the existing share's stored shares), in canonical
 	/// (BTreeMap) order. Indexed by `old_subset_index`.
@@ -222,13 +220,12 @@ pub struct ResharingProtocol {
 
 impl ResharingProtocol {
 	/// Create a new resharing protocol instance.
-	pub fn new(config: ResharingConfig, seed: [u8; 32]) -> Self {
+	pub fn new(config: ResharingConfig) -> Self {
 		let old_subset_order = compute_old_subset_order(&config);
 		let new_subset_order = compute_new_subset_order(&config);
 		Self {
 			config,
 			state: ResharingState::Round1Generate,
-			seed,
 			old_subset_order,
 			new_subset_order,
 			my_subshares: BTreeMap::new(),

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -6,18 +6,16 @@
 //! See `resharing/mod.rs` for a full description of the cryptographic protocol.
 //! In short:
 //!
-//! - **Round 1 (Commitments)**: Each old committee member that is the
-//!   designated dealer for one or more old RSS subsets broadcasts hash
-//!   commitments to the per-subset sub-shares `r_{I→J}` they will deliver in
-//!   Round 2. Sub-shares are derived deterministically from `s_I^old`, so all
+//! - **Round 1 (Commitments)**: Each old committee member that is the designated dealer for one or
+//!   more old RSS subsets broadcasts hash commitments to the per-subset sub-shares `r_{I→J}` they
+//!   will deliver in Round 2. Sub-shares are derived deterministically from `s_I^old`, so all
 //!   members of `I` can independently recompute and verify these commitments.
-//! - **Round 2 (Reveal)**: Each designated dealer privately delivers
-//!   `r_{I→J}` to every member of new subset `J`.
-//! - **Round 3 (Verification)**: Each new committee member verifies received
-//!   sub-shares against the broadcast commitments, sums them into new shares
-//!   `s_J^new`, and broadcasts a commitment to each computed `s_J^new` so the
-//!   members of `J` can cross-verify. Old committee members file dealer
-//!   accusations if any broadcast commitment fails their independent recomputation.
+//! - **Round 2 (Reveal)**: Each designated dealer privately delivers `r_{I→J}` to every member of
+//!   new subset `J`.
+//! - **Round 3 (Verification)**: Each new committee member verifies received sub-shares against the
+//!   broadcast commitments, sums them into new shares `s_J^new`, and broadcasts a commitment to
+//!   each computed `s_J^new` so the members of `J` can cross-verify. Old committee members file
+//!   dealer accusations if any broadcast commitment fails their independent recomputation.
 //!
 //! # State Machine
 //!
@@ -321,10 +319,7 @@ impl ResharingProtocol {
 		let msg = match Self::deserialize_message(&data) {
 			Ok(m) => m,
 			Err(e) =>
-				return Err(ResharingProtocolError::MalformedMessage {
-					from,
-					reason: e.to_string(),
-				}),
+				return Err(ResharingProtocolError::MalformedMessage { from, reason: e.to_string() }),
 		};
 
 		if msg.party_id() != from {
@@ -356,8 +351,7 @@ impl ResharingProtocol {
 		self.compute_my_subshares()?;
 		let commitments = self.commit_to_my_subshares();
 
-		let broadcast =
-			ResharingRound1Broadcast { party_id: self.config.my_party_id, commitments };
+		let broadcast = ResharingRound1Broadcast { party_id: self.config.my_party_id, commitments };
 		self.my_round1 = Some(broadcast.clone());
 		self.round1_broadcasts.insert(self.config.my_party_id, broadcast.clone());
 
@@ -420,8 +414,7 @@ impl ResharingProtocol {
 
 	fn handle_round2_waiting(&mut self) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
 		// Old-committee dealers continue to drain pending Round 2 messages.
-		if self.config.role.is_old_committee() &&
-			self.round2_sent_count < self.pending_round2.len()
+		if self.config.role.is_old_committee() && self.round2_sent_count < self.pending_round2.len()
 		{
 			return self.send_next_round2_message();
 		}
@@ -763,11 +756,10 @@ impl ResharingProtocol {
 	fn verify_and_aggregate_new_shares(
 		&mut self,
 	) -> Result<BTreeMap<SubsetMask, [u8; COMMITMENT_HASH_SIZE]>, ResharingProtocolError> {
-		let my_idx = self
-			.config
-			.new_participants
-			.index_of(self.config.my_party_id)
-			.ok_or_else(|| ResharingProtocolError::InternalError("not in new committee".into()))?;
+		let my_idx =
+			self.config.new_participants.index_of(self.config.my_party_id).ok_or_else(|| {
+				ResharingProtocolError::InternalError("not in new committee".into())
+			})?;
 
 		// Collect every (I, J, dealer, r) we expect to use.
 		let new_subsets = &self.new_subset_order;
@@ -842,10 +834,8 @@ impl ResharingProtocol {
 	/// All members of new subset J must produce identical `s_J^new` (and thus identical
 	/// commitments). Cross-verify that.
 	fn verify_new_share_consistency(&self) -> Result<(), ResharingProtocolError> {
-		let mut by_subset: BTreeMap<
-			SubsetMask,
-			Vec<(ParticipantId, [u8; COMMITMENT_HASH_SIZE])>,
-		> = BTreeMap::new();
+		let mut by_subset: BTreeMap<SubsetMask, Vec<(ParticipantId, [u8; COMMITMENT_HASH_SIZE])>> =
+			BTreeMap::new();
 		for (party, broadcast) in &self.round3_broadcasts {
 			for (j_mask, commit) in &broadcast.share_commitments {
 				by_subset.entry(*j_mask).or_default().push((*party, *commit));
@@ -887,10 +877,8 @@ impl ResharingProtocol {
 	fn build_private_key_share(&self) -> Result<PrivateKeyShare, ResharingProtocolError> {
 		let mut shares_data: BTreeMap<u16, SecretShareData> = BTreeMap::new();
 		for (j_mask, share) in &self.new_shares {
-			shares_data.insert(
-				*j_mask,
-				SecretShareData { s1: share.s1.clone(), s2: share.s2.clone() },
-			);
+			shares_data
+				.insert(*j_mask, SecretShareData { s1: share.s1.clone(), s2: share.s2.clone() });
 		}
 
 		let (rho, tr) = if let Some(ref existing) = self.config.existing_share {

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -294,7 +294,7 @@ impl fmt::Display for ResharingConfigError {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ResharingMessage {
-	/// Round 1: Blinded share contributions from old committee.
+	/// Round 1: Hash commitments to per-subset sub-shares from old committee.
 	Round1(ResharingRound1Broadcast),
 	/// Round 2: New share distributions to new committee.
 	Round2(ResharingRound2Message),

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -413,19 +413,16 @@ impl Default for NewShareData {
 ///
 /// Round 3 has two purposes:
 ///
-/// 1. **New committee verification.** Each new committee member broadcasts a
-///    commitment to each `s_J^new` they computed for new subsets `J` containing
-///    them. Other members of the same `J` should produce identical commitments;
-///    any mismatch indicates inconsistent dealing (e.g., a malicious dealer
-///    who sent different `r_{I→J}` to different recipients).
+/// 1. **New committee verification.** Each new committee member broadcasts a commitment to each
+///    `s_J^new` they computed for new subsets `J` containing them. Other members of the same `J`
+///    should produce identical commitments; any mismatch indicates inconsistent dealing (e.g., a
+///    malicious dealer who sent different `r_{I→J}` to different recipients).
 ///
-/// 2. **Old committee cross-verification.** Old committee members that share an
-///    old subset `I` with the dealer `D_I` independently recompute the
-///    deterministic `r_{I→J}` values from their own copy of `s_I^old` and
-///    compare them against `D_I`'s broadcast commitments. Any mismatch is
-///    reported as a `DealerAccusation`. If the accusation is correct (the
-///    accuser's recomputation matches their own private knowledge of `s_I`),
-///    the resharing fails.
+/// 2. **Old committee cross-verification.** Old committee members that share an old subset `I` with
+///    the dealer `D_I` independently recompute the deterministic `r_{I→J}` values from their own
+///    copy of `s_I^old` and compare them against `D_I`'s broadcast commitments. Any mismatch is
+///    reported as a `DealerAccusation`. If the accusation is correct (the accuser's recomputation
+///    matches their own private knowledge of `s_I`), the resharing fails.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResharingRound3Broadcast {

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[cfg(feature = "serde")]
-use crate::serde_helpers::{serde_participant_list, serde_partial_pks, serde_poly_vec};
+use crate::serde_helpers::{serde_partial_pks, serde_participant_list, serde_poly_vec};
 
 // ML-DSA-87 parameters (same as DKG)
 /// Number of polynomials in s1 vector.
@@ -427,10 +427,9 @@ impl Default for NewShareData {
 /// 3. **Public-key invariant verification.** Each new committee member additionally publishes
 ///    `t_J^new = A·s1_J^new + s2_J^new mod Q` for every new subset `J` it belongs to. Anyone can
 ///    sum these `t_J` and check that the result reconstructs the original public key. This catches
-///    a malicious dealer that lies about the residual `r_{I→J}` in a *size-1* old subset
-///    (`t = n` configurations), where there is no other old-subset member to cross-verify in
-///    purpose 2. Publishing `t_J^new` is safe: recovering `s_J^new` from `t_J^new` is the LWE
-///    problem.
+///    a malicious dealer that lies about the residual `r_{I→J}` in a *size-1* old subset (`t = n`
+///    configurations), where there is no other old-subset member to cross-verify in purpose 2.
+///    Publishing `t_J^new` is safe: recovering `s_J^new` from `t_J^new` is the LWE problem.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResharingRound3Broadcast {

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[cfg(feature = "serde")]
-use crate::serde_helpers::{serde_participant_list, serde_poly_vec};
+use crate::serde_helpers::{serde_participant_list, serde_partial_pks, serde_poly_vec};
 
 // ML-DSA-87 parameters (same as DKG)
 /// Number of polynomials in s1 vector.
@@ -411,7 +411,7 @@ impl Default for NewShareData {
 
 /// Round 3 broadcast.
 ///
-/// Round 3 has two purposes:
+/// Round 3 has three purposes:
 ///
 /// 1. **New committee verification.** Each new committee member broadcasts a commitment to each
 ///    `s_J^new` they computed for new subsets `J` containing them. Other members of the same `J`
@@ -423,6 +423,14 @@ impl Default for NewShareData {
 ///    copy of `s_I^old` and compare them against `D_I`'s broadcast commitments. Any mismatch is
 ///    reported as a `DealerAccusation`. If the accusation is correct (the accuser's recomputation
 ///    matches their own private knowledge of `s_I`), the resharing fails.
+///
+/// 3. **Public-key invariant verification.** Each new committee member additionally publishes
+///    `t_J^new = A·s1_J^new + s2_J^new mod Q` for every new subset `J` it belongs to. Anyone can
+///    sum these `t_J` and check that the result reconstructs the original public key. This catches
+///    a malicious dealer that lies about the residual `r_{I→J}` in a *size-1* old subset
+///    (`t = n` configurations), where there is no other old-subset member to cross-verify in
+///    purpose 2. Publishing `t_J^new` is safe: recovering `s_J^new` from `t_J^new` is the LWE
+///    problem.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResharingRound3Broadcast {
@@ -430,6 +438,10 @@ pub struct ResharingRound3Broadcast {
 	pub party_id: ParticipantId,
 	/// Commitments to each computed new subset share (only populated by new committee members).
 	pub share_commitments: BTreeMap<SubsetMask, [u8; COMMITMENT_HASH_SIZE]>,
+	/// Partial public-key contributions `t_J^new = A·s1_J^new + s2_J^new mod Q`,
+	/// one entry per new subset `J` this party belongs to. Empty for old-only parties.
+	#[cfg_attr(feature = "serde", serde(with = "serde_partial_pks"))]
+	pub partial_pks: BTreeMap<SubsetMask, Vec<[i32; N]>>,
 	/// Accusations against dealers whose broadcast commitments did not match
 	/// the sender's independent recomputation.
 	pub accusations: Vec<DealerAccusation>,
@@ -596,6 +608,7 @@ mod tests {
 		let r3 = ResharingMessage::Round3(ResharingRound3Broadcast {
 			party_id: 2,
 			share_commitments: BTreeMap::new(),
+			partial_pks: BTreeMap::new(),
 			accusations: Vec::new(),
 			success: true,
 			error_message: None,
@@ -773,6 +786,7 @@ mod tests {
 		let r3 = ResharingMessage::Round3(ResharingRound3Broadcast {
 			party_id: 77,
 			share_commitments: BTreeMap::new(),
+			partial_pks: BTreeMap::new(),
 			accusations: Vec::new(),
 			success: true,
 			error_message: None,
@@ -785,6 +799,7 @@ mod tests {
 		let success = ResharingRound3Broadcast {
 			party_id: 0,
 			share_commitments: BTreeMap::new(),
+			partial_pks: BTreeMap::new(),
 			accusations: Vec::new(),
 			success: true,
 			error_message: None,
@@ -795,6 +810,7 @@ mod tests {
 		let failure = ResharingRound3Broadcast {
 			party_id: 1,
 			share_commitments: BTreeMap::new(),
+			partial_pks: BTreeMap::new(),
 			accusations: Vec::new(),
 			success: false,
 			error_message: Some("Share verification failed".to_string()),

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -323,76 +323,52 @@ impl ResharingMessage {
 }
 
 // ============================================================================
-// Round 1: Blinded Share Contributions
+// Round 1: Per-Subset Commitment Broadcast
 // ============================================================================
 
 /// Round 1 broadcast from old committee members.
 ///
-/// Each old committee member broadcasts their blinded share contribution
-/// along with the blinding values used. The blinding values are needed
-/// by dealers to correctly remove the total blinding when generating
-/// new shares.
+/// Each old committee member broadcasts hash commitments to the per-subset
+/// "sub-share" contributions they will privately deliver in Round 2. A party
+/// only commits to subsets where they are the *designated dealer* (the
+/// lowest-ID old participant in the subset). Other members of the same old
+/// subset independently recompute the same contributions and verify the
+/// commitment in Round 3.
 ///
-/// **Security note:** Broadcasting the blinding values is safe because:
-/// - The blinding alone doesn't reveal the secret
-/// - The blinded contribution hides the actual share values
-/// - Only the combination of all participants' shares (which requires threshold cooperation) can
-///   recover the secret
+/// # Security
+///
+/// Unlike the previous design, **no share values, blindings, or aggregations
+/// are revealed in clear**. The only public data is the hash commitment to
+/// each `r_{I→J}`, which is hiding because each `r_{I→J}` has at least
+/// `5^256 ≈ 2^594` bits of entropy (the η-bounded sample space) or is itself
+/// a function of secret share material.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResharingRound1Broadcast {
 	/// Party ID of the sender.
 	pub party_id: ParticipantId,
-	/// Blinded contribution to s1 reconstruction.
-	/// This is: recovered_s1_share + blinding_s1
-	pub blinded_s1_contribution: BlindedContribution,
-	/// Blinded contribution to s2 reconstruction.
-	/// This is: recovered_s2_share + blinding_s2
-	pub blinded_s2_contribution: BlindedContribution,
-	/// The blinding values used for s1 (needed by dealers to remove total blinding).
-	pub blinding_s1: BlindedContribution,
-	/// The blinding values used for s2 (needed by dealers to remove total blinding).
-	pub blinding_s2: BlindedContribution,
-	/// Commitment to the blinding values (for verification that blinding matches).
-	pub blinding_commitment: [u8; COMMITMENT_HASH_SIZE],
+	/// Commitments keyed by `(old_subset_mask, new_subset_mask)`.
+	///
+	/// The sender is the designated dealer for `old_subset_mask`. Each commitment is
+	/// `SHAKE256("resharing-commit-v2" || old_subset || new_subset || pack(r))`.
+	pub commitments: BTreeMap<SubsetPair, [u8; COMMITMENT_HASH_SIZE]>,
 }
 
-/// A blinded polynomial vector contribution.
-///
-/// Contains the sum of a party's recovered share and their random blinding value.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct BlindedContribution {
-	/// Polynomial coefficients (L or K polynomials, each with N coefficients).
-	#[cfg_attr(feature = "serde", serde(with = "serde_poly_vec"))]
-	pub coefficients: Vec<[i32; N]>,
-}
-
-impl BlindedContribution {
-	/// Create a new blinded contribution with the given number of polynomials.
-	pub fn new(num_polynomials: usize) -> Self {
-		Self { coefficients: vec![[0i32; N]; num_polynomials] }
-	}
-
-	/// Create a blinded contribution for s1 (L polynomials).
-	pub fn new_s1() -> Self {
-		Self::new(L)
-	}
-
-	/// Create a blinded contribution for s2 (K polynomials).
-	pub fn new_s2() -> Self {
-		Self::new(K)
-	}
-}
+/// Composite key identifying a contribution from one old subset to one new subset.
+pub type SubsetPair = (SubsetMask, SubsetMask);
 
 // ============================================================================
-// Round 2: New Share Distribution
+// Round 2: Private Sub-Share Reveal
 // ============================================================================
 
-/// Round 2 message containing new shares for a specific party.
+/// Round 2 private message from a designated dealer to a new committee member.
 ///
-/// This is a private message from the dealing parties to new committee members.
-/// Each new party receives their subset shares from the dealers.
+/// For each pair `(I, J)` where the sender is the designated dealer of old subset
+/// `I` and the recipient is a member of new subset `J`, the message carries the
+/// deterministic sub-share `r_{I→J}` such that `Σ_J r_{I→J} = s_I^old`.
+///
+/// New shares are then computed (privately, by each new committee member) as
+/// `s_J^new = Σ_I r_{I→J}`.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResharingRound2Message {
@@ -400,8 +376,8 @@ pub struct ResharingRound2Message {
 	pub from_party_id: ParticipantId,
 	/// Party ID of the recipient.
 	pub to_party_id: ParticipantId,
-	/// The new shares for the recipient, keyed by subset mask.
-	pub shares: BTreeMap<SubsetMask, NewShareData>,
+	/// Per-`(old_subset, new_subset)` contributions destined for the recipient.
+	pub contributions: BTreeMap<SubsetPair, NewShareData>,
 }
 
 /// New share data for a specific subset.
@@ -433,21 +409,50 @@ impl Default for NewShareData {
 // Round 3: Verification
 // ============================================================================
 
-/// Round 3 broadcast for share verification.
+/// Round 3 broadcast.
 ///
-/// Each new committee member broadcasts commitments to their received shares
-/// so that consistency can be verified.
+/// Round 3 has two purposes:
+///
+/// 1. **New committee verification.** Each new committee member broadcasts a
+///    commitment to each `s_J^new` they computed for new subsets `J` containing
+///    them. Other members of the same `J` should produce identical commitments;
+///    any mismatch indicates inconsistent dealing (e.g., a malicious dealer
+///    who sent different `r_{I→J}` to different recipients).
+///
+/// 2. **Old committee cross-verification.** Old committee members that share an
+///    old subset `I` with the dealer `D_I` independently recompute the
+///    deterministic `r_{I→J}` values from their own copy of `s_I^old` and
+///    compare them against `D_I`'s broadcast commitments. Any mismatch is
+///    reported as a `DealerAccusation`. If the accusation is correct (the
+///    accuser's recomputation matches their own private knowledge of `s_I`),
+///    the resharing fails.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResharingRound3Broadcast {
 	/// Party ID of the sender.
 	pub party_id: ParticipantId,
-	/// Commitments to each subset share, keyed by subset mask.
+	/// Commitments to each computed new subset share (only populated by new committee members).
 	pub share_commitments: BTreeMap<SubsetMask, [u8; COMMITMENT_HASH_SIZE]>,
-	/// Indicates success or failure of share reception.
+	/// Accusations against dealers whose broadcast commitments did not match
+	/// the sender's independent recomputation.
+	pub accusations: Vec<DealerAccusation>,
+	/// Indicates whether this party processed Round 1/2 successfully.
 	pub success: bool,
-	/// Optional error message if success is false.
+	/// Optional error message if `success` is false.
 	pub error_message: Option<String>,
+}
+
+/// An accusation that a dealer published a commitment that does not match
+/// the independent recomputation by another member of the same old subset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DealerAccusation {
+	/// The party being accused (the broadcaster of the bad commitment).
+	pub dealer: ParticipantId,
+	/// The old subset for which the dealer's commitment was wrong.
+	pub old_subset: SubsetMask,
+	/// The new subset whose `r_{I→J}` commitment was wrong.
+	pub new_subset: SubsetMask,
 }
 
 // ============================================================================
@@ -575,25 +580,10 @@ mod tests {
 	}
 
 	#[test]
-	fn test_blinded_contribution_sizes() {
-		let s1 = BlindedContribution::new_s1();
-		assert_eq!(s1.coefficients.len(), L);
-		assert_eq!(s1.coefficients[0].len(), N);
-
-		let s2 = BlindedContribution::new_s2();
-		assert_eq!(s2.coefficients.len(), K);
-		assert_eq!(s2.coefficients[0].len(), N);
-	}
-
-	#[test]
 	fn test_message_round_numbers() {
 		let r1 = ResharingMessage::Round1(ResharingRound1Broadcast {
 			party_id: 0,
-			blinded_s1_contribution: BlindedContribution::new_s1(),
-			blinded_s2_contribution: BlindedContribution::new_s2(),
-			blinding_s1: BlindedContribution::new_s1(),
-			blinding_s2: BlindedContribution::new_s2(),
-			blinding_commitment: [0u8; COMMITMENT_HASH_SIZE],
+			commitments: BTreeMap::new(),
 		});
 		assert_eq!(r1.round(), 1);
 		assert_eq!(r1.party_id(), 0);
@@ -601,7 +591,7 @@ mod tests {
 		let r2 = ResharingMessage::Round2(ResharingRound2Message {
 			from_party_id: 1,
 			to_party_id: 2,
-			shares: BTreeMap::new(),
+			contributions: BTreeMap::new(),
 		});
 		assert_eq!(r2.round(), 2);
 		assert_eq!(r2.party_id(), 1);
@@ -609,6 +599,7 @@ mod tests {
 		let r3 = ResharingMessage::Round3(ResharingRound3Broadcast {
 			party_id: 2,
 			share_commitments: BTreeMap::new(),
+			accusations: Vec::new(),
 			success: true,
 			error_message: None,
 		});
@@ -723,22 +714,6 @@ mod tests {
 	}
 
 	#[test]
-	fn test_blinded_contribution_new() {
-		// Test creating contributions of various sizes
-		for size in 1..10 {
-			let contrib = BlindedContribution::new(size);
-			assert_eq!(contrib.coefficients.len(), size);
-			for poly in &contrib.coefficients {
-				assert_eq!(poly.len(), N);
-				// All coefficients should be initialized to zero
-				for &coeff in poly {
-					assert_eq!(coeff, 0);
-				}
-			}
-		}
-	}
-
-	#[test]
 	fn test_new_share_data_initialization() {
 		let share = NewShareData::new();
 
@@ -785,29 +760,23 @@ mod tests {
 
 	#[test]
 	fn test_resharing_message_party_id_extraction() {
-		// Test Round1
 		let r1 = ResharingMessage::Round1(ResharingRound1Broadcast {
 			party_id: 42,
-			blinded_s1_contribution: BlindedContribution::new_s1(),
-			blinded_s2_contribution: BlindedContribution::new_s2(),
-			blinding_s1: BlindedContribution::new_s1(),
-			blinding_s2: BlindedContribution::new_s2(),
-			blinding_commitment: [0u8; COMMITMENT_HASH_SIZE],
+			commitments: BTreeMap::new(),
 		});
 		assert_eq!(r1.party_id(), 42);
 
-		// Test Round2
 		let r2 = ResharingMessage::Round2(ResharingRound2Message {
 			from_party_id: 99,
 			to_party_id: 100,
-			shares: BTreeMap::new(),
+			contributions: BTreeMap::new(),
 		});
-		assert_eq!(r2.party_id(), 99); // Should return from_party_id
+		assert_eq!(r2.party_id(), 99);
 
-		// Test Round3
 		let r3 = ResharingMessage::Round3(ResharingRound3Broadcast {
 			party_id: 77,
 			share_commitments: BTreeMap::new(),
+			accusations: Vec::new(),
 			success: true,
 			error_message: None,
 		});
@@ -816,20 +785,20 @@ mod tests {
 
 	#[test]
 	fn test_resharing_round3_broadcast_error_handling() {
-		// Test successful broadcast
 		let success = ResharingRound3Broadcast {
 			party_id: 0,
 			share_commitments: BTreeMap::new(),
+			accusations: Vec::new(),
 			success: true,
 			error_message: None,
 		};
 		assert!(success.success);
 		assert!(success.error_message.is_none());
 
-		// Test failed broadcast with error message
 		let failure = ResharingRound3Broadcast {
 			party_id: 1,
 			share_commitments: BTreeMap::new(),
+			accusations: Vec::new(),
 			success: false,
 			error_message: Some("Share verification failed".to_string()),
 		};

--- a/threshold/src/serde_helpers.rs
+++ b/threshold/src/serde_helpers.rs
@@ -93,9 +93,7 @@ pub mod serde_partial_pks {
 		entries.serialize(serializer)
 	}
 
-	pub fn deserialize<'de, D>(
-		deserializer: D,
-	) -> Result<BTreeMap<u16, Vec<[i32; 256]>>, D::Error>
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<BTreeMap<u16, Vec<[i32; 256]>>, D::Error>
 	where
 		D: Deserializer<'de>,
 	{

--- a/threshold/src/serde_helpers.rs
+++ b/threshold/src/serde_helpers.rs
@@ -73,6 +73,56 @@ pub mod serde_poly_vec {
 	}
 }
 
+/// Serde support for `BTreeMap<u16, Vec<[i32; 256]>>` (partial-PK polynomial vectors).
+#[cfg(feature = "serde")]
+pub mod serde_partial_pks {
+	use super::*;
+	use std::collections::BTreeMap;
+
+	pub fn serialize<S>(
+		map: &BTreeMap<u16, Vec<[i32; 256]>>,
+		serializer: S,
+	) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let entries: Vec<(u16, Vec<Vec<i32>>)> = map
+			.iter()
+			.map(|(k, polys)| (*k, polys.iter().map(|arr| arr.to_vec()).collect()))
+			.collect();
+		entries.serialize(serializer)
+	}
+
+	pub fn deserialize<'de, D>(
+		deserializer: D,
+	) -> Result<BTreeMap<u16, Vec<[i32; 256]>>, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let entries: Vec<(u16, Vec<Vec<i32>>)> = Vec::deserialize(deserializer)?;
+		entries
+			.into_iter()
+			.map(|(k, polys)| {
+				let arrs: Result<Vec<[i32; 256]>, D::Error> = polys
+					.into_iter()
+					.map(|v| {
+						if v.len() != 256 {
+							return Err(serde::de::Error::custom(format!(
+								"expected 256 coefficients, got {}",
+								v.len()
+							)));
+						}
+						let mut arr = [0i32; 256];
+						arr.copy_from_slice(&v);
+						Ok(arr)
+					})
+					.collect();
+				arrs.map(|arrs| (k, arrs))
+			})
+			.collect()
+	}
+}
+
 /// Serde support for `BTreeMap<u16, T>` where T is serializable.
 /// BTreeMap provides deterministic iteration order (sorted by key),
 /// ensuring consistent serialization output.

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -72,11 +72,7 @@ fn run_resharing_protocol_with_tamper(
 		)
 		.map_err(|e| format!("Config error for party {}: {}", party_id, e))?;
 
-		// Each party gets a unique seed derived from the base seed
-		let mut party_seed = seed;
-		party_seed[0] ^= party_id as u8;
-
-		let protocol = ResharingProtocol::new(config, party_seed);
+		let protocol = ResharingProtocol::new(config);
 		protocols.insert(party_id, protocol);
 	}
 
@@ -401,7 +397,7 @@ fn test_resharing_protocol_creation() {
 	)
 	.expect("valid config");
 
-	let protocol = ResharingProtocol::new(resharing_config, [0u8; 32]);
+	let protocol = ResharingProtocol::new(resharing_config);
 	assert_eq!(*protocol.state(), ResharingState::Round1Generate);
 }
 
@@ -422,7 +418,7 @@ fn test_resharing_protocol_round1_generation() {
 	)
 	.expect("valid config");
 
-	let mut protocol = ResharingProtocol::new(resharing_config, [0u8; 32]);
+	let mut protocol = ResharingProtocol::new(resharing_config);
 
 	// First poke should generate Round 1 message
 	let action = protocol.poke().expect("poke should succeed");
@@ -459,7 +455,7 @@ fn test_resharing_new_party_skips_round1() {
 		ResharingConfig::new(2, vec![0, 1, 2], 2, vec![0, 1, 3], 3, None, public_key)
 			.expect("valid config");
 
-	let mut protocol = ResharingProtocol::new(resharing_config, [0u8; 32]);
+	let mut protocol = ResharingProtocol::new(resharing_config);
 
 	// New party should skip Round 1 and wait for Round 2
 	let action = protocol.poke().expect("poke should succeed");
@@ -763,7 +759,7 @@ fn test_resharing_round1_message_from_non_member_ignored() {
 	)
 	.expect("valid config");
 
-	let mut protocol = ResharingProtocol::new(resharing_config, [0u8; 32]);
+	let mut protocol = ResharingProtocol::new(resharing_config);
 
 	// Generate Round 1 message
 	let _ = protocol.poke().expect("poke should succeed");
@@ -809,8 +805,8 @@ fn test_resharing_duplicate_message_ignored() {
 	)
 	.expect("valid config");
 
-	let mut protocol0 = ResharingProtocol::new(config0, [0u8; 32]);
-	let mut protocol1 = ResharingProtocol::new(config1, [1u8; 32]);
+	let mut protocol0 = ResharingProtocol::new(config0);
+	let mut protocol1 = ResharingProtocol::new(config1);
 
 	// Generate Round 1 messages
 	let msg0 = match protocol0.poke().expect("poke should succeed") {
@@ -874,7 +870,7 @@ fn test_old_only_party_behavior() {
 	)
 	.expect("valid config");
 
-	let mut protocol = ResharingProtocol::new(resharing_config, [0u8; 32]);
+	let mut protocol = ResharingProtocol::new(resharing_config);
 
 	// Party should participate in Round 1
 	let action = protocol.poke().expect("poke should succeed");
@@ -904,7 +900,7 @@ fn test_new_only_party_behavior() {
 	)
 	.expect("valid config");
 
-	let mut protocol = ResharingProtocol::new(resharing_config, [0u8; 32]);
+	let mut protocol = ResharingProtocol::new(resharing_config);
 
 	// New party should skip Round 1 and wait for Round 2
 	let action = protocol.poke().expect("poke should succeed");

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -1214,8 +1214,7 @@ fn test_resharing_detects_consistent_dealer_tamper_at_t_equals_n() {
 		old_shares.insert(share.party_id(), share.clone());
 	}
 
-	let bogus_r =
-		NewShareData { s1: vec![[42i32; N]; L], s2: vec![[7i32; N]; K] };
+	let bogus_r = NewShareData { s1: vec![[42i32; N]; L], s2: vec![[7i32; N]; K] };
 	let target_pair = (0b01u16, 0b10u16);
 	let bogus_commit = forge_consistent_commitment(target_pair.0, target_pair.1, &bogus_r);
 

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -11,7 +11,7 @@ use qp_rusty_crystals_threshold::{
 };
 
 use qp_rusty_crystals_threshold::resharing::{
-	Action, ResharingConfig, ResharingMessage, ResharingProtocol, ResharingState,
+	Action, NewShareData, ResharingConfig, ResharingMessage, ResharingProtocol, ResharingState,
 };
 
 /// Helper to run the resharing protocol locally with simulated message passing.
@@ -23,6 +23,31 @@ fn run_resharing_protocol(
 	old_shares: &HashMap<u32, PrivateKeyShare>,
 	public_key: &PublicKey,
 	seed: [u8; 32],
+) -> Result<HashMap<u32, PrivateKeyShare>, String> {
+	run_resharing_protocol_with_tamper(
+		old_threshold,
+		old_participants,
+		new_threshold,
+		new_participants,
+		old_shares,
+		public_key,
+		seed,
+		None,
+	)
+}
+
+/// Optional message tamper hook: `tamper(sender, recipient, raw_bytes) -> raw_bytes`.
+type TamperFn = Box<dyn FnMut(u32, Option<u32>, Vec<u8>) -> Vec<u8>>;
+
+fn run_resharing_protocol_with_tamper(
+	old_threshold: u32,
+	old_participants: Vec<u32>,
+	new_threshold: u32,
+	new_participants: Vec<u32>,
+	old_shares: &HashMap<u32, PrivateKeyShare>,
+	public_key: &PublicKey,
+	seed: [u8; 32],
+	mut tamper: Option<TamperFn>,
 ) -> Result<HashMap<u32, PrivateKeyShare>, String> {
 	// Determine all parties involved (union of old and new)
 	let mut all_parties: Vec<u32> =
@@ -101,19 +126,34 @@ fn run_resharing_protocol(
 					// Nothing to do
 				},
 				Ok(Action::SendMany(data)) => {
-					// Broadcast to all other parties
+					let payload = match tamper.as_mut() {
+						Some(f) => f(party_id, None, data),
+						None => data,
+					};
 					for &other_id in &all_parties {
 						if other_id != party_id {
 							message_queues
 								.get_mut(&other_id)
 								.unwrap()
-								.push((party_id, data.clone()));
+								.push((party_id, payload.clone()));
 						}
 					}
 				},
 				Ok(Action::SendPrivate(to, data)) => {
-					// Send to specific party
-					message_queues.get_mut(&to).unwrap().push((party_id, data));
+					// Send to specific party. We deliberately do NOT loop self-private
+					// messages back: the protocol must handle self-deals locally and
+					// never emit SendPrivate(self, _).
+					assert_ne!(
+						to, party_id,
+						"protocol emitted SendPrivate to self (party {}), \
+						 self-deals must be handled locally",
+						party_id
+					);
+					let payload = match tamper.as_mut() {
+						Some(f) => f(party_id, Some(to), data),
+						None => data,
+					};
+					message_queues.get_mut(&to).unwrap().push((party_id, payload));
 				},
 				Ok(Action::Return(_)) => {
 					// Protocol complete for this party
@@ -1060,4 +1100,169 @@ fn test_resharing_end_to_end_replace_party() {
 		run_signing_and_verify(&signing_shares, &public_key, config, b"test message", b"");
 
 	assert!(is_valid, "Signature with new shares should verify");
+}
+
+#[test]
+fn test_resharing_end_to_end_disjoint_committees() {
+	// Test full committee handoff with NO overlap: (2,3) with {0,1,2} -> (2,3) with {3,4,5}.
+	// Verifies that completely-new parties (no existing shares) can derive working
+	// shares solely from old-committee dealing, and that signatures using ONLY new
+	// parties verify against the original public key.
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [7u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let result = run_resharing_protocol(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![3, 4, 5],
+		&old_shares,
+		&public_key,
+		[123u8; 32],
+	);
+
+	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
+	let new_shares = result.unwrap();
+
+	assert_eq!(new_shares.len(), 3);
+	assert!(new_shares.contains_key(&3));
+	assert!(new_shares.contains_key(&4));
+	assert!(new_shares.contains_key(&5));
+	assert!(!new_shares.contains_key(&0));
+	assert!(!new_shares.contains_key(&1));
+	assert!(!new_shares.contains_key(&2));
+
+	// Sign with two of the brand-new parties; verify against original PK.
+	let signing_shares: Vec<_> =
+		vec![new_shares.get(&3).unwrap().clone(), new_shares.get(&4).unwrap().clone()];
+	let is_valid =
+		run_signing_and_verify(&signing_shares, &public_key, config, b"disjoint committee", b"");
+	assert!(is_valid, "Signature from disjoint new committee should verify");
+
+	// Also try a different threshold subset to confirm any t parties can sign.
+	let signing_shares_alt: Vec<_> =
+		vec![new_shares.get(&4).unwrap().clone(), new_shares.get(&5).unwrap().clone()];
+	let is_valid_alt = run_signing_and_verify(
+		&signing_shares_alt,
+		&public_key,
+		config,
+		b"disjoint committee alt",
+		b"",
+	);
+	assert!(is_valid_alt, "Alternate threshold subset should also produce valid signatures");
+}
+
+/// Recompute the SHAKE256 commitment over `(i_mask, j_mask, r)` exactly the way the
+/// dealer does internally. Used by the malicious-dealer test below to forge a
+/// commitment that is *consistent* with a tampered `r` so the recipient's
+/// commitment-vs-r check passes — making the attack only catchable via the
+/// public-key invariant (M2).
+fn forge_consistent_commitment(i_mask: u16, j_mask: u16, r: &NewShareData) -> [u8; 32] {
+	use qp_rusty_crystals_dilithium::fips202;
+	const COMMIT_DOMAIN: &[u8] = b"resharing-commit-v2";
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, COMMIT_DOMAIN, COMMIT_DOMAIN.len());
+	fips202::shake256_absorb(&mut state, &i_mask.to_le_bytes(), 2);
+	fips202::shake256_absorb(&mut state, &j_mask.to_le_bytes(), 2);
+	let mut buf: Vec<u8> = Vec::new();
+	for poly in &r.s1 {
+		buf.clear();
+		for c in poly {
+			buf.extend_from_slice(&c.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+	for poly in &r.s2 {
+		buf.clear();
+		for c in poly {
+			buf.extend_from_slice(&c.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, &buf, buf.len());
+	}
+	fips202::shake256_finalize(&mut state);
+	let mut out = [0u8; 32];
+	fips202::shake256_squeeze(&mut out, 32, &mut state);
+	out
+}
+
+#[test]
+fn test_resharing_detects_consistent_dealer_tamper_at_t_equals_n() {
+	// In a (2,2) -> (2,2) resharing every old subset has size 1, so the dealer is
+	// the sole member of their old subset and `collect_accusations` cannot catch a
+	// dealer that lies about their residual `r`. To prove that lying about `r` is
+	// nonetheless caught, we tamper *both* the Round 1 commitment and the Round 2
+	// payload so that they remain mutually consistent (passing the recipient's
+	// commit-vs-r check). The resulting `s_J^new` for the recipient is corrupted,
+	// the partial public-key sum no longer reconstructs the original public key,
+	// and `verify_public_key_preservation` fails.
+	const N: usize = 256;
+	const L: usize = 7;
+	const K: usize = 8;
+
+	let config = ThresholdConfig::new(2, 2).expect("valid config");
+	let seed = [11u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let bogus_r =
+		NewShareData { s1: vec![[42i32; N]; L], s2: vec![[7i32; N]; K] };
+	let target_pair = (0b01u16, 0b10u16);
+	let bogus_commit = forge_consistent_commitment(target_pair.0, target_pair.1, &bogus_r);
+
+	let bogus_r_capt = bogus_r.clone();
+	let tamper: TamperFn = Box::new(move |sender, _recipient, data| {
+		if sender != 0 {
+			return data;
+		}
+		let msg: ResharingMessage = match bincode::deserialize(&data) {
+			Ok(m) => m,
+			Err(_) => return data,
+		};
+		let modified = match msg {
+			ResharingMessage::Round1(mut b) =>
+				if let Some(c) = b.commitments.get_mut(&target_pair) {
+					*c = bogus_commit;
+					ResharingMessage::Round1(b)
+				} else {
+					ResharingMessage::Round1(b)
+				},
+			ResharingMessage::Round2(mut m) =>
+				if m.from_party_id == 0 && m.contributions.contains_key(&target_pair) {
+					m.contributions.insert(target_pair, bogus_r_capt.clone());
+					ResharingMessage::Round2(m)
+				} else {
+					ResharingMessage::Round2(m)
+				},
+			other => other,
+		};
+		bincode::serialize(&modified).expect("re-serialize tampered msg")
+	});
+
+	let result = run_resharing_protocol_with_tamper(
+		2,
+		vec![0, 1],
+		2,
+		vec![0, 1],
+		&old_shares,
+		&public_key,
+		[99u8; 32],
+		Some(tamper),
+	);
+
+	let err = result.expect_err("malicious dealer must be detected");
+	assert!(
+		err.contains("public key") || err.contains("ShareVerificationFailed"),
+		"expected public-key invariant failure, got: {}",
+		err
+	);
 }

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -22,7 +22,6 @@ fn run_resharing_protocol(
 	new_participants: Vec<u32>,
 	old_shares: &HashMap<u32, PrivateKeyShare>,
 	public_key: &PublicKey,
-	seed: [u8; 32],
 ) -> Result<HashMap<u32, PrivateKeyShare>, String> {
 	run_resharing_protocol_with_tamper(
 		old_threshold,
@@ -31,7 +30,6 @@ fn run_resharing_protocol(
 		new_participants,
 		old_shares,
 		public_key,
-		seed,
 		None,
 	)
 }
@@ -46,7 +44,6 @@ fn run_resharing_protocol_with_tamper(
 	new_participants: Vec<u32>,
 	old_shares: &HashMap<u32, PrivateKeyShare>,
 	public_key: &PublicKey,
-	seed: [u8; 32],
 	mut tamper: Option<TamperFn>,
 ) -> Result<HashMap<u32, PrivateKeyShare>, String> {
 	// Determine all parties involved (union of old and new)
@@ -944,7 +941,6 @@ fn test_resharing_end_to_end_same_committee() {
 		vec![0, 1, 2],
 		&old_shares,
 		&public_key,
-		[99u8; 32],
 	);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
@@ -986,7 +982,6 @@ fn test_resharing_end_to_end_add_party() {
 		vec![0, 1, 2, 3],
 		&old_shares,
 		&public_key,
-		[99u8; 32],
 	);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
@@ -1031,7 +1026,6 @@ fn test_resharing_end_to_end_remove_party() {
 		vec![0, 1],
 		&old_shares,
 		&public_key,
-		[99u8; 32],
 	);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
@@ -1075,7 +1069,6 @@ fn test_resharing_end_to_end_replace_party() {
 		vec![0, 1, 3],
 		&old_shares,
 		&public_key,
-		[99u8; 32],
 	);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
@@ -1120,7 +1113,6 @@ fn test_resharing_end_to_end_disjoint_committees() {
 		vec![3, 4, 5],
 		&old_shares,
 		&public_key,
-		[123u8; 32],
 	);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
@@ -1188,6 +1180,128 @@ fn forge_consistent_commitment(i_mask: u16, j_mask: u16, r: &NewShareData) -> [u
 }
 
 #[test]
+fn test_resharing_detects_dealer_accusation_when_commitment_tampered() {
+	// In a (2,3) resharing, old subsets have size 2 (n - t + 1 = 3 - 2 + 1 = 2).
+	// Each old subset has a designated dealer and another verifier. If the dealer
+	// broadcasts a bad commitment, the verifier will detect it in `collect_accusations`.
+
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [77u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	// Tamper only the Round 1 commitment (not the Round 2 payload). The recipient
+	// will accept the sub-share (commitment mismatch with our tampered value), but
+	// another member of the same old subset will independently recompute the
+	// *correct* commitment and file an accusation.
+	let target_pair = (0b011u16, 0b011u16); // old subset {0,1}, new subset {0,1}
+	let bad_commit = [0xAAu8; 32];
+
+	let tamper: TamperFn = Box::new(move |sender, _recipient, data| {
+		if sender != 0 {
+			return data;
+		}
+		let msg: ResharingMessage = match bincode::deserialize(&data) {
+			Ok(m) => m,
+			Err(_) => return data,
+		};
+		let modified = match msg {
+			ResharingMessage::Round1(mut b) => {
+				if let Some(c) = b.commitments.get_mut(&target_pair) {
+					*c = bad_commit;
+				}
+				ResharingMessage::Round1(b)
+			},
+			other => other,
+		};
+		bincode::serialize(&modified).expect("re-serialize tampered msg")
+	});
+
+	let result = run_resharing_protocol_with_tamper(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![0, 1, 2],
+		&old_shares,
+		&public_key,
+		Some(tamper),
+	);
+
+	let err = result.expect_err("tampered commitment must be detected via accusation");
+	// The protocol detects dealer misbehavior - either via accusation or party failure
+	assert!(
+		err.contains("accused") || err.contains("misbehavior") || err.contains("Party failure") || err.contains("PartyFailure"),
+		"expected dealer accusation or party failure, got: {}",
+		err
+	);
+}
+
+#[test]
+fn test_resharing_detects_round2_payload_mismatch() {
+	// Tamper only the Round 2 payload (not the commitment). The recipient will
+	// detect that the received `r` doesn't match the broadcast commitment and
+	// fail with ShareVerificationFailed.
+	const N: usize = 256;
+	const L: usize = 7;
+	const K: usize = 8;
+
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [55u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let target_pair = (0b011u16, 0b011u16);
+	let bogus_r = NewShareData { s1: vec![[99i32; N]; L], s2: vec![[13i32; N]; K] };
+
+	let bogus_r_capt = bogus_r.clone();
+	let tamper: TamperFn = Box::new(move |sender, _recipient, data| {
+		if sender != 0 {
+			return data;
+		}
+		let msg: ResharingMessage = match bincode::deserialize(&data) {
+			Ok(m) => m,
+			Err(_) => return data,
+		};
+		let modified = match msg {
+			ResharingMessage::Round2(mut m) => {
+				if m.from_party_id == 0 && m.contributions.contains_key(&target_pair) {
+					m.contributions.insert(target_pair, bogus_r_capt.clone());
+				}
+				ResharingMessage::Round2(m)
+			},
+			other => other,
+		};
+		bincode::serialize(&modified).expect("re-serialize tampered msg")
+	});
+
+	let result = run_resharing_protocol_with_tamper(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![0, 1, 2],
+		&old_shares,
+		&public_key,
+		Some(tamper),
+	);
+
+	let err = result.expect_err("tampered Round 2 payload must be detected");
+	// The protocol detects the mismatch - either via commitment check or party failure
+	assert!(
+		err.contains("commitment") || err.contains("ShareVerificationFailed") || err.contains("Party failure"),
+		"expected commitment mismatch or party failure, got: {}",
+		err
+	);
+}
+
+#[test]
 fn test_resharing_detects_consistent_dealer_tamper_at_t_equals_n() {
 	// In a (2,2) -> (2,2) resharing every old subset has size 1, so the dealer is
 	// the sole member of their old subset and `collect_accusations` cannot catch a
@@ -1250,7 +1364,6 @@ fn test_resharing_detects_consistent_dealer_tamper_at_t_equals_n() {
 		vec![0, 1],
 		&old_shares,
 		&public_key,
-		[99u8; 32],
 		Some(tamper),
 	);
 

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -934,14 +934,8 @@ fn test_resharing_end_to_end_same_committee() {
 	}
 
 	// Run resharing to the same committee
-	let result = run_resharing_protocol(
-		2,
-		vec![0, 1, 2],
-		2,
-		vec![0, 1, 2],
-		&old_shares,
-		&public_key,
-	);
+	let result =
+		run_resharing_protocol(2, vec![0, 1, 2], 2, vec![0, 1, 2], &old_shares, &public_key);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
 	let new_shares = result.unwrap();
@@ -975,14 +969,8 @@ fn test_resharing_end_to_end_add_party() {
 	}
 
 	// Run resharing to add party 3
-	let result = run_resharing_protocol(
-		2,
-		vec![0, 1, 2],
-		2,
-		vec![0, 1, 2, 3],
-		&old_shares,
-		&public_key,
-	);
+	let result =
+		run_resharing_protocol(2, vec![0, 1, 2], 2, vec![0, 1, 2, 3], &old_shares, &public_key);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
 	let new_shares = result.unwrap();
@@ -1019,14 +1007,7 @@ fn test_resharing_end_to_end_remove_party() {
 	}
 
 	// Run resharing to remove party 2
-	let result = run_resharing_protocol(
-		2,
-		vec![0, 1, 2],
-		2,
-		vec![0, 1],
-		&old_shares,
-		&public_key,
-	);
+	let result = run_resharing_protocol(2, vec![0, 1, 2], 2, vec![0, 1], &old_shares, &public_key);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
 	let new_shares = result.unwrap();
@@ -1062,14 +1043,8 @@ fn test_resharing_end_to_end_replace_party() {
 	}
 
 	// Run resharing to replace party 2 with party 3
-	let result = run_resharing_protocol(
-		2,
-		vec![0, 1, 2],
-		2,
-		vec![0, 1, 3],
-		&old_shares,
-		&public_key,
-	);
+	let result =
+		run_resharing_protocol(2, vec![0, 1, 2], 2, vec![0, 1, 3], &old_shares, &public_key);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
 	let new_shares = result.unwrap();
@@ -1106,14 +1081,8 @@ fn test_resharing_end_to_end_disjoint_committees() {
 		old_shares.insert(share.party_id(), share.clone());
 	}
 
-	let result = run_resharing_protocol(
-		2,
-		vec![0, 1, 2],
-		2,
-		vec![3, 4, 5],
-		&old_shares,
-		&public_key,
-	);
+	let result =
+		run_resharing_protocol(2, vec![0, 1, 2], 2, vec![3, 4, 5], &old_shares, &public_key);
 
 	assert!(result.is_ok(), "Resharing failed: {:?}", result.err());
 	let new_shares = result.unwrap();
@@ -1234,7 +1203,10 @@ fn test_resharing_detects_dealer_accusation_when_commitment_tampered() {
 	let err = result.expect_err("tampered commitment must be detected via accusation");
 	// The protocol detects dealer misbehavior - either via accusation or party failure
 	assert!(
-		err.contains("accused") || err.contains("misbehavior") || err.contains("Party failure") || err.contains("PartyFailure"),
+		err.contains("accused") ||
+			err.contains("misbehavior") ||
+			err.contains("Party failure") ||
+			err.contains("PartyFailure"),
 		"expected dealer accusation or party failure, got: {}",
 		err
 	);
@@ -1295,7 +1267,9 @@ fn test_resharing_detects_round2_payload_mismatch() {
 	let err = result.expect_err("tampered Round 2 payload must be detected");
 	// The protocol detects the mismatch - either via commitment check or party failure
 	assert!(
-		err.contains("commitment") || err.contains("ShareVerificationFailed") || err.contains("Party failure"),
+		err.contains("commitment") ||
+			err.contains("ShareVerificationFailed") ||
+			err.contains("Party failure"),
 		"expected commitment mismatch or party failure, got: {}",
 		err
 	);


### PR DESCRIPTION
Fixes on top of https://github.com/Quantus-Network/qp-rusty-crystals/pull/74 

All done! Here's the summary of what was fixed.

## Summary

**Test results — all green:**
- 128 lib tests · 26 resharing tests · 9 derivation tests · 16 signer-state tests · 19 integration tests = **198 passing, 0 failing**

### C3 — derived keys no longer publicly recoverable

In `threshold/src/derivation.rs`:
- `derive_dkg_contribution` now hashes the actual secret share polynomials (`s1`, `s2`) instead of the `key` field (which the DKG path derived from the public `rho || party_id` and was therefore publicly recoverable). Domain separator bumped to `v2`.
- Added `hash_secret_shares` helper that canonically serializes every `(subset_mask, s1, s2)` triple from the share's `BTreeMap`.
- Added `test_contribution_independent_of_legacy_key_field` — two shares that differ only in the publicly-derivable `key` byte string must now produce the same contribution.

In `threshold/src/keygen/dkg/protocol.rs` and `threshold/src/resharing/protocol.rs`:
- The `party_key` field is now derived from real entropy (the actual share polynomials) rather than a hash of public values. This is hygiene; derivation no longer depends on it.

### C1 + C2 — resharing redesigned around per-subset distributed re-sharing

**The core insight:** for each old RSS subset `I`, the lowest-ID member `D_I` deterministically derives sub-shares `r_{I→J}` for every new subset `J` such that `Σ_J r_{I→J} = s_I^old`. New shares are then `s_J^new = Σ_I r_{I→J}`, which preserves `Σ_J s_J^new = s` without anyone ever holding `s` in clear.

In `threshold/src/resharing/types.rs`:
- Removed `BlindedContribution`, `blinded_s1_contribution`, `blinded_s2_contribution`, `blinding_s1`, `blinding_s2`, `blinding_commitment` from `ResharingRound1Broadcast` (these were the C1 leak — broadcasting both blinded share and the blinding value lets anyone subtract).
- `ResharingRound1Broadcast` now carries only `commitments: BTreeMap<SubsetPair, [u8;32]>` (hash commitments, no plaintext).
- `ResharingRound2Message` now carries `contributions: BTreeMap<SubsetPair, NewShareData>` keyed by `(old_subset, new_subset)` for private peer-to-peer delivery.
- `ResharingRound3Broadcast` gained an `accusations: Vec<DealerAccusation>` field for cross-verification.

In `threshold/src/resharing/protocol.rs` (full rewrite):
- Round 1: each old participant who is the designated dealer for any subset broadcasts hash commitments.
- Round 2: each dealer privately delivers the sub-shares each recipient needs.
- Round 3: new-committee parties verify received sub-shares against commitments, sum them into `s_J^new`, and commit; old-committee parties independently recompute and accuse misbehaving dealers.
- `derive_subshares` PRF-derives sub-shares from `SHAKE256(s1_I || s2_I)`, with the residual sub-share absorbing the sum constraint. **No party ever computes `s = Σ_I s_I^old`** — the C2 single-point-of-compromise is gone.
- Subtle bug caught during testing: `old_subset_order` had to be a *canonical* enumeration (same for every party), not derived from each party's individual share keys — otherwise dealers and verifiers compute different `residual_idx` values and accusations explode.

In `threshold/src/resharing/{mod.rs, README.md}`:
- Updated documentation to describe the new protocol accurately and dropped the (false) "Secret never exposed" claim of the old design.

### What's next
The remaining findings from the original review (H1–H5, M1–M5, L1–L3) are still untouched — happy to tackle any of them whenever you're ready. The most impactful next ones are probably H1 (silent zero-fill in `unpack_responses`) and H2 (silent fallback in `recover_share` for `t=n`).