### PR TITLE
Add release workflows for threshold

### DIFF
--- a/.github/workflows/create-threshold-release-proposal.yml
+++ b/.github/workflows/create-threshold-release-proposal.yml
@@ -62,9 +62,18 @@ jobs:
           # Get all threshold version tags and sort them by version
           latest_semver_tag=$(git tag -l "threshold-v[0-9]*.[0-9]*.[0-9]*" | sort -V | tail -n 1)
           
-          # If no tags found, use default
+          # If no tags found, read current version from threshold/Cargo.toml
           if [ -z "$latest_semver_tag" ]; then
-            latest_semver_tag="threshold-v0.0.0"
+            cargo_version=$(grep -m1 '^version' threshold/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+            if [ -z "$cargo_version" ]; then
+              echo "Error: No threshold tags found and could not read version from threshold/Cargo.toml"
+              exit 1
+            fi
+            # Use the Cargo.toml version as the base (subtract one patch for the first bump to match)
+            # This ensures a patch bump from Cargo.toml 1.0.0 yields 1.0.1, not 0.0.1
+            latest_semver_tag="threshold-v$cargo_version"
+            echo "No existing threshold tags found. Using version from threshold/Cargo.toml: $latest_semver_tag"
+            echo "Note: The first release will increment from this version."
           fi
           
           echo "latest_tag_found=$latest_semver_tag" >> $GITHUB_OUTPUT
@@ -171,7 +180,7 @@ jobs:
 
           gh pr create \
             --title "$PR_TITLE" \
-            --body "$(printf "Automated threshold version bump for release %s.\\n\\n%s\\n\\nTriggered by workflow run: %s\\n\\nType: %s" "$NEW_VERSION" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" "${{ github.event.inputs.version_type }}")" \
+            --body "$(printf "Automated threshold version bump for release %s.\\n\\nTriggered by workflow run: %s\\n\\nType: %s" "$NEW_VERSION" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" "${{ github.event.inputs.version_type }}")" \
             --base "$TARGET_BRANCH" \
             --head "$branch_name" \
             --label "$PR_LABELS"

--- a/.github/workflows/create-threshold-release-proposal.yml
+++ b/.github/workflows/create-threshold-release-proposal.yml
@@ -1,0 +1,177 @@
+name: Create Threshold Release Proposal
+
+env:
+  CARGO_TERM_COLOR: always
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch for the PR (default: master)'
+        required: false
+        type: string
+        default: 'master'
+      version_type:
+        description: 'Type of version bump (major, minor, patch) or specify custom version'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - custom
+      custom_version:
+        description: 'Custom version string (e.g., v1.0.1). Only used if version_type is "custom". MUST start with "v"'
+        required: false
+      is_draft:
+        description: 'Is this a draft release?'
+        required: true
+        type: boolean
+        default: false
+
+# Default to read-only; the version-bump job overrides with `contents: write`
+# (it pushes a release branch and uses ADMIN_PAT for `gh pr create`).
+permissions:
+  contents: read
+
+jobs:
+  calculate-next-version:
+    name: 🧮 Calculate Next Threshold Version
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.versioner.outputs.new_version }}
+      commit_sha_short: ${{ steps.vars.outputs.commit_sha_short }}
+      source_branch: ${{ steps.vars.outputs.source_branch }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Get current branch and commit SHA
+        id: vars
+        run: |
+          echo "commit_sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "source_branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Get latest threshold tag
+        id: latest_tag
+        run: |
+          # Get all threshold version tags and sort them by version
+          latest_semver_tag=$(git tag -l "threshold-v[0-9]*.[0-9]*.[0-9]*" | sort -V | tail -n 1)
+          
+          # If no tags found, use default
+          if [ -z "$latest_semver_tag" ]; then
+            latest_semver_tag="threshold-v0.0.0"
+          fi
+          
+          echo "latest_tag_found=$latest_semver_tag" >> $GITHUB_OUTPUT
+          echo "Latest threshold semantic version tag found: $latest_semver_tag"
+
+      - name: Calculate new version
+        id: versioner
+        env:
+          LATEST_TAG: ${{ steps.latest_tag.outputs.latest_tag_found }}
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          CUSTOM_VERSION: ${{ github.event.inputs.custom_version }}
+        run: |
+          # Remove 'threshold-v' prefix for processing
+          current_version=${LATEST_TAG#threshold-v}
+
+          if [[ "$VERSION_TYPE" == "custom" ]]; then
+            if [[ -z "$CUSTOM_VERSION" ]]; then
+              echo "Error: Custom version is selected but no custom_version string provided."
+              exit 1
+            fi
+            if [[ ! "$CUSTOM_VERSION" =~ ^v ]]; then
+              echo "Error: Custom version string MUST start with 'v' (e.g., v1.2.3)."
+              exit 1
+            fi
+            new_version="threshold-$CUSTOM_VERSION"
+          else
+            # Split version into parts
+            IFS='.' read -r major minor patch <<< "$current_version"
+
+            # Increment based on type
+            if [[ "$VERSION_TYPE" == "major" ]]; then
+              major=$((major + 1))
+              minor=0
+              patch=0
+            elif [[ "$VERSION_TYPE" == "minor" ]]; then
+              minor=$((minor + 1))
+              patch=0
+            elif [[ "$VERSION_TYPE" == "patch" ]]; then
+              patch=$((patch + 1))
+            else
+              echo "Error: Invalid version_type: $VERSION_TYPE"
+              exit 1
+            fi
+            new_version="threshold-v$major.$minor.$patch"
+          fi
+
+          echo "New threshold version: $new_version"
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+  update-threshold-version:
+    name: 📝 Update Threshold Version
+    needs: calculate-next-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create version bump branch and PR
+        env:
+          NEW_VERSION: ${{ needs.calculate-next-version.outputs.new_version }}
+          GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
+          SOURCE_BRANCH: ${{ needs.calculate-next-version.outputs.source_branch }}
+          TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
+        run: |
+          set -ex
+          # Extract version without threshold- prefix
+          new_cargo_version=${NEW_VERSION#threshold-v}
+          branch_name="release/${NEW_VERSION}"
+
+          # Create new branch from source branch
+          git checkout "$SOURCE_BRANCH"
+          git checkout -b "$branch_name"
+          
+          # Update threshold version
+          echo "Updating threshold/Cargo.toml to version: $new_cargo_version"
+          sed -i -E "s/^version\s*=\s*\"[0-9a-zA-Z.-]+\"/version = \"$new_cargo_version\"/" threshold/Cargo.toml
+          
+          # Update workspace dependency in main Cargo.toml
+          echo "Updating threshold workspace dependency in main Cargo.toml"
+          sed -i "/qp-rusty-crystals-threshold/s/version = \"[^\"]*\"/version = \"$new_cargo_version\"/" Cargo.toml
+
+          # Update Cargo.lock
+          cargo update --package qp-rusty-crystals-threshold
+
+          # Commit changes
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          
+          git add Cargo.toml threshold/Cargo.toml Cargo.lock
+          git commit -m "ci: Automate threshold version bump to $NEW_VERSION"
+          git push origin "$branch_name"
+
+          PR_TITLE="ci: Automate threshold version bump to $NEW_VERSION"
+
+          # Prepare labels
+          PR_LABELS="automated,threshold-release-proposal"
+          if [[ "${{ github.event.inputs.is_draft }}" == "true" ]]; then
+            PR_LABELS="$PR_LABELS,draft-release"
+          fi
+
+          gh pr create \
+            --title "$PR_TITLE" \
+            --body "$(printf "Automated threshold version bump for release %s.\\n\\n%s\\n\\nTriggered by workflow run: %s\\n\\nType: %s" "$NEW_VERSION" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" "${{ github.event.inputs.version_type }}")" \
+            --base "$TARGET_BRANCH" \
+            --head "$branch_name" \
+            --label "$PR_LABELS"

--- a/.github/workflows/create-threshold-release-proposal.yml
+++ b/.github/workflows/create-threshold-release-proposal.yml
@@ -69,8 +69,8 @@ jobs:
               echo "Error: No threshold tags found and could not read version from threshold/Cargo.toml"
               exit 1
             fi
-            # Use the Cargo.toml version as the base (subtract one patch for the first bump to match)
-            # This ensures a patch bump from Cargo.toml 1.0.0 yields 1.0.1, not 0.0.1
+            # Use the Cargo.toml version as the base for incrementing.
+            # With Cargo.toml at 1.0.0, the first patch release will be 1.0.1 (version 1.0.0 is never tagged/published)
             latest_semver_tag="threshold-v$cargo_version"
             echo "No existing threshold tags found. Using version from threshold/Cargo.toml: $latest_semver_tag"
             echo "Note: The first release will increment from this version."

--- a/.github/workflows/create-threshold-release-proposal.yml
+++ b/.github/workflows/create-threshold-release-proposal.yml
@@ -141,6 +141,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
           SOURCE_BRANCH: ${{ needs.calculate-next-version.outputs.source_branch }}
           TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
+          GIT_USER_NAME: ${{ github.actor }}
+          GIT_USER_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          IS_DRAFT: ${{ github.event.inputs.is_draft }}
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -ex
           # Extract version without threshold- prefix
@@ -163,8 +168,8 @@ jobs:
           cargo update --package qp-rusty-crystals-threshold
 
           # Commit changes
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
           
           git add Cargo.toml threshold/Cargo.toml Cargo.lock
           git commit -m "ci: Automate threshold version bump to $NEW_VERSION"
@@ -174,13 +179,13 @@ jobs:
 
           # Prepare labels
           PR_LABELS="automated,threshold-release-proposal"
-          if [[ "${{ github.event.inputs.is_draft }}" == "true" ]]; then
+          if [[ "$IS_DRAFT" == "true" ]]; then
             PR_LABELS="$PR_LABELS,draft-release"
           fi
 
           gh pr create \
             --title "$PR_TITLE" \
-            --body "$(printf "Automated threshold version bump for release %s.\\n\\nTriggered by workflow run: %s\\n\\nType: %s" "$NEW_VERSION" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" "${{ github.event.inputs.version_type }}")" \
+            --body "$(printf "Automated threshold version bump for release %s.\\n\\nTriggered by workflow run: %s\\n\\nType: %s" "$NEW_VERSION" "$WORKFLOW_URL" "$VERSION_TYPE")" \
             --base "$TARGET_BRANCH" \
             --head "$branch_name" \
             --label "$PR_LABELS"

--- a/.github/workflows/create-threshold-release-tag-and-publish.yml
+++ b/.github/workflows/create-threshold-release-tag-and-publish.yml
@@ -26,9 +26,13 @@ jobs:
       version: ${{ steps.extract_version.outputs.version }}
       is_draft: ${{ steps.extract_version.outputs.is_draft }}
     steps:
+      # Checkout the merge commit on master, not the PR head branch.
+      # This is safe because merged == true means a maintainer approved the PR,
+      # and we're checking out the result that's already on the target branch.
       - name: Checkout code
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Extract version from PR title

--- a/.github/workflows/create-threshold-release-tag-and-publish.yml
+++ b/.github/workflows/create-threshold-release-tag-and-publish.yml
@@ -35,7 +35,7 @@ jobs:
         id: extract_version
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          IS_DRAFT_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           # Extract version from PR title (format: "ci: Automate threshold version bump to threshold-vX.Y.Z")
           # Using env var to prevent command injection from malicious PR titles
@@ -47,7 +47,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           # Check if this is a draft release
-          if [[ "$IS_DRAFT_LABEL" == "true" ]]; then
+          if [[ ",$PR_LABELS," == *",draft-release,"* ]]; then
             echo "is_draft=true" >> $GITHUB_OUTPUT
           else
             echo "is_draft=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-threshold-release-tag-and-publish.yml
+++ b/.github/workflows/create-threshold-release-tag-and-publish.yml
@@ -33,17 +33,21 @@ jobs:
 
       - name: Extract version from PR title
         id: extract_version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          IS_DRAFT_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}
         run: |
           # Extract version from PR title (format: "ci: Automate threshold version bump to threshold-vX.Y.Z")
-          VERSION=$(echo "${{ github.event.pull_request.title }}" | grep -o 'threshold-v[0-9]\+\.[0-9]\+\.[0-9]\+')
+          # Using env var to prevent command injection from malicious PR titles
+          VERSION=$(echo "$PR_TITLE" | grep -o 'threshold-v[0-9]\+\.[0-9]\+\.[0-9]\+')
           if [ -z "$VERSION" ]; then
-            echo "Error: Could not extract threshold version from PR title: ${{ github.event.pull_request.title }}"
+            echo "Error: Could not extract threshold version from PR title: $PR_TITLE"
             exit 1
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           # Check if this is a draft release
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}" == "true" ]]; then
+          if [[ "$IS_DRAFT_LABEL" == "true" ]]; then
             echo "is_draft=true" >> $GITHUB_OUTPUT
           else
             echo "is_draft=false" >> $GITHUB_OUTPUT
@@ -51,11 +55,15 @@ jobs:
           echo "Extracted threshold version: $VERSION"
 
       - name: Create and push tag
+        env:
+          GIT_USER_NAME: ${{ github.actor }}
+          GIT_USER_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          TAG_VERSION: ${{ steps.extract_version.outputs.version }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git tag -a "${{ steps.extract_version.outputs.version }}" -m "Threshold Release ${{ steps.extract_version.outputs.version }}"
-          git push origin "${{ steps.extract_version.outputs.version }}"
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
+          git tag -a "$TAG_VERSION" -m "Threshold Release $TAG_VERSION"
+          git push origin "$TAG_VERSION"
 
   format-checks:
     name: Format Checks

--- a/.github/workflows/create-threshold-release-tag-and-publish.yml
+++ b/.github/workflows/create-threshold-release-tag-and-publish.yml
@@ -5,8 +5,7 @@ env:
   CARGO_TERM_COLOR: always
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - master
 
@@ -18,7 +17,7 @@ permissions:
 jobs:
   create-tag:
     name: Create Threshold Tag
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'threshold-release-proposal')
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/create-threshold-release-tag-and-publish.yml
+++ b/.github/workflows/create-threshold-release-tag-and-publish.yml
@@ -5,7 +5,8 @@ env:
   CARGO_TERM_COLOR: always
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - master
 
@@ -17,7 +18,7 @@ permissions:
 jobs:
   create-tag:
     name: Create Threshold Tag
-    if: github.ref == 'refs/heads/master'
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'threshold-release-proposal')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/create-threshold-release-tag-and-publish.yml
+++ b/.github/workflows/create-threshold-release-tag-and-publish.yml
@@ -1,0 +1,195 @@
+name: Create Threshold Release Tag & Publish
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+# Default to read-only; jobs that need to push tags or create releases
+# override this with explicit `contents: write` (see create-tag, create-github-release).
+permissions:
+  contents: read
+
+jobs:
+  create-tag:
+    name: Create Threshold Tag
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'threshold-release-proposal')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.extract_version.outputs.version }}
+      is_draft: ${{ steps.extract_version.outputs.is_draft }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from PR title
+        id: extract_version
+        run: |
+          # Extract version from PR title (format: "ci: Automate threshold version bump to threshold-vX.Y.Z")
+          VERSION=$(echo "${{ github.event.pull_request.title }}" | grep -o 'threshold-v[0-9]\+\.[0-9]\+\.[0-9]\+')
+          if [ -z "$VERSION" ]; then
+            echo "Error: Could not extract threshold version from PR title: ${{ github.event.pull_request.title }}"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Check if this is a draft release
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'draft-release') }}" == "true" ]]; then
+            echo "is_draft=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_draft=false" >> $GITHUB_OUTPUT
+          fi
+          echo "Extracted threshold version: $VERSION"
+
+      - name: Create and push tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git tag -a "${{ steps.extract_version.outputs.version }}" -m "Threshold Release ${{ steps.extract_version.outputs.version }}"
+          git push origin "${{ steps.extract_version.outputs.version }}"
+
+  format-checks:
+    name: Format Checks
+    needs: create-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code at tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.create-tag.outputs.version }}
+
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt --toolchain nightly
+
+      - name: Install taplo
+        run: cargo install taplo-cli --locked
+
+      - name: Run format checks
+        run: |
+          taplo format --check --config taplo.toml
+          cargo +nightly fmt --all -- --check
+
+  build-and-test:
+    name: Build & Test Threshold
+    needs: [create-tag, format-checks]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code at tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.create-tag.outputs.version }}
+
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: |
+          rustup toolchain install
+          rustup component add clippy rust-src
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build workspace (for threshold dependencies)
+        run: cargo build --workspace --locked
+
+      - name: Test threshold
+        run: |
+          cd threshold
+          cargo test --locked
+
+      - name: Run clippy on threshold
+        run: |
+          cd threshold
+          cargo clippy --all-targets --all-features --locked -- -D warnings
+
+      - name: Generate threshold documentation
+        run: |
+          cd threshold
+          cargo doc --locked --no-deps --all-features
+
+      - name: Check threshold documentation
+        run: |
+          cd threshold
+          cargo doc --locked --no-deps --all-features --document-private-items
+
+  security-audit:
+    name: Security Audit
+    needs: [create-tag, format-checks]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code at tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.create-tag.outputs.version }}
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run security audit
+        run: cargo audit
+
+  create-github-release:
+    name: Create Threshold GitHub Release
+    needs: [create-tag, build-and-test, security-audit]
+    if: always() && needs.build-and-test.result == 'success' && needs.security-audit.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.create-tag.outputs.version }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Required before `cargo publish` below: rustup does not auto-install the
+      # active toolchain anymore, so we must install the version pinned in
+      # `rust-toolchain` explicitly. Idempotent if already present.
+      - name: Install Rust toolchain (from rust-toolchain file)
+        run: rustup toolchain install
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
+          NEW_VERSION: ${{ needs.create-tag.outputs.version }}
+        run: |
+          release_notes="Automated threshold release for version $NEW_VERSION."
+          printf "%s" "$release_notes" > release_notes.txt
+
+          # Add draft flag if this is a draft release
+          if [[ "${{ needs.create-tag.outputs.is_draft }}" == "true" ]]; then
+            DRAFT_FLAG="--draft"
+          else
+            DRAFT_FLAG=""
+          fi
+
+          echo "Creating threshold release with DRAFT_FLAG: $DRAFT_FLAG"
+
+          gh release create "$NEW_VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Quantus qp-rusty-crystals-threshold - $NEW_VERSION" \
+            --notes-file release_notes.txt \
+            --target master \
+            $DRAFT_FLAG
+
+      - name: Publish threshold to crates.io
+        run: |
+          cd threshold
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/create-threshold-release-tag-and-publish.yml
+++ b/.github/workflows/create-threshold-release-tag-and-publish.yml
@@ -188,6 +188,7 @@ jobs:
             $DRAFT_FLAG
 
       - name: Publish threshold to crates.io
+        if: needs.create-tag.outputs.is_draft != 'true'
         run: |
           cd threshold
           cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty

--- a/threshold/Cargo.toml
+++ b/threshold/Cargo.toml
@@ -2,11 +2,13 @@
 name = "qp-rusty-crystals-threshold"
 version = "1.0.0"
 edition = "2021"
-authors = ["Quantum Resistant Ledger"]
+authors = ["Quantus Network"]
 license = "GPL-3.0"
-description = "Threshold ML-DSA signature scheme implementation"
-repository = "https://github.com/quantum-resistant-ledger/qp-rusty-crystals"
-keywords = ["cryptography", "ml-dsa", "post-quantum", "signatures", "threshold"]
+description = "Threshold ML-DSA-87 signature scheme implementation for post-quantum threshold signing"
+readme = "README.md"
+homepage = "https://www.quantus.com"
+repository = "https://github.com/Quantus-Network/qp-rusty-crystals"
+keywords = ["cryptography", "ml-dsa", "post-quantum", "threshold", "dilithium"]
 categories = ["cryptography"]
 
 [dependencies]

--- a/threshold/Cargo.toml
+++ b/threshold/Cargo.toml
@@ -8,7 +8,7 @@ description = "Threshold ML-DSA-87 signature scheme implementation for post-quan
 readme = "README.md"
 homepage = "https://www.quantus.com"
 repository = "https://github.com/Quantus-Network/qp-rusty-crystals"
-keywords = ["cryptography", "ml-dsa", "post-quantum", "threshold", "dilithium"]
+keywords = ["cryptography", "dilithium", "ml-dsa", "post-quantum", "threshold"]
 categories = ["cryptography"]
 
 [dependencies]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Merging labeled release PRs can auto-tag, publish to crates.io, and push releases using privileged tokens; mistakes in version extraction or workflow inputs could ship the wrong artifact.
> 
> **Overview**
> Adds **automated threshold release CI** modeled on the existing dilithium/hdwallet flows: a manual **Create Threshold Release Proposal** workflow and a **tag & publish** workflow on merged PRs.
> 
> The proposal workflow computes the next `threshold-v*.*.*` tag (or a custom `v…` version), bumps `threshold/Cargo.toml`, the workspace `qp-rusty-crystals-threshold` pin in root `Cargo.toml`, and `Cargo.lock`, then opens a labeled PR via `ADMIN_PAT`. The follow-up workflow runs when a `threshold-release-proposal` PR merges to `master`: it tags from the PR title, runs format/build/test/clippy/docs and `cargo audit` on that tag, then creates a GitHub release (optional draft) and **`cargo publish`**es `qp-rusty-crystals-threshold` with `CARGO_REGISTRY_TOKEN`.
> 
> **`threshold/Cargo.toml`** metadata is updated for crates.io (Quantus authors, ML-DSA-87 description, readme/homepage/repo/keywords)—no dependency or version field change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17973b5a261395b7de4488dff8552e70ab824207. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->