### PR TITLE
Replace manual zeroize impls with derives - on top of threshold-2 PR

### DIFF
--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -1,11 +1,11 @@
 use crate::{fips202, ntt, params, reduce, rounding};
-use zeroize::ZeroizeOnDrop;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 const N: usize = params::N as usize;
 const UNIFORM_NBLOCKS: usize = (767 + fips202::SHAKE128_RATE) / fips202::SHAKE128_RATE;
 const D_SHL: i32 = 1 << (params::D - 1);
 
 /// Represents a polynomial
-#[derive(Clone, ZeroizeOnDrop)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct Poly {
 	pub coeffs: [i32; N],
 }

--- a/dilithium/src/polyvec.rs
+++ b/dilithium/src/polyvec.rs
@@ -1,11 +1,11 @@
 use crate::{params, poly, poly::Poly};
 use core::{array, mem::swap};
-use zeroize::ZeroizeOnDrop;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const K: usize = params::K;
 const L: usize = params::L;
 
-#[derive(Clone, ZeroizeOnDrop)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct Polyveck {
 	pub vec: [Poly; K],
 }
@@ -16,7 +16,7 @@ impl Default for Polyveck {
 	}
 }
 
-#[derive(Clone, ZeroizeOnDrop)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct Polyvecl {
 	pub vec: [Poly; L],
 }

--- a/threshold/Cargo.toml
+++ b/threshold/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography"]
 # Core dependencies
 rand = { workspace = true }
 rand_core = { workspace = true }
-zeroize = { workspace = true }
+zeroize = { workspace = true, features = ["alloc"] }
 
 # Logging (no_std compatible)
 log = { workspace = true }

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -30,7 +30,7 @@ use alloc::{collections::BTreeMap, vec, vec::Vec};
 use core::fmt;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{config::ThresholdConfig, error::MAX_PARTIES};
 
@@ -300,7 +300,7 @@ where
 // ============================================================================
 
 /// Contribution for a single subset (η-bounded secret polynomials).
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Zeroize, ZeroizeOnDrop)]
 pub struct SubsetContribution {
 	/// Share of s1 polynomial vector.
 	pub s1: Vec<[i32; N as usize]>,
@@ -337,17 +337,6 @@ impl SubsetContribution {
 impl Default for SubsetContribution {
 	fn default() -> Self {
 		Self::new()
-	}
-}
-
-impl Zeroize for SubsetContribution {
-	fn zeroize(&mut self) {
-		for poly in &mut self.s1 {
-			poly.zeroize();
-		}
-		for poly in &mut self.s2 {
-			poly.zeroize();
-		}
 	}
 }
 

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -112,23 +112,12 @@ pub struct PrivateKeyShare {
 }
 
 /// Internal secret share data for a specific signer subset.
-#[derive(Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct SecretShareData {
 	/// Share of s1 polynomial vector (L polynomials).
 	pub(crate) s1: Vec<[i32; 256]>,
 	/// Share of s2 polynomial vector (K polynomials).
 	pub(crate) s2: Vec<[i32; 256]>,
-}
-
-impl Zeroize for SecretShareData {
-	fn zeroize(&mut self) {
-		for poly in &mut self.s1 {
-			poly.zeroize();
-		}
-		for poly in &mut self.s2 {
-			poly.zeroize();
-		}
-	}
 }
 
 impl PrivateKeyShare {

--- a/threshold/src/participants.rs
+++ b/threshold/src/participants.rs
@@ -33,6 +33,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use core::iter;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use zeroize::Zeroize;
 
 /// Type alias for participant identifiers.
 ///
@@ -59,6 +60,13 @@ pub struct ParticipantList {
 	participants: Vec<ParticipantId>,
 	/// Maps participant ID to index in the sorted list
 	indices: BTreeMap<ParticipantId, usize>,
+}
+
+impl Zeroize for ParticipantList {
+	fn zeroize(&mut self) {
+		self.participants.zeroize();
+		self.indices.clear();
+	}
 }
 
 impl ParticipantList {

--- a/threshold/src/protocol/primitives.rs
+++ b/threshold/src/protocol/primitives.rs
@@ -156,7 +156,7 @@ pub(crate) fn compute_ntt_dot_product(
 /// Used for rejection sampling in the threshold signing protocol. Samples are
 /// drawn from a hyperball of specified radius and scaled by nu for the s1
 /// components.
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct HyperballSampleVector {
 	data: Box<[f64]>,
 }
@@ -349,23 +349,6 @@ impl HyperballSampleVector {
 		Self { data: data.into_boxed_slice() }
 	}
 }
-
-impl Zeroize for HyperballSampleVector {
-	fn zeroize(&mut self) {
-		// Zeroize all f64 values in the boxed slice
-		// This contains secret witness data (y + cs2) that could reveal s1
-		// Use zeroize crate's implementation for f64 slices
-		self.data.zeroize();
-	}
-}
-
-impl Drop for HyperballSampleVector {
-	fn drop(&mut self) {
-		self.zeroize();
-	}
-}
-
-impl ZeroizeOnDrop for HyperballSampleVector {}
 
 // ============================================================================
 // Hint Computation

--- a/threshold/src/protocol/signing.rs
+++ b/threshold/src/protocol/signing.rs
@@ -14,7 +14,7 @@ use qp_rusty_crystals_dilithium::{
 	},
 	poly, polyvec,
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
 	config::ThresholdConfig,
@@ -36,6 +36,7 @@ use crate::{
 // ============================================================================
 
 /// Internal state after Round 1 completes.
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub(crate) struct Round1Data {
 	/// K different w commitments for canonical iterations.
 	pub(crate) w_commitments: Vec<polyvec::Polyveck>,
@@ -47,28 +48,8 @@ pub(crate) struct Round1Data {
 	pub(crate) rho_prime: [u8; 64],
 }
 
-impl Zeroize for Round1Data {
-	fn zeroize(&mut self) {
-		self.commitment_hash.zeroize();
-		self.rho_prime.zeroize();
-		// Zeroize w_commitments (polyvec doesn't implement Zeroize)
-		for w in &mut self.w_commitments {
-			for i in 0..K {
-				w.vec[i].coeffs.fill(0);
-			}
-		}
-		self.w_commitments.clear();
-		// HyperballSampleVector implements Zeroize/ZeroizeOnDrop,
-		// but we explicitly zeroize before clearing for defense in depth
-		for sample in &mut self.hyperball_samples {
-			sample.zeroize();
-		}
-		self.hyperball_samples.clear();
-	}
-}
-
 /// Internal state after Round 2 completes.
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct Round2Data {
 	/// Message hash μ.
 	pub(crate) mu: [u8; 64],
@@ -78,20 +59,6 @@ pub(crate) struct Round2Data {
 	/// Stores the actual participant IDs (which can be arbitrary u32 values).
 	/// The ParticipantList provides index mapping for internal bitmask operations.
 	pub(crate) active_participants: ParticipantList,
-}
-
-impl Zeroize for Round2Data {
-	fn zeroize(&mut self) {
-		self.mu.zeroize();
-		for w in &mut self.w_aggregated {
-			for i in 0..K {
-				w.vec[i].coeffs.fill(0);
-			}
-		}
-		self.w_aggregated.clear();
-		// ParticipantList doesn't contain secrets, but clear it anyway
-		self.active_participants = ParticipantList::new(&[]).unwrap();
-	}
 }
 
 // ============================================================================

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -54,8 +54,6 @@ use crate::{
 	},
 };
 
-use qp_rusty_crystals_dilithium::params::L;
-
 /// A threshold signer for a single party.
 ///
 /// Each party in the threshold scheme creates one `ThresholdSigner` with their
@@ -109,6 +107,12 @@ enum SigningPhase {
 	AfterRound3,
 }
 
+impl Zeroize for SigningPhase {
+	fn zeroize(&mut self) {
+		*self = SigningPhase::Fresh;
+	}
+}
+
 /// Internal state of the signer.
 ///
 /// Uses a flat struct with Option fields instead of an enum with associated data.
@@ -116,7 +120,7 @@ enum SigningPhase {
 /// - Avoids `mem::take` which would lose data on validation errors
 /// - Enables proper `ZeroizeOnDrop` - all fields are zeroized when dropped
 /// - Keeps data persistent across phases until explicitly cleared
-#[derive(Default)]
+#[derive(Default, Zeroize, ZeroizeOnDrop)]
 struct SignerState {
 	/// Current phase of the protocol.
 	phase: SigningPhase,
@@ -131,45 +135,6 @@ struct SignerState {
 	/// Our computed responses (for Round 3).
 	my_responses: Option<Vec<polyvec::Polyvecl>>,
 }
-
-impl Zeroize for SignerState {
-	fn zeroize(&mut self) {
-		self.phase = SigningPhase::Fresh;
-		if let Some(ref mut data) = self.round1_data {
-			data.zeroize();
-		}
-		self.round1_data = None;
-		if let Some(ref mut data) = self.round2_data {
-			data.zeroize();
-		}
-		self.round2_data = None;
-		if let Some(ref mut msg) = self.message {
-			msg.zeroize();
-		}
-		self.message = None;
-		if let Some(ref mut ctx) = self.context {
-			ctx.zeroize();
-		}
-		self.context = None;
-		if let Some(ref mut responses) = self.my_responses {
-			// polyvec doesn't implement Zeroize, clear manually
-			for resp in responses.iter_mut() {
-				for i in 0..L {
-					resp.vec[i].coeffs.fill(0);
-				}
-			}
-		}
-		self.my_responses = None;
-	}
-}
-
-impl Drop for SignerState {
-	fn drop(&mut self) {
-		self.zeroize();
-	}
-}
-
-impl ZeroizeOnDrop for SignerState {}
 
 impl SignerState {
 	/// Verify Fresh phase (for starting round 1).
@@ -537,11 +502,8 @@ impl ThresholdSigner {
 		let broadcast = Round3Broadcast::new(self.private_key.party_id(), packed_response);
 
 		// Update state - clear round1_data as it's no longer needed
+		// (dropping the Option zeroizes its contents via ZeroizeOnDrop).
 		self.state.my_responses = Some(responses);
-		// Zeroize round1_data before clearing (it contains sensitive hyperball samples)
-		if let Some(ref mut r1) = self.state.round1_data {
-			r1.zeroize();
-		}
 		self.state.round1_data = None;
 		self.state.phase = SigningPhase::AfterRound3;
 
@@ -658,16 +620,12 @@ impl ThresholdSigner {
 	/// This clears all internal state and returns the signer to the `Fresh` state.
 	/// Call this after completing a signing session or to abort a session in progress.
 	pub fn reset(&mut self) {
-		self.state.zeroize();
+		self.state = SignerState::default();
 	}
 }
 
-impl Drop for ThresholdSigner {
-	fn drop(&mut self) {
-		self.reset();
-	}
-}
-
+// `state` (SignerState) and `private_key` (PrivateKeyShare) both implement
+// ZeroizeOnDrop, so their secret material is zeroized via field-by-field drop.
 impl ZeroizeOnDrop for ThresholdSigner {}
 
 #[cfg(test)]


### PR DESCRIPTION
## Replace manual zeroize impls with derives

Addresses review feedback to use `#[derive(ZeroizeOnDrop)]` instead of hand-rolling `impl Zeroize` / `impl Drop` / `impl ZeroizeOnDrop`.

### Changes

- **`dilithium`**: added `Zeroize` to the derive list on `Poly`, `Polyveck`, `Polyvecl` (the keystone — without it `Vec<Polyvecl>: Zeroize` was unsatisfied, forcing manual impls all the way up).
- **`threshold`**: replaced manual zeroize boilerplate with derives on `HyperballSampleVector`, `Round1Data`, `Round2Data`, `SignerState`, `SecretShareData`, `SubsetContribution`.
- Tiny `impl Zeroize` for `SigningPhase` and `ParticipantList` (clears in place; avoids `#[zeroize(skip)]` + a known `zeroize_derive` warning in modern rustc).
- Enabled `zeroize/alloc` in `threshold/Cargo.toml` so `Vec<T>: Zeroize` is available in `no_std` builds.
- Removed redundant explicit `.zeroize()` calls / manual `Drop` for `ThresholdSigner` now that the field-by-field drop cascade handles them.

### Left as-is

`PrivateKeyShare`, `MithrilRound{1..4}State`, `MithrilDkgState`, `MithrilDkg::drop` — all blocked by `BTreeMap` (no upstream `Zeroize`) or generic `S: TranscriptSigner`. Cascade still works: `SecretShareData` is now `ZeroizeOnDrop`, so dropping the `BTreeMap` zeroizes each value.

### Net

~100 lines of zeroize boilerplate deleted. 2 types newly gain drop-zeroize.

### Verification

- `cargo clippy --all-targets` (with and without `--no-default-features`): clean, 0 warnings
- `cargo test`: 81 dilithium + 153 threshold lib + 16 signer-state + 30 resharing + 13 borsh tests all pass