### PR TITLE
ci: Automate dilithium version bump to dilithium-v2.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ checksum = "78172860cd960773c72e97fba07ead9e5a1c13086c5746283744933e2e4a577b"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ getrandom = { version = "=0.2.17", features = ["js"] }
 hex = { version = "=0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = { version = "=0.4.1", default-features = false }
 qp-poseidon-core = { version = "2.1.0", default-features = false }
-qp-rusty-crystals-dilithium = { path = "./dilithium", version = "2.4.0", default-features = false }
+qp-rusty-crystals-dilithium = { path = "./dilithium", version = "2.5.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "2.3.1", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-dilithium"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of CRYSTALS-Dilithium digital signature scheme"


### PR DESCRIPTION
Automated dilithium version bump for release dilithium-v2.5.0.

https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/27115121427

Triggered by workflow run: minor

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata and lockfile updates with no cryptographic or logic changes in the diff.
> 
> **Overview**
> Automated release bump for **`qp-rusty-crystals-dilithium`** from **2.4.0** to **2.5.0**, aligned with tag **dilithium-v2.5.0**.
> 
> The crate version in `dilithium/Cargo.toml`, the workspace dependency pin in the root `Cargo.toml`, and the corresponding entry in **`Cargo.lock`** are updated. No source or API changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ebe90927fdff4c66f17e8c8f98e4e1bf98ae267. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->