### PR TITLE
ci: Automate hdwallet version bump to hdwallet-v2.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ hex = { version = "=0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = { version = "=0.4.1", default-features = false }
 qp-poseidon-core = { version = "2.1.0", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "2.5.0", default-features = false }
-qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "2.3.1", default-features = false }
+qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "2.4.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }
 rusty-crystals-integration-tests = { path = "./tests" }

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-hdwallet"
-version = "2.3.1"
+version = "2.4.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of HD wallet functionality with post-quantum cryptography"


### PR DESCRIPTION
Automated hdwallet version bump for release hdwallet-v2.4.0.

Triggered by workflow run: https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/27117194392

Type: minor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only manifest and lockfile updates with no runtime or cryptographic logic changes.
> 
> **Overview**
> Automated **minor release** bump for `qp-rusty-crystals-hdwallet` from **2.3.1** to **2.4.0**.
> 
> The crate version in `hdwallet/Cargo.toml`, the workspace pin in root `Cargo.toml`, and the corresponding entry in `Cargo.lock` are updated so the workspace resolves the new hdwallet release. No library or application source changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd83de8807030a333d6bc3f4ec13f2486e5b8bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->