### PR TITLE
threshold: bind combine_with_message to round 2 message; fix max-parties doc

### DIFF
--- a/threshold/src/lib.rs
+++ b/threshold/src/lib.rs
@@ -11,7 +11,7 @@
 //! - Any t or more parties can cooperate to produce a valid signature
 //! - Fewer than t parties cannot produce a signature or learn the secret key
 //!
-//! This implementation supports configurations up to (7, 7) and produces
+//! This implementation supports configurations up to (6, 6) and produces
 //! signatures that are compatible with standard ML-DSA-87 verification.
 //!
 //! ## Quick Start

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -687,15 +687,26 @@ impl ThresholdSigner {
 		_all_round2: &[Round2Broadcast],
 		all_round3: &[Round3Broadcast],
 	) -> ThresholdResult<Signature> {
-		let (round2_data, my_responses, _, _) = self.state.expect_round3()?;
+		let (round2_data, my_responses, bound_message, bound_context) =
+			self.state.expect_round3()?;
+
+		// Round 3 responses are bound to the message/context captured in Round 2.
+		// Combining against anything else would silently yield an invalid signature,
+		// so reject the mismatch instead of proceeding.
+		if message != bound_message || context != bound_context {
+			return Err(ThresholdError::InvalidData(
+				"combine_with_message message/context does not match the values bound in round 2"
+					.to_string(),
+			));
+		}
 
 		let all_responses = self.collect_responses(my_responses, all_round3)?;
 
 		let signature_bytes = combine_signature(
 			&self.public_key,
 			&self.config,
-			message,
-			context,
+			bound_message,
+			bound_context,
 			&round2_data.w_aggregated,
 			&all_responses,
 		)?;

--- a/threshold/tests/signer_state_tests.rs
+++ b/threshold/tests/signer_state_tests.rs
@@ -266,3 +266,64 @@ fn test_round2_preserves_state_on_insufficient_parties() {
 		_ => panic!("Unexpected result: {:?}", result2),
 	}
 }
+
+/// `combine_with_message` must reject a message/context that differs from the values
+/// bound in Round 2, rather than silently combining responses for the wrong message.
+#[test]
+fn test_combine_with_message_rejects_mismatched_message() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("key generation");
+
+	let mut signers: Vec<_> = shares
+		.iter()
+		.take(2)
+		.map(|share| ThresholdSigner::new(share.clone(), public_key.clone(), config).unwrap())
+		.collect();
+
+	let message = b"bound message";
+	let context = b"bound context";
+
+	let participant_list = ParticipantList::new(&[0u32, 1u32]).unwrap();
+	let ssid = compute_ssid(&public_key, 2, 3, &participant_list, &[0xDD; 32]);
+
+	let r1: Vec<_> = signers
+		.iter_mut()
+		.enumerate()
+		.map(|(i, s)| {
+			let mut party_seed = [0u8; 32];
+			party_seed[0] = (i as u8) + 1;
+			s.round1_commit_with_seed(&ssid, &party_seed).unwrap()
+		})
+		.collect();
+
+	let r2: Vec<_> = signers
+		.iter_mut()
+		.enumerate()
+		.map(|(i, s)| {
+			let others: Vec<_> = r1.iter().filter(|r| r.party_id != i as u32).cloned().collect();
+			s.round2_reveal(&ssid, message, context, &others).unwrap()
+		})
+		.collect();
+
+	let r3: Vec<_> = signers
+		.iter_mut()
+		.enumerate()
+		.map(|(i, s)| {
+			let o1: Vec<_> = r1.iter().filter(|r| r.party_id != i as u32).cloned().collect();
+			let o2: Vec<_> = r2.iter().filter(|r| r.party_id != i as u32).cloned().collect();
+			s.round3_respond(&ssid, &o1, &o2).unwrap()
+		})
+		.collect();
+
+	// A different message is rejected loudly before any signature is produced.
+	let mismatched = signers[0].combine_with_message(b"different message", context, &r2, &r3);
+	assert!(mismatched.is_err(), "mismatched message must be rejected");
+
+	// The bound message/context never triggers that rejection (a CombinationFailed from
+	// this attempt's rejection sampling is acceptable; the mismatch error is not).
+	if let Err(e) = signers[0].combine_with_message(message, context, &r2, &r3) {
+		let msg = format!("{}", e);
+		assert!(!msg.contains("does not match"), "bound message must not be rejected: {}", msg);
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to the re-review of #74, addressing the two actionable residual items called out there. Based on `illuzen/threshold-2` so it can be folded into #74 (the `threshold` crate only exists on that branch).

- **`combine_with_message` now binds to the Round 2 message/context.** Previously it used the caller-supplied `message`/`context` and ignored the values captured in `AfterRound3`; combining against a different message silently produced an invalid signature (`CombinationFailed`) rather than failing on the real cause. It now rejects a mismatch with `InvalidData` and uses the bound values for the actual signature computation. (`combine()` already used the captured values, and the network adapter passes its own stored message — so this only tightens the standalone convenience API.)
- **Doc fix:** `lib.rs` claimed support "up to (7, 7)" while `MAX_PARTIES = 6`.

Not included (by design / not closable in a patch — these need an external cryptographic review and are already covered by the crate's "research only — not audited" warning): no in-library CSPRNG / SSID not binding the message, floating-point hyperball sampling and non-constant-time NTT on secret data, and the hardcoded hyperball/`K` parameters resting on a Monte-Carlo script rather than a published proof.

## Test plan

- [x] `cargo test -p qp-rusty-crystals-threshold --lib` (201 passed)
- [x] `cargo test -p qp-rusty-crystals-threshold --test signer_state_tests` (13 passed, incl. new `test_combine_with_message_rejects_mismatched_message`)
- [x] `cargo clippy -p qp-rusty-crystals-threshold --all-targets` (clean)
- [x] `cargo +nightly fmt -p qp-rusty-crystals-threshold -- --check` (clean)
