### PR TITLE
Set max msg size to prevent OOM panics

### DIFF
--- a/dilithium/src/errors.rs
+++ b/dilithium/src/errors.rs
@@ -21,12 +21,14 @@ impl Display for KeyParsingError {
 #[derive(Debug)]
 pub enum SignatureError {
 	ContextTooLong,
+	MessageTooLong,
 }
 
 impl Display for SignatureError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		let str = match self {
 			SignatureError::ContextTooLong => "ContextTooLong",
+			SignatureError::MessageTooLong => "MessageTooLong",
 		};
 		write!(f, "{str}")
 	}

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -81,9 +81,14 @@ impl Keypair {
 	///
 	/// # Arguments
 	///
-	/// * 'msg' - message to sign
+	/// * 'msg' - message to sign (max 64 MiB)
+	/// * 'ctx' - optional context string (max 255 bytes)
+	/// * 'hedge' - optional random bytes for hedged signing
 	///
-	/// Returns Result<Signature, SignatureError>
+	/// # Errors
+	///
+	/// Returns `SignatureError::MessageTooLong` if the message exceeds 64 MiB.
+	/// Returns `SignatureError::ContextTooLong` if the context exceeds 255 bytes.
 	pub fn sign(
 		&self,
 		msg: &[u8],
@@ -97,10 +102,13 @@ impl Keypair {
 	///
 	/// # Arguments
 	///
-	/// * 'msg' - message that is claimed to be signed
+	/// * 'msg' - message that is claimed to be signed (max 64 MiB)
 	/// * 'sig' - signature to verify
+	/// * 'ctx' - optional context string (max 255 bytes)
 	///
-	/// Returns 'true' if the verification process was successful, 'false' otherwise
+	/// Returns 'true' if the verification process was successful, 'false' otherwise.
+	/// Returns 'false' if the message exceeds 64 MiB, the context exceeds 255 bytes,
+	/// or the signature length is incorrect.
 	pub fn verify(&self, msg: &[u8], sig: &[u8], ctx: Option<&[u8]>) -> bool {
 		self.public.verify(msg, sig, ctx)
 	}
@@ -254,8 +262,9 @@ impl PublicKey {
 
 #[cfg(test)]
 mod tests {
-	use super::Keypair;
-	use crate::SensitiveBytes32;
+	use super::{Keypair, MAX_MESSAGE_SIZE, SIGNBYTES};
+	use crate::{errors::SignatureError, SensitiveBytes32};
+	use alloc::vec;
 	use rand::Rng;
 
 	fn get_random_bytes() -> SensitiveBytes32 {
@@ -309,5 +318,20 @@ mod tests {
 
 		// Verify with correct context should still work
 		assert!(keys.verify(&msg, &sig, Some(ctx1)));
+	}
+
+	#[test]
+	fn sign_rejects_oversized_message() {
+		let keys = Keypair::generate(get_random_bytes());
+		let big_msg = vec![0u8; MAX_MESSAGE_SIZE + 1];
+		let result = keys.sign(&big_msg, None, None);
+		assert!(matches!(result, Err(SignatureError::MessageTooLong)));
+	}
+
+	#[test]
+	fn verify_rejects_oversized_message() {
+		let keys = Keypair::generate(get_random_bytes());
+		let big_msg = vec![0u8; MAX_MESSAGE_SIZE + 1];
+		assert!(!keys.verify(&big_msg, &[0u8; SIGNBYTES], None));
 	}
 }

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -12,6 +12,12 @@ pub const PUBLICKEYBYTES: usize = crate::params::PUBLICKEYBYTES;
 pub const SIGNBYTES: usize = crate::params::SIGNBYTES;
 pub const KEYPAIRBYTES: usize = SECRETKEYBYTES + PUBLICKEYBYTES;
 
+/// Maximum message size for signing/verification (64 MiB).
+///
+/// This limit prevents denial-of-service attacks via memory exhaustion from
+/// oversized messages. The limit is generous enough for any legitimate use case.
+pub const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+
 pub type Signature = [u8; SIGNBYTES];
 
 /// A pair of private and public keys.
@@ -137,17 +143,23 @@ impl SecretKey {
 	///
 	/// # Arguments
 	///
-	/// * 'msg' - message to sign
-	/// * 'ctx' - context string
+	/// * 'msg' - message to sign (max 64 MiB)
+	/// * 'ctx' - context string (max 255 bytes)
 	/// * 'hedged' - wether to use RNG or not
 	///
-	/// Returns Option<Signature>
+	/// # Errors
+	///
+	/// Returns `SignatureError::MessageTooLong` if the message exceeds 64 MiB.
+	/// Returns `SignatureError::ContextTooLong` if the context exceeds 255 bytes.
 	pub fn sign(
 		&self,
 		msg: &[u8],
 		ctx: Option<&[u8]>,
 		hedge: Option<[u8; params::SEEDBYTES]>,
 	) -> Result<Signature, SignatureError> {
+		if msg.len() > MAX_MESSAGE_SIZE {
+			return Err(SignatureError::MessageTooLong);
+		}
 		match ctx {
 			Some(x) => {
 				if x.len() > 255 {
@@ -205,13 +217,17 @@ impl PublicKey {
 	///
 	/// # Arguments
 	///
-	/// * 'msg' - message that is claimed to be signed
+	/// * 'msg' - message that is claimed to be signed (max 64 MiB)
 	/// * 'sig' - signature to verify
-	/// * 'ctx' - context string
+	/// * 'ctx' - context string (max 255 bytes)
 	///
-	/// Returns 'true' if the verification process was successful, 'false' otherwise
+	/// Returns 'true' if the verification process was successful, 'false' otherwise.
+	/// Returns 'false' early if the message exceeds 64 MiB or context exceeds 255 bytes.
 	pub fn verify(&self, msg: &[u8], sig: &[u8], ctx: Option<&[u8]>) -> bool {
 		if sig.len() != SIGNBYTES {
+			return false;
+		}
+		if msg.len() > MAX_MESSAGE_SIZE {
 			return false;
 		}
 		match ctx {


### PR DESCRIPTION
Simple validation, someone could crash the chain by supplying a too-big message. If a message this big needs to be signed they can hash then sign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a hard 64MiB input limit to cryptographic `sign`/`verify`, which can cause new rejections for previously-accepted large messages but reduces DoS/OOM risk.
> 
> **Overview**
> Adds a **64 MiB maximum message size** (`MAX_MESSAGE_SIZE`) for ML-DSA-87 signing and verification to prevent memory-exhaustion/OOM scenarios.
> 
> `SecretKey::sign` now returns `SignatureError::MessageTooLong` when exceeded, and `PublicKey::verify` returns `false` early for oversized messages; docs are updated and tests cover both rejection paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21455a8029f844ec785dc1bdbeefac2a1b8abda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->