### PR TITLE
Resharing hardening again: liveness, signed transcript acceptance, and SSID v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/clippy.sh
+++ b/clippy.sh
@@ -2,4 +2,6 @@
 # Run the same clippy command as CI (see .github/workflows/ci.yml)
 set -euo pipefail
 
+cargo +nightly fmt
+taplo format
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -20,28 +20,41 @@ Without resharing, any change would require generating a new key and migrating a
 - **New Committee**: Parties that will hold new shares (threshold `t_new` of `n_new`)
 - **Overlap**: Parties may be in both committees
 
-### Protocol Rounds (5-round session-randomized protocol)
+### Protocol Rounds (session-randomized protocol with active-set liveness)
 
-This module uses **distributed per-subset re-sharing** with SSID-based replay protection and public session randomization. At no point does any party ever assemble the full secret `s`, and no individual share is exposed on public broadcast traffic. Round 4 private traffic does contain secret share material and requires an authenticated-encrypted channel.
+This module uses **distributed per-subset re-sharing** with SSID-based replay protection, public session randomization, and active-set liveness (resharing succeeds when up to `n_old − t_old` old members are offline). At no point does any party ever assemble the full secret `s`, and no individual share is exposed on public broadcast traffic. Round 4 private traffic does contain secret share material and requires an authenticated-encrypted channel.
 
 ```
-Round 1: Entropy Commitment (Session Randomization)
+Round 1: Entropy Commitment / Ready (Session Randomization)
 ├── Each old committee member generates fresh entropy and broadcasts H(entropy).
+├── The commitment doubles as that member's Ready signal.
 └── Commit-reveal prevents any party from biasing the session seed.
 
+Act Proposal (Active-Set Selection)
+├── The session leader (lowest-ID new committee member) proposes the active set Act:
+│   all old members once everyone has committed (fast path), or the committed subset
+│   after the caller closes the ready window (close_ready_window(), e.g. on a
+│   transport timeout).
+├── Every party verifies: sender is the leader, Act ⊆ old committee, |Act| ≥ t_old.
+│   |Act| ≥ t_old guarantees every old subset I (size n_old − t_old + 1) intersects
+│   Act, so a live dealer exists for every subset.
+└── If fewer than t_old old members are ready, the protocol aborts
+    (InsufficientParties).
+
 Round 2: Entropy Reveal (Public Session Seed)
-├── Old committee members reveal their entropy.
+├── Active old committee members reveal their entropy.
 ├── All parties verify reveals against Round 1 commitments.
-└── Session seed = SHAKE256("resharing-session-seed-v1" || party_1 || entropy_1 || ...)
-    computed deterministically from all contributions in sorted party ID order.
+└── Session seed = SHAKE256("resharing-session-seed-v1" || ssid || party_1 || entropy_1 || ...)
+    computed deterministically from the active set's contributions in sorted party ID order.
 
 Round 3: Per-Subset Commitments
-├── For each old subset I, the designated dealer D_I (lowest-ID old participant in I)
-│   deterministically derives bounded sub-shares r_{I→J} for every new subset J such that
-│   Σ_J r_{I→J} = s_I^old. The derivation incorporates the public session seed for
-│   per-session randomization.
+├── For each old subset I, the designated dealer D_I = min(I ∩ Act) (lowest-ID active
+│   old participant in I) deterministically derives bounded sub-shares r_{I→J} for every
+│   new subset J such that Σ_J r_{I→J} = s_I^old. The derivation incorporates the public
+│   session seed for per-session randomization. All members of I hold the same s_I^old
+│   and the derivation is deterministic, so dealer identity does not affect the values.
 ├── D_I broadcasts H(r_{I→J}) for each (I, J).
-└── Every other old member of I recomputes the same r_{I→J} values and verifies
+└── Every other active member of I recomputes the same r_{I→J} values and verifies
     D_I's commitments before any Round 4 private delivery occurs.
 
 Round 4: Private Sub-Share Reveal (⚠️ REQUIRES SECURE CHANNEL)
@@ -64,7 +77,7 @@ Because `Σ_J s_J^new = Σ_J Σ_I r_{I→J} = Σ_I s_I^old = s`, the secret — 
 
 ## Session Randomization and Threat Model
 
-The 5-round protocol provides public session randomization, replay protection, and anti-bias commit-reveal. It does **not** provide post-compromise forward secrecy.
+The protocol provides public session randomization, replay protection, and anti-bias commit-reveal. It does **not** provide post-compromise forward secrecy.
 
 Round 2 entropy reveals are part of the public transcript. After Round 2, the `session_seed` is public transcript material. Because sub-shares are derived deterministically from `session_seed`, `i_mask`, and `s_I^old`, an attacker who records the transcript and later compromises old subset shares can recompute the resharing randomness and derive the corresponding new shares.
 
@@ -95,7 +108,8 @@ Before Round 2 reveals are known, an attacker cannot predict the session seed un
 |----------|-----------|
 | **Secrecy of `s`** | No party — not even any dealer — ever holds `s` in clear. Each `D_I` only handles `s_I^old`, which they already had. |
 | **Replay protection** | Every message carries an SSID derived from the old/new committees, public key, and session nonce. Messages with a mismatched SSID are ignored. |
-| **Session randomization** | Session seed incorporates the SSID and fresh entropy from all old committee members via commit-reveal, so different sessions produce different deterministic sub-share splits even if entropy is accidentally reused. This does not provide post-compromise forward secrecy once the transcript is recorded. |
+| **Session randomization** | Session seed incorporates the SSID and fresh entropy from all active old committee members via commit-reveal, so different sessions produce different deterministic sub-share splits even if entropy is accidentally reused. This does not provide post-compromise forward secrecy once the transcript is recorded. |
+| **Liveness with offline old members** | Round 1 commitments double as Ready signals. The session leader (lowest-ID new committee member) proposes the active set `Act` of ready members (`|Act| ≥ t_old`); dealers are assigned as `min(I ∩ Act)`, so resharing completes with up to `n_old − t_old` old members offline. The leader cannot break safety: parties verify `Act` against the Ready signals they received themselves, sub-share derivation is deterministic (dealer identity doesn't change values), and the seed stays unbiased because `Act` is fixed before any entropy is revealed and contains at least one honest member. A malicious leader can at most deny service or select among ready members; equivocating proposals lead to mismatched deterministic commitments and an abort. |
 | **Confidentiality of contributions** | Rounds 1-3, 5 broadcast only hash commitments; Round 4 sub-shares travel privately. Even an unbounded eavesdropper learns nothing about any `s_I^old` from the public transcript. |
 | **Cheating-dealer detection** | Old-subset peers recompute and verify Round 3 commitments before Round 4 whenever the old subset has another member. New-subset members verify delivered sub-shares against Round 3 commitments, reject over-large sub-share coefficients, and reject recovered signing partials that exceed the existing hyperball safety envelope. A final partial-public-key sum check reconstructs `T` from `Σ_J t_J^new`, catching aggregate-secret corruption even when an old subset has size 1. If any verification fails, the protocol aborts. |
 | **PK Preservation** | Public key `t = A·s1 + s2` unchanged, verified at the end of Round 5 via a deterministic byte-equality check against the original PK. |
@@ -243,7 +257,8 @@ Each party has a role determined by committee membership:
 
 ## Message Types
 
-- `Round1EntropyCommitment`: Hash commitment to entropy `H(entropy)` for session randomization
+- `Round1EntropyCommitment`: Hash commitment to entropy `H(entropy)` for session randomization; doubles as the sender's Ready signal
+- `ActProposal`: The leader's proposed active set `Act` (sorted, `⊆` old committee, `|Act| ≥ t_old`)
 - `Round2EntropyReveal`: Revealed entropy (32 bytes) — verified against Round 1 commitment
 - `Round3Broadcast`: Per-subset commitment hashes `H(r_{I→J})` (no plaintext shares)
 - `Round4Message`: Private sub-share reveal (**requires secure channel**) — one message per (dealer, recipient) carrying every `r_{I→J}` the dealer owes that recipient. Dealers handle self-deals locally and never emit `SendPrivate(self, _)`.
@@ -257,14 +272,14 @@ Round1Generate -> Round1Waiting -> Round2Generate -> Round2Waiting
     -> Round5Generate -> Round5Waiting -> Combining -> Done
 ```
 
-NewOnly parties skip Rounds 1-2 (entropy commit-reveal) and go directly to `Round2Waiting`.
+NewOnly parties skip Rounds 1-2 (entropy commit-reveal) and go directly to `Round2Waiting`. The Act proposal is emitted and consumed within the `Round1Waiting`/`Round2Waiting` states; parties do not advance past them until `Act` is agreed. Old members outside `Act` observe (they verify and, if in the new committee, receive shares) but do not contribute entropy or deal.
 
 ## Limitations
 
 - Maximum 16 parties (due to u16 subset masks)
-- Requires every designated dealer to be online; if a dealer is offline or cheats, the protocol aborts (no recovery / re-deal in this implementation)
+- Requires at least `t_old` old committee members (and every new committee member) to be online. Offline old members are excluded from the active set after the caller closes the ready window (`close_ready_window()` on the leader, e.g. after a transport timeout); dealers fail over to `min(I ∩ Act)`. If an *active* dealer goes offline mid-session or cheats, the protocol still aborts (no mid-session re-deal in this implementation) — restart the session and the dead dealer will be excluded from the next active set.
 - **Secure channels required for Round 4 private messages** (see Transport Security section above)
-- **Cryptographically random entropy required from each old committee member** (see Entropy Requirements section above)
+- **Cryptographically random entropy required from each active old committee member** (see Entropy Requirements section above)
 
 ## Coefficient Growth and Signing Security
 

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -114,14 +114,20 @@ Round 2 entropy reveals are part of the public transcript. After Round 2, the `s
 
 ### Security Boundary
 
-Before Round 2 reveals are known, an attacker cannot predict the session seed unless they know every old committee member's entropy contribution. After Round 2, the seed is public. The protocol's replay protection comes from the SSID, which binds messages to the old committee, new committee, public key, and session nonce. The protocol's confidentiality depends on keeping Round 4 private messages encrypted and authenticated.
+Before Round 2 reveals are known, an attacker cannot predict the session seed unless they know every old committee member's entropy contribution. After Round 2, the seed is public. The protocol's replay protection comes from the SSID, which binds messages to the protocol version, cryptographic suite, handoff epoch, old committee, new committee, public key, and session nonce. The protocol's confidentiality depends on keeping Round 4 private messages encrypted and authenticated.
+
+### Mandatory Erasure at Finalize
+
+Because sub-share derivation is deterministic from the (public, post-Round-2) session seed and the old subset shares, erasure of pre-handoff state is the compensating control for forward secrecy: an attacker must compromise a machine **while it still holds old material** to recompute the handoff.
+
+On successful completion (`Action::Return`), the protocol zeroizes, in place: the caller-provided seed, this party's entropy, the session seed, all derived sub-shares `r_{I→J}`, all received Round 4 messages, the aggregated new-share working set, and — for old committee members — **the old share held in the config**. `old_share_erased()` reports whether the config's share is gone. The same erasure runs again on `Drop` (covering abort paths). Callers must still erase their own copies: the original share file/keystore entry and anything cloned before `ResharingConfig::new`.
 
 ## Security Properties
 
 | Property | Guarantee |
 |----------|-----------|
 | **Secrecy of `s`** | No party — not even any dealer — ever holds `s` in clear. Each `D_I` only handles `s_I^old`, which they already had. |
-| **Replay protection** | Every message carries an SSID derived from the old/new committees, public key, and session nonce. Messages with a mismatched SSID are ignored. |
+| **Replay protection** | Every message carries an SSID derived from the protocol version, suite ID, handoff epoch, old/new committees, public key, and session nonce (`RESHARING_SSID_V2`). Messages with a mismatched SSID are ignored; transcripts from other protocol versions, suites, or epochs cannot be replayed. |
 | **Session randomization** | Session seed incorporates the SSID and fresh entropy from all active old committee members via commit-reveal, so different sessions produce different deterministic sub-share splits even if entropy is accidentally reused. This does not provide post-compromise forward secrecy once the transcript is recorded. |
 | **Liveness with offline old members** | Round 1 commitments double as Ready signals. The session leader (lowest-ID new committee member) proposes the active set `Act` of ready members (`|Act| ≥ t_old`); dealers are assigned as `min(I ∩ Act)`, so resharing completes with up to `n_old − t_old` old members offline. The leader cannot break safety: parties verify `Act` against the Ready signals they received themselves, sub-share derivation is deterministic (dealer identity doesn't change values), and the seed stays unbiased because `Act` is fixed before any entropy is revealed and contains at least one honest member. A malicious leader can at most deny service or select among ready members; equivocating proposals lead to mismatched deterministic commitments and an abort. |
 | **Confidentiality of contributions** | Rounds 1-3, 5 broadcast only hash commitments; Round 4 sub-shares travel privately. Even an unbounded eavesdropper learns nothing about any `s_I^old` from the public transcript. |
@@ -177,6 +183,8 @@ sqrt(τ) · sqrt(||p_{i,1}||² / ν² + ||p_{i,2}||²) ≤ B'
 
 for the existing `(t_new, n_new)` hyperball parameters. This catches bounded, public-key-preserving zero-sum reshaping attacks that would pass the per-subshare coefficient bound but push later signing outside the intended proof regime.
 
+Round 5 additionally enforces a per-subset **stored-share norm guard** (`B_G` analog): each aggregated `s_J^new` individually must satisfy the same weighted-norm bound with `num_secrets = 1` (a single base secret's envelope, versus the `⌈C(N,T−1)/T⌉` shares summed at recovery time). This is defense in depth against inflating an individual stored share while arranging cancellation in the specific combinations the recovered-partial check sums.
+
 ## Usage
 
 ```rust
@@ -212,7 +220,9 @@ let signer_config = ResharingSignerConfig::new(
 )?;
 
 // Old committee members pass Some(existing_share); new-only parties pass None.
-let mut protocol = ResharingProtocol::new(config, signer_config, seed, &session_nonce)?;
+// `epoch` is a monotonic handoff counter for this public key (0 for the first
+// resharing after keygen), bound into the SSID against cross-epoch replay.
+let mut protocol = ResharingProtocol::new(config, signer_config, seed, &session_nonce, epoch)?;
 
 // Run protocol loop
 loop {

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -71,6 +71,20 @@ Round 5: Verification + Public-Key Invariant
 │   even when their old subset has size 1.
 └── If any verification fails, the protocol aborts. (No blame attribution is
     attempted since it's not always possible to identify the misbehaving party.)
+
+Round 6: Signed Transcript Acceptance (Certificate)
+├── After all Round 5 checks pass, each party computes the transcript hash:
+│   SHAKE256("resharing-transcript-v1" || ssid || Act || session_seed ||
+│   Round 3 broadcasts (Act, sorted) || Round 5 broadcasts (Act ∪ new, sorted)).
+├── Each new committee member signs
+│   SHAKE256("resharing-accept-v1" || ssid || transcript_hash) with its
+│   long-term key (TranscriptSigner) and broadcasts the signature.
+├── Every party verifies every acceptance against its *own* transcript hash.
+│   A dealer that equivocated (sent different broadcasts to different parties)
+│   causes verification to fail on at least one honest party, which aborts.
+└── The output includes a ResharingCertificate (ssid, Act, transcript hash,
+    acceptance signatures) verifiable by any third party holding the new
+    committee's verifying keys.
 ```
 
 Because `Σ_J s_J^new = Σ_J Σ_I r_{I→J} = Σ_I s_I^old = s`, the secret — and hence the public key `t = A·s1 + s2` — is preserved.
@@ -113,6 +127,7 @@ Before Round 2 reveals are known, an attacker cannot predict the session seed un
 | **Confidentiality of contributions** | Rounds 1-3, 5 broadcast only hash commitments; Round 4 sub-shares travel privately. Even an unbounded eavesdropper learns nothing about any `s_I^old` from the public transcript. |
 | **Cheating-dealer detection** | Old-subset peers recompute and verify Round 3 commitments before Round 4 whenever the old subset has another member. New-subset members verify delivered sub-shares against Round 3 commitments, reject over-large sub-share coefficients, and reject recovered signing partials that exceed the existing hyperball safety envelope. A final partial-public-key sum check reconstructs `T` from `Σ_J t_J^new`, catching aggregate-secret corruption even when an old subset has size 1. If any verification fails, the protocol aborts. |
 | **PK Preservation** | Public key `t = A·s1 + s2` unchanged, verified at the end of Round 5 via a deterministic byte-equality check against the original PK. |
+| **Transcript agreement + attestation** | Round 6: every new committee member signs the transcript hash with its long-term key; every party verifies all acceptances against its own transcript hash, so completion implies all parties observed identical broadcasts (equivocation ⇒ abort). The resulting `ResharingCertificate` lets a third party holding the new committee's verifying keys confirm the whole new committee attested to the handoff. It attests process integrity and PK preservation, not share-distribution properties (that would require ZK proofs). |
 
 ## Why Custom Protocol?
 
@@ -166,7 +181,7 @@ for the existing `(t_new, n_new)` hyperball parameters. This catches bounded, pu
 
 ```rust
 use qp_rusty_crystals_threshold::resharing::{
-    ResharingConfig, ResharingProtocol, Action,
+    ResharingConfig, ResharingProtocol, ResharingSignerConfig, Action,
 };
 use rand::RngCore;
 
@@ -188,8 +203,16 @@ let config = ResharingConfig::new(
     public_key,
 )?;
 
+// Long-term-key signer for Round 6 transcript acceptance (e.g. Ed25519),
+// plus the verifying keys of every new committee member.
+let signer_config = ResharingSignerConfig::new(
+    my_signer,          // implements TranscriptSigner
+    verifying_keys,     // BTreeMap<ParticipantId, PublicKey>, covers new committee
+    &new_participants,
+)?;
+
 // Old committee members pass Some(existing_share); new-only parties pass None.
-let mut protocol = ResharingProtocol::new(config, my_existing_share, seed, &session_nonce)?;
+let mut protocol = ResharingProtocol::new(config, signer_config, seed, &session_nonce)?;
 
 // Run protocol loop
 loop {
@@ -201,6 +224,8 @@ loop {
         Action::Return(output) => {
             // Resharing complete
             let new_share = output.private_share;
+            // Publicly verifiable proof of the handoff:
+            let certificate = output.certificate;
             break;
         }
     }
@@ -220,7 +245,7 @@ provide its own encryption layer.
 
 | Message Type | Transport Requirement |
 |--------------|----------------------|
-| `Action::SendMany` (Rounds 1, 2, 3, 5) | Authenticated broadcast (integrity only) |
+| `Action::SendMany` (Rounds 1, 2, 3, 5, 6) | Authenticated broadcast (integrity only) |
 | `Action::SendPrivate` (Round 4) | **Authenticated encryption required** (confidentiality + integrity) |
 
 If `SendPrivate` messages are sent over an unencrypted channel, an eavesdropper can recover
@@ -263,13 +288,15 @@ Each party has a role determined by committee membership:
 - `Round3Broadcast`: Per-subset commitment hashes `H(r_{I→J})` (no plaintext shares)
 - `Round4Message`: Private sub-share reveal (**requires secure channel**) — one message per (dealer, recipient) carrying every `r_{I→J}` the dealer owes that recipient. Dealers handle self-deals locally and never emit `SendPrivate(self, _)`.
 - `Round5Broadcast`: Commitments to computed `s_J^new`, partial public-key contributions `t_J^new`
+- `Accept`: Signed acceptance of the transcript hash by a new committee member (Round 6); the collected signatures form the `ResharingCertificate`
 
 ## State Machine
 
 ```
 Round1Generate -> Round1Waiting -> Round2Generate -> Round2Waiting
     -> Round3Generate -> Round3Waiting -> Round4Generate -> Round4Waiting
-    -> Round5Generate -> Round5Waiting -> Combining -> Done
+    -> Round5Generate -> Round5Waiting -> Combining
+    -> AcceptGenerate -> AcceptWaiting -> Done
 ```
 
 NewOnly parties skip Rounds 1-2 (entropy commit-reveal) and go directly to `Round2Waiting`. The Act proposal is emitted and consumed within the `Round1Waiting`/`Round2Waiting` states; parties do not advance past them until `Act` is agreed. Old members outside `Act` observe (they verify and, if in the new committee, receive shares) but do not contribute entropy or deal.

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -32,12 +32,18 @@ Round 1: Entropy Commitment / Ready (Session Randomization)
 
 Act Proposal (Active-Set Selection)
 ├── The session leader (lowest-ID new committee member) proposes the active set Act:
-│   all old members once everyone has committed (fast path), or the committed subset
-│   after the caller closes the ready window (close_ready_window(), e.g. on a
-│   transport timeout).
+│   all old members once everyone has committed (fast path), the committed subset
+│   once every *expected* member has committed (set_expected_active_set(), for
+│   transports where some old members are structurally unreachable), or the
+│   committed subset after the caller closes the ready window
+│   (close_ready_window(), e.g. on a transport timeout).
 ├── Every party verifies: sender is the leader, Act ⊆ old committee, |Act| ≥ t_old.
 │   |Act| ≥ t_old guarantees every old subset I (size n_old − t_old + 1) intersects
 │   Act, so a live dealer exists for every subset.
+├── No party broadcasts its Round 2 reveal until it holds a Round 1 commitment from
+│   every Act member: every contributor's entropy is fixed before any reveal is
+│   sent, so a colluding member listed in Act cannot choose its entropy after
+│   seeing honest reveals to bias the session seed.
 └── If fewer than t_old old members are ready, the protocol aborts
     (InsufficientParties).
 
@@ -129,7 +135,7 @@ On successful completion (`Action::Return`), the protocol zeroizes, in place: th
 | **Secrecy of `s`** | No party — not even any dealer — ever holds `s` in clear. Each `D_I` only handles `s_I^old`, which they already had. |
 | **Replay protection** | Every message carries an SSID derived from the protocol version, suite ID, handoff epoch, old/new committees, public key, and session nonce (`RESHARING_SSID_V2`). Messages with a mismatched SSID are ignored; transcripts from other protocol versions, suites, or epochs cannot be replayed. |
 | **Session randomization** | Session seed incorporates the SSID and fresh entropy from all active old committee members via commit-reveal, so different sessions produce different deterministic sub-share splits even if entropy is accidentally reused. This does not provide post-compromise forward secrecy once the transcript is recorded. |
-| **Liveness with offline old members** | Round 1 commitments double as Ready signals. The session leader (lowest-ID new committee member) proposes the active set `Act` of ready members (`|Act| ≥ t_old`); dealers are assigned as `min(I ∩ Act)`, so resharing completes with up to `n_old − t_old` old members offline. The leader cannot break safety: parties verify `Act` against the Ready signals they received themselves, sub-share derivation is deterministic (dealer identity doesn't change values), and the seed stays unbiased because `Act` is fixed before any entropy is revealed and contains at least one honest member. A malicious leader can at most deny service or select among ready members; equivocating proposals lead to mismatched deterministic commitments and an abort. |
+| **Liveness with offline old members** | Round 1 commitments double as Ready signals. The session leader (lowest-ID new committee member) proposes the active set `Act` of ready members (`|Act| ≥ t_old`); dealers are assigned as `min(I ∩ Act)`, so resharing completes with up to `n_old − t_old` old members offline. Transports where some old members are structurally unreachable (e.g. a mesh spanning only the new committee) can use `set_expected_active_set` on the leader for a deterministic proposal without waiting for a timeout. The leader cannot break safety: parties verify `Act` against the Ready signals they received themselves, no party reveals entropy until it holds commitments from all of `Act` (so every contributor's entropy is fixed before any reveal), sub-share derivation is deterministic (dealer identity doesn't change values), and the seed stays unbiased because `Act` contains at least one honest member. A malicious leader can at most deny service or select among ready members; equivocating proposals lead to mismatched deterministic commitments and an abort. |
 | **Confidentiality of contributions** | Rounds 1-3, 5 broadcast only hash commitments; Round 4 sub-shares travel privately. Even an unbounded eavesdropper learns nothing about any `s_I^old` from the public transcript. |
 | **Cheating-dealer detection** | Old-subset peers recompute and verify Round 3 commitments before Round 4 whenever the old subset has another member. New-subset members verify delivered sub-shares against Round 3 commitments, reject over-large sub-share coefficients, and reject recovered signing partials that exceed the existing hyperball safety envelope. A final partial-public-key sum check reconstructs `T` from `Σ_J t_J^new`, catching aggregate-secret corruption even when an old subset has size 1. If any verification fails, the protocol aborts. |
 | **PK Preservation** | Public key `t = A·s1 + s2` unchanged, verified at the end of Round 5 via a deterministic byte-equality check against the original PK. |
@@ -314,7 +320,7 @@ NewOnly parties skip Rounds 1-2 (entropy commit-reveal) and go directly to `Roun
 ## Limitations
 
 - Maximum 16 parties (due to u16 subset masks)
-- Requires at least `t_old` old committee members (and every new committee member) to be online. Offline old members are excluded from the active set after the caller closes the ready window (`close_ready_window()` on the leader, e.g. after a transport timeout); dealers fail over to `min(I ∩ Act)`. If an *active* dealer goes offline mid-session or cheats, the protocol still aborts (no mid-session re-deal in this implementation) — restart the session and the dead dealer will be excluded from the next active set.
+- Requires at least `t_old` old committee members (and every new committee member) to be online. Offline old members are excluded from the active set after the caller closes the ready window (`close_ready_window()` on the leader, e.g. after a transport timeout), or deterministically via `set_expected_active_set()` on the leader when the transport makes some old members structurally unreachable; dealers fail over to `min(I ∩ Act)`. If an *active* dealer goes offline mid-session or cheats, the protocol still aborts (no mid-session re-deal in this implementation) — restart the session and the dead dealer will be excluded from the next active set.
 - **Secure channels required for Round 4 private messages** (see Transport Security section above)
 - **Cryptographically random entropy required from each active old committee member** (see Entropy Requirements section above)
 

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -61,8 +61,9 @@
 //!
 //! - **Secrecy of `s`**: No party — not even the designated dealers — ever reconstructs the full
 //!   secret `s`. Each `D_I` only handles `s_I^old`, which they already had.
-//! - **Replay protection**: Each message includes an SSID derived from the old/new committees, the
-//!   public key, and a session nonce. Messages with a different SSID are ignored.
+//! - **Replay protection**: Each message includes an SSID derived from the protocol version,
+//!   suite ID, handoff epoch, old/new committees, the public key, and a session nonce. Messages
+//!   with a different SSID are ignored.
 //! - **Session randomization**: Rounds 1-2 commit to and reveal fresh entropy before deriving a
 //!   public session seed, making sub-share splits unpredictable before reveal and different across
 //!   fresh sessions. This is not post-compromise forward secrecy: a recorded transcript plus later
@@ -94,6 +95,11 @@
 //!
 //! This matches the standard proactive secret sharing model: security holds if fewer than `t`
 //! parties are compromised in any single epoch, with proper old-state erasure between epochs.
+//!
+//! The protocol erases its own session state at finalize: on successful completion it zeroizes
+//! the seed, entropy, session seed, derived and received sub-shares, and the old share held in
+//! its config (check via `ResharingProtocol::old_share_erased`). Callers remain responsible for
+//! erasing their own copies of the old share (key files, keystore entries).
 //!
 //! # Why Custom Protocol?
 //!
@@ -131,7 +137,8 @@
 //! let signer_config = ResharingSignerConfig::new(my_signer, verifying_keys, &new_participants)?;
 //!
 //! // Old committee members pass Some(existing_share); new-only parties pass None.
-//! let mut protocol = ResharingProtocol::new(config, signer_config, seed, &session_nonce)?;
+//! // `epoch` is a monotonic handoff counter for this key (0 = first resharing).
+//! let mut protocol = ResharingProtocol::new(config, signer_config, seed, &session_nonce, epoch)?;
 //!
 //! loop {
 //!     match protocol.poke()? {
@@ -160,7 +167,8 @@ pub use types::{
 	ResharingOutput, ResharingRole, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
 	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast,
 	ResharingSignerConfig, SubsetMask, SubsetPair, ENTROPY_SIZE, MAX_ACCEPT_SIGNATURE_LEN,
-	RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
+	RESHARING_SSID_SIZE, RESHARING_PROTOCOL_VERSION, RESHARING_SUITE_ML_DSA_87,
+	SUBSHARE_COEFF_BOUND,
 };
 
 // Re-export the long-term-key signing trait used for Round 6 acceptance, so

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -22,18 +22,25 @@
 //! Resharing uses **distributed per-subset re-sharing** with replay protection and public session
 //! randomization:
 //!
-//! ## Protocol Rounds (5-round session-randomized protocol)
+//! ## Protocol Rounds (session-randomized protocol with active-set liveness)
 //!
-//! - **Round 1**: Entropy commitment - old committee broadcasts `H(entropy)`
-//! - **Round 2**: Entropy reveal - old committee reveals entropy and a public session seed is
+//! - **Round 1**: Entropy commitment / Ready - old committee broadcasts `H(entropy)`
+//! - **Act proposal**: The session leader (lowest-ID new committee member) proposes the active
+//!   set `Act` of ready old members. All old members once everyone commits (fast path), or the
+//!   committed subset after [`ResharingProtocol::close_ready_window`] — requires `|Act| >=
+//!   t_old`, so resharing succeeds even when up to `n_old - t_old` old members are offline
+//! - **Round 2**: Entropy reveal - active members reveal entropy and a public session seed is
 //!   computed
 //! - **Round 3**: Sub-share commitments - designated dealers broadcast `H(r_{I→J})`
 //! - **Round 4**: Private delivery - dealers send `r_{I→J}` to new committee (**secure channel**)
 //! - **Round 5**: Verification - share commitments, partial PKs
 //!
 //! For each old RSS subset `I` (a `k_old`-subset of the old committee whose members all hold the
-//! η-bounded share `s_I^old`), the lowest-ID member of `I` (the "designated dealer" `D_I`)
-//! re-shares `s_I^old` to the new committee:
+//! η-bounded share `s_I^old`), the lowest-ID *active* member of `I` (the "designated dealer"
+//! `D_I = min(I ∩ Act)`) re-shares `s_I^old` to the new committee. Because `|Act| >= t_old` and
+//! `|I| = n_old - t_old + 1`, every old subset has a live dealer; all members of `I` hold the
+//! same `s_I^old` and derivation is deterministic, so dealer identity does not affect the
+//! derived values:
 //!
 //! 1. `D_I` deterministically derives sub-shares `r_{I→J}` for every new RSS subset `J`, such that
 //!    `Σ_J r_{I→J} = s_I^old`. The derivation incorporates the public session seed from Rounds 1-2
@@ -137,8 +144,8 @@ mod types;
 
 // Re-export public types
 pub use types::{
-	compute_resharing_ssid, NewShareData, ResharingConfig, ResharingMessage, ResharingOutput,
-	ResharingRole, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
+	compute_resharing_ssid, NewShareData, ResharingActProposal, ResharingConfig, ResharingMessage,
+	ResharingOutput, ResharingRole, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
 	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast, SubsetMask,
 	SubsetPair, ENTROPY_SIZE, RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
 };

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -10,7 +10,7 @@
 //! in plaintext and **MUST** be transmitted over an authenticated-encrypted channel.
 //! This protocol does not provide its own encryption layer.
 //!
-//! - `Action::SendMany` (Rounds 1, 2, 3, 5): Requires authenticated broadcast (integrity)
+//! - `Action::SendMany` (Rounds 1, 2, 3, 5, 6): Requires authenticated broadcast (integrity)
 //! - `Action::SendPrivate` (Round 4): **Requires authenticated encryption** (confidentiality +
 //!   integrity)
 //!
@@ -34,6 +34,9 @@
 //! - **Round 3**: Sub-share commitments - designated dealers broadcast `H(r_{I→J})`
 //! - **Round 4**: Private delivery - dealers send `r_{I→J}` to new committee (**secure channel**)
 //! - **Round 5**: Verification - share commitments, partial PKs
+//! - **Round 6**: Signed transcript acceptance - new committee members sign the transcript hash
+//!   with their long-term keys ([`TranscriptSigner`]); the collected signatures form a publicly
+//!   verifiable [`ResharingCertificate`]
 //!
 //! For each old RSS subset `I` (a `k_old`-subset of the old committee whose members all hold the
 //! η-bounded share `s_I^old`), the lowest-ID *active* member of `I` (the "designated dealer"
@@ -69,6 +72,10 @@
 //! - **Cheating-dealer detection**: New subset members cross-verify computed `s_J^new` values;
 //!   public-key invariant verification catches inconsistent dealing.
 //! - **Public key preservation**: `t = A·s1 + s2` is unchanged.
+//! - **Transcript agreement + attestation**: Round 6 acceptance signatures are verified by every
+//!   party against its own transcript hash, so completion implies all parties observed identical
+//!   broadcasts (equivocation causes an abort). The resulting certificate is verifiable by third
+//!   parties holding the new committee's verifying keys.
 //!
 //! # Proactive Security Model
 //!
@@ -98,7 +105,7 @@
 //!
 //! ```ignore
 //! use qp_rusty_crystals_threshold::resharing::{
-//!     ResharingConfig, ResharingProtocol, Action,
+//!     ResharingConfig, ResharingProtocol, ResharingSignerConfig, Action,
 //! };
 //! use rand::RngCore;
 //!
@@ -120,8 +127,11 @@
 //!     public_key,
 //! )?;
 //!
+//! // Long-term-key signer (e.g. Ed25519) + new committee's verifying keys for Round 6.
+//! let signer_config = ResharingSignerConfig::new(my_signer, verifying_keys, &new_participants)?;
+//!
 //! // Old committee members pass Some(existing_share); new-only parties pass None.
-//! let mut protocol = ResharingProtocol::new(config, existing_share, seed, &session_nonce)?;
+//! let mut protocol = ResharingProtocol::new(config, signer_config, seed, &session_nonce)?;
 //!
 //! loop {
 //!     match protocol.poke()? {
@@ -132,6 +142,7 @@
 //!         Action::Return(output) => {
 //!             // Resharing complete!
 //!             let new_share = output.private_share;
+//!             let certificate = output.certificate; // publicly verifiable
 //!             break;
 //!         }
 //!     }
@@ -144,11 +155,17 @@ mod types;
 
 // Re-export public types
 pub use types::{
-	compute_resharing_ssid, NewShareData, ResharingActProposal, ResharingConfig, ResharingMessage,
+	compute_accept_hash, compute_resharing_ssid, NewShareData, ResharingAccept,
+	ResharingActProposal, ResharingCertificate, ResharingConfig, ResharingMessage,
 	ResharingOutput, ResharingRole, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
-	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast, SubsetMask,
-	SubsetPair, ENTROPY_SIZE, RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
+	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast,
+	ResharingSignerConfig, SubsetMask, SubsetPair, ENTROPY_SIZE, MAX_ACCEPT_SIGNATURE_LEN,
+	RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
 };
+
+// Re-export the long-term-key signing trait used for Round 6 acceptance, so
+// integrators don't need to reach into the DKG module.
+pub use crate::keygen::dkg::TranscriptSigner;
 
 pub use protocol::{
 	resharing_norm_enlargement, Action, ResharingProtocol, ResharingProtocolError, ResharingState,

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -25,10 +25,10 @@
 //! ## Protocol Rounds (session-randomized protocol with active-set liveness)
 //!
 //! - **Round 1**: Entropy commitment / Ready - old committee broadcasts `H(entropy)`
-//! - **Act proposal**: The session leader (lowest-ID new committee member) proposes the active
-//!   set `Act` of ready old members. All old members once everyone commits (fast path), or the
-//!   committed subset after [`ResharingProtocol::close_ready_window`] — requires `|Act| >=
-//!   t_old`, so resharing succeeds even when up to `n_old - t_old` old members are offline
+//! - **Act proposal**: The session leader (lowest-ID new committee member) proposes the active set
+//!   `Act` of ready old members. All old members once everyone commits (fast path), or the
+//!   committed subset after [`ResharingProtocol::close_ready_window`] — requires `|Act| >= t_old`,
+//!   so resharing succeeds even when up to `n_old - t_old` old members are offline
 //! - **Round 2**: Entropy reveal - active members reveal entropy and a public session seed is
 //!   computed
 //! - **Round 3**: Sub-share commitments - designated dealers broadcast `H(r_{I→J})`
@@ -61,9 +61,9 @@
 //!
 //! - **Secrecy of `s`**: No party — not even the designated dealers — ever reconstructs the full
 //!   secret `s`. Each `D_I` only handles `s_I^old`, which they already had.
-//! - **Replay protection**: Each message includes an SSID derived from the protocol version,
-//!   suite ID, handoff epoch, old/new committees, the public key, and a session nonce. Messages
-//!   with a different SSID are ignored.
+//! - **Replay protection**: Each message includes an SSID derived from the protocol version, suite
+//!   ID, handoff epoch, old/new committees, the public key, and a session nonce. Messages with a
+//!   different SSID are ignored.
 //! - **Session randomization**: Rounds 1-2 commit to and reveal fresh entropy before deriving a
 //!   public session seed, making sub-share splits unpredictable before reveal and different across
 //!   fresh sessions. This is not post-compromise forward secrecy: a recorded transcript plus later
@@ -163,11 +163,11 @@ mod types;
 // Re-export public types
 pub use types::{
 	compute_accept_hash, compute_resharing_ssid, NewShareData, ResharingAccept,
-	ResharingActProposal, ResharingCertificate, ResharingConfig, ResharingMessage,
-	ResharingOutput, ResharingRole, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
+	ResharingActProposal, ResharingCertificate, ResharingConfig, ResharingMessage, ResharingOutput,
+	ResharingRole, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
 	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast,
 	ResharingSignerConfig, SubsetMask, SubsetPair, ENTROPY_SIZE, MAX_ACCEPT_SIGNATURE_LEN,
-	RESHARING_SSID_SIZE, RESHARING_PROTOCOL_VERSION, RESHARING_SUITE_ML_DSA_87,
+	RESHARING_PROTOCOL_VERSION, RESHARING_SSID_SIZE, RESHARING_SUITE_ML_DSA_87,
 	SUBSHARE_COEFF_BOUND,
 };
 

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -59,11 +59,14 @@ use crate::{
 };
 
 use super::types::{
-	compute_resharing_ssid, NewShareData, ResharingActProposal, ResharingConfig, ResharingMessage,
+	compute_accept_hash, compute_resharing_ssid, NewShareData, ResharingAccept,
+	ResharingActProposal, ResharingCertificate, ResharingConfig, ResharingMessage,
 	ResharingOutput, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
-	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast, SubsetMask,
-	SubsetPair, COMMITMENT_HASH_SIZE, ENTROPY_SIZE, RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
+	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast,
+	ResharingSignerConfig, SubsetMask, SubsetPair, COMMITMENT_HASH_SIZE, ENTROPY_SIZE,
+	RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
 };
+use crate::keygen::dkg::TranscriptSigner;
 
 /// Domain separator for the per-subset PRF seed (includes public session seed for randomization).
 const SUBSET_SEED_DOMAIN: &[u8] = b"resharing-subset-prf-v3";
@@ -108,6 +111,9 @@ const NEW_SHARE_COMMIT_DOMAIN: &[u8] = b"resharing-new-share-commit-v3";
 
 /// Domain separator for entropy commitment.
 const ENTROPY_COMMIT_DOMAIN: &[u8] = b"resharing-entropy-commit-v1";
+
+/// Domain separator for the session transcript hash (Round 6 acceptance).
+const TRANSCRIPT_DOMAIN: &[u8] = b"resharing-transcript-v1";
 
 /// Domain separator for session seed derivation.
 const SESSION_SEED_DOMAIN: &[u8] = b"resharing-session-seed-v1";
@@ -267,6 +273,10 @@ pub enum ResharingState {
 	Round5Waiting,
 	/// Combining shares and finalizing.
 	Combining,
+	/// Generating the Round 6 acceptance signature (new committee members).
+	AcceptGenerate,
+	/// Waiting for Round 6 acceptance signatures from all new committee members.
+	AcceptWaiting,
 	/// Protocol completed successfully.
 	Done,
 	/// Protocol failed.
@@ -278,8 +288,12 @@ pub enum ResharingState {
 // ============================================================================
 
 /// The main resharing protocol state machine.
-pub struct ResharingProtocol {
+///
+/// Generic over `S`, the long-term-key signature scheme used for transcript
+/// acceptance (Round 6). See [`TranscriptSigner`] and [`ResharingSignerConfig`].
+pub struct ResharingProtocol<S: TranscriptSigner> {
 	config: ResharingConfig,
+	signer_config: ResharingSignerConfig<S>,
 	state: ResharingState,
 
 	/// Session identifier (SSID) for this resharing session.
@@ -352,9 +366,18 @@ pub struct ResharingProtocol {
 	new_shares: BTreeMap<SubsetMask, NewShareData>,
 	/// Final output (cached so `take_output` can return it after Combining).
 	completed_output: Option<ResharingOutput>,
+
+	// ========================================================================
+	// Round 6: Signed transcript acceptance
+	// ========================================================================
+	/// Transcript hash computed after all Combining checks pass.
+	transcript_hash: Option<[u8; COMMITMENT_HASH_SIZE]>,
+	/// Acceptance signatures received (and our own), keyed by sender. Raw
+	/// bytes; verified against our own transcript hash in `AcceptWaiting`.
+	accepts: BTreeMap<ParticipantId, Vec<u8>>,
 }
 
-impl Drop for ResharingProtocol {
+impl<S: TranscriptSigner> Drop for ResharingProtocol<S> {
 	fn drop(&mut self) {
 		// Zeroize all secret-bearing fields
 		self.seed.zeroize();
@@ -376,7 +399,7 @@ impl Drop for ResharingProtocol {
 	}
 }
 
-impl ResharingProtocol {
+impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// Create a new resharing protocol instance.
 	///
 	/// The config must be created using `ResharingConfig::new_for_old_member` (for old committee
@@ -386,9 +409,16 @@ impl ResharingProtocol {
 	/// # Arguments
 	///
 	/// * `config` - The resharing configuration (includes existing_share for old members)
+	/// * `signer_config` - This party's long-term-key signer plus the new committee's verifying
+	///   keys, used for Round 6 transcript acceptance
 	/// * `seed` - 32 bytes of cryptographic randomness for this party's entropy contribution
 	/// * `session_nonce` - Unique nonce for SSID computation (prevents cross-session replay)
-	pub fn new(config: ResharingConfig, seed: [u8; 32], session_nonce: &[u8; 32]) -> Self {
+	pub fn new(
+		config: ResharingConfig,
+		signer_config: ResharingSignerConfig<S>,
+		seed: [u8; 32],
+		session_nonce: &[u8; 32],
+	) -> Self {
 		let old_participants: Vec<_> = config.old_participants().iter().collect();
 		let new_participants: Vec<_> = config.new_participants().iter().collect();
 		let ssid = compute_resharing_ssid(
@@ -405,6 +435,7 @@ impl ResharingProtocol {
 		let new_subset_order = compute_new_subset_order(&config);
 		Self {
 			config,
+			signer_config,
 			state: ResharingState::Round1Generate,
 			ssid,
 			seed,
@@ -425,6 +456,8 @@ impl ResharingProtocol {
 			round5_broadcasts: BTreeMap::new(),
 			new_shares: BTreeMap::new(),
 			completed_output: None,
+			transcript_hash: None,
+			accepts: BTreeMap::new(),
 		}
 	}
 
@@ -600,6 +633,8 @@ impl ResharingProtocol {
 			ResharingState::Round5Generate => self.handle_round5_generate(),
 			ResharingState::Round5Waiting => self.handle_round5_waiting(),
 			ResharingState::Combining => self.handle_combining(),
+			ResharingState::AcceptGenerate => self.handle_accept_generate(),
+			ResharingState::AcceptWaiting => self.handle_accept_waiting(),
 			ResharingState::Done =>
 				Err(ResharingProtocolError::InvalidState("Protocol already completed".to_string())),
 			ResharingState::Failed(reason) =>
@@ -659,6 +694,7 @@ impl ResharingProtocol {
 			ResharingMessage::Round4(m) => self.handle_round4_message(from, m),
 			ResharingMessage::Round5(broadcast) => self.handle_round5_message(from, broadcast),
 			ResharingMessage::ActProposal(m) => self.handle_act_proposal(from, m),
+			ResharingMessage::Accept(m) => self.handle_accept_message(from, m),
 		}
 
 		Ok(())
@@ -1345,10 +1381,194 @@ impl ResharingProtocol {
 		// a malicious dealer that lies about a residual `r_{I→J}`.
 		self.verify_public_key_preservation()?;
 
-		let output = self.build_output()?;
+		// All checks passed: fix the transcript hash and move to the signed
+		// acceptance round.
+		self.transcript_hash = Some(self.compute_transcript_hash()?);
+		self.state = ResharingState::AcceptGenerate;
+		self.poke()
+	}
+
+	// ========================================================================
+	// Round 6: Signed Transcript Acceptance
+	// ========================================================================
+
+	/// Hash of everything that determines the session outcome: the active set,
+	/// the session seed, every active member's Round 3 dealer commitments, and
+	/// every *required* Round 5 broadcast (active old members + new committee).
+	///
+	/// Broadcasts from parties outside the required sets (e.g. a non-active
+	/// old observer's Round 5 status) are deliberately excluded: not every
+	/// party is guaranteed to have received them, and including them would
+	/// make honest parties disagree on the hash.
+	fn compute_transcript_hash(
+		&self,
+	) -> Result<[u8; COMMITMENT_HASH_SIZE], ResharingProtocolError> {
+		let act = self.active_set.as_ref().ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"Computing transcript hash before active set is agreed".to_string(),
+			)
+		})?;
+		let session_seed = self.session_seed.as_ref().ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"Computing transcript hash before session seed".to_string(),
+			)
+		})?;
+
+		let mut state = fips202::KeccakState::default();
+		fips202::shake256_absorb(&mut state, TRANSCRIPT_DOMAIN);
+		fips202::shake256_absorb(&mut state, &self.ssid);
+		fips202::shake256_absorb(&mut state, &(act.len() as u32).to_le_bytes());
+		for &p in act {
+			fips202::shake256_absorb(&mut state, &p.to_le_bytes());
+		}
+		fips202::shake256_absorb(&mut state, session_seed);
+
+		// Round 3 dealer commitments from active members, in Act (sorted) order.
+		// (`round3_broadcasts` includes our own broadcast.)
+		for &p in act {
+			let broadcast = self.round3_broadcasts.get(&p);
+			let broadcast = broadcast.ok_or_else(|| {
+				ResharingProtocolError::InternalError(format!(
+					"Missing Round 3 broadcast from active party {} for transcript",
+					p
+				))
+			})?;
+			let bytes = borsh::to_vec(broadcast).map_err(|e| {
+				ResharingProtocolError::SerializationError(format!(
+					"Failed to serialize Round 3 broadcast for transcript: {}",
+					e
+				))
+			})?;
+			fips202::shake256_absorb(&mut state, &(bytes.len() as u32).to_le_bytes());
+			fips202::shake256_absorb(&mut state, &bytes);
+		}
+
+		// Required Round 5 broadcasts: active old members + new committee, in
+		// sorted order (matches `have_all_round5`).
+		let required: alloc::collections::BTreeSet<ParticipantId> =
+			act.iter().copied().chain(self.config.new_participants().iter()).collect();
+		for p in required {
+			let broadcast = self.round5_broadcasts.get(&p).ok_or_else(|| {
+				ResharingProtocolError::InternalError(format!(
+					"Missing Round 5 broadcast from required party {} for transcript",
+					p
+				))
+			})?;
+			let bytes = borsh::to_vec(broadcast).map_err(|e| {
+				ResharingProtocolError::SerializationError(format!(
+					"Failed to serialize Round 5 broadcast for transcript: {}",
+					e
+				))
+			})?;
+			fips202::shake256_absorb(&mut state, &(bytes.len() as u32).to_le_bytes());
+			fips202::shake256_absorb(&mut state, &bytes);
+		}
+
+		fips202::shake256_finalize(&mut state);
+		let mut out = [0u8; COMMITMENT_HASH_SIZE];
+		fips202::shake256_squeeze(&mut out, &mut state);
+		Ok(out)
+	}
+
+	fn handle_accept_generate(
+		&mut self,
+	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
+		let transcript_hash = self.transcript_hash.ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"AcceptGenerate reached without a transcript hash".to_string(),
+			)
+		})?;
+
+		// Only new committee members attest: they are the parties that verified
+		// and now hold the reshared key material. Old-only parties observe.
+		if !self.config.role().is_new_committee() {
+			self.state = ResharingState::AcceptWaiting;
+			return self.handle_accept_waiting();
+		}
+
+		let accept_hash = compute_accept_hash(&self.ssid, &transcript_hash);
+		let signature = self.signer_config.my_signer.sign(&accept_hash);
+		let my_id = self.config.my_party_id();
+		self.accepts.insert(my_id, signature.as_ref().to_vec());
+
+		let msg = ResharingAccept {
+			ssid: self.ssid,
+			party_id: my_id,
+			signature: signature.as_ref().to_vec(),
+		};
+		let data = Self::serialize_message(&ResharingMessage::Accept(msg))?;
+		self.state = ResharingState::AcceptWaiting;
+		Ok(Action::SendMany(data))
+	}
+
+	fn handle_accept_waiting(
+		&mut self,
+	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
+		let transcript_hash = self.transcript_hash.ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"AcceptWaiting reached without a transcript hash".to_string(),
+			)
+		})?;
+
+		// Need an acceptance from every new committee member.
+		let new_participants: Vec<ParticipantId> =
+			self.config.new_participants().iter().collect();
+		if !new_participants.iter().all(|p| self.accepts.contains_key(p)) {
+			return Ok(Action::Wait);
+		}
+
+		// Verify every signature against *our own* transcript hash. A signer
+		// that observed a different transcript (dealer equivocation, tampered
+		// broadcast) produces a signature that fails here, and we abort.
+		let accept_hash = compute_accept_hash(&self.ssid, &transcript_hash);
+		for p in &new_participants {
+			let pk = self.signer_config.verifying_keys.get(p).ok_or_else(|| {
+				ResharingProtocolError::InternalError(format!(
+					"Missing verifying key for new committee member {} (validated at config)",
+					p
+				))
+			})?;
+			let sig = self.accepts.get(p).expect("presence checked above");
+			if !S::verify_bytes(pk, &accept_hash, sig) {
+				let reason = format!(
+					"invalid transcript acceptance from party {} — transcript disagreement \
+					 or forged signature",
+					p
+				);
+				self.state = ResharingState::Failed(reason.clone());
+				return Err(ResharingProtocolError::ShareVerificationFailed(reason));
+			}
+		}
+
+		let certificate = ResharingCertificate {
+			ssid: self.ssid,
+			active_set: self.active_set.clone().expect("set before transcript hash"),
+			transcript_hash,
+			accepts: self.accepts.clone(),
+		};
+
+		let output = self.build_output(certificate)?;
 		self.completed_output = Some(output.clone());
 		self.state = ResharingState::Done;
 		Ok(Action::Return(output))
+	}
+
+	fn handle_accept_message(&mut self, from: ParticipantId, msg: ResharingAccept) {
+		if matches!(self.state, ResharingState::Done | ResharingState::Failed(_)) {
+			return;
+		}
+		// Only new committee members attest.
+		if !self.config.new_participants().contains(from) {
+			return;
+		}
+		// First message wins; duplicates ignored (matches other rounds).
+		if self.accepts.contains_key(&from) {
+			return;
+		}
+		// Signature verification is deferred to `AcceptWaiting`, where our own
+		// transcript hash is known. Accepts can legitimately arrive earlier
+		// (e.g. while we are still draining Round 5 traffic).
+		self.accepts.insert(from, msg.signature);
 	}
 
 	// ========================================================================
@@ -1815,12 +2035,16 @@ impl ResharingProtocol {
 		Ok(())
 	}
 
-	fn build_output(&self) -> Result<ResharingOutput, ResharingProtocolError> {
+	fn build_output(
+		&self,
+		certificate: ResharingCertificate,
+	) -> Result<ResharingOutput, ResharingProtocolError> {
 		if !self.config.role().is_new_committee() {
 			return Ok(ResharingOutput {
 				private_share: None,
 				public_key: self.config.public_key().clone(),
 				new_config: self.config.new_config(),
+				certificate,
 			});
 		}
 		let new_share = self.build_private_key_share()?;
@@ -1828,6 +2052,7 @@ impl ResharingProtocol {
 			private_share: Some(new_share),
 			public_key: self.config.public_key().clone(),
 			new_config: self.config.new_config(),
+			certificate,
 		})
 	}
 
@@ -2408,6 +2633,50 @@ mod tests {
 	/// Test SSID for use in unit tests.
 	const TEST_SSID: [u8; RESHARING_SSID_SIZE] = [0xABu8; RESHARING_SSID_SIZE];
 
+	/// Minimal transcript signer for unit tests: "signature" = party_id || hash.
+	#[derive(Clone)]
+	pub(crate) struct TestSigner {
+		pub id: u32,
+	}
+
+	impl TranscriptSigner for TestSigner {
+		type Signature = Vec<u8>;
+		type PublicKey = u32;
+
+		fn sign(&self, hash: &[u8; 32]) -> Self::Signature {
+			let mut sig = vec![0u8; 36];
+			sig[..4].copy_from_slice(&self.id.to_le_bytes());
+			sig[4..36].copy_from_slice(hash);
+			sig
+		}
+
+		fn verify(pk: &Self::PublicKey, hash: &[u8; 32], sig: &Self::Signature) -> bool {
+			Self::verify_bytes(pk, hash, sig)
+		}
+
+		fn verify_bytes(pk: &Self::PublicKey, hash: &[u8; 32], sig: &[u8]) -> bool {
+			if sig.len() < 36 {
+				return false;
+			}
+			let sig_id = u32::from_le_bytes(sig[..4].try_into().unwrap());
+			sig_id == *pk && &sig[4..36] == hash
+		}
+
+		fn public_key(&self) -> Self::PublicKey {
+			self.id
+		}
+	}
+
+	/// Build a `ResharingSignerConfig<TestSigner>` covering `participants`.
+	fn test_signer_config(
+		my_id: u32,
+		participants: &[u32],
+	) -> ResharingSignerConfig<TestSigner> {
+		let keys: BTreeMap<u32, u32> = participants.iter().map(|&p| (p, p)).collect();
+		ResharingSignerConfig::new(TestSigner { id: my_id }, keys, participants)
+			.expect("keys cover participants")
+	}
+
 	#[test]
 	fn test_generate_subset_masks() {
 		let s = generate_subset_masks(3, 2);
@@ -2733,7 +3002,12 @@ mod tests {
 			public_key,
 		)
 		.expect("valid resharing config");
-		let mut protocol = ResharingProtocol::new(resharing_config, [1u8; 32], &[2u8; 32]);
+		let mut protocol = ResharingProtocol::new(
+			resharing_config,
+			test_signer_config(1, &[0, 1, 2]),
+			[1u8; 32],
+			&[2u8; 32],
+		);
 		let session_seed = [9u8; 32];
 		protocol.session_seed = Some(session_seed);
 		// Model the post-Act state: the full old committee is active.
@@ -2792,7 +3066,12 @@ mod tests {
 			public_key,
 		)
 		.expect("valid resharing config");
-		let mut protocol = ResharingProtocol::new(resharing_config, [1u8; 32], &[2u8; 32]);
+		let mut protocol = ResharingProtocol::new(
+			resharing_config,
+			test_signer_config(1, &[0, 1, 2]),
+			[1u8; 32],
+			&[2u8; 32],
+		);
 
 		// This models a bounded zero-sum reshaping attack: +delta on one new RSS
 		// subset and -delta on another preserves the aggregate public key, and each

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -338,6 +338,11 @@ pub struct ResharingProtocol<S: TranscriptSigner> {
 	/// the Ready signals received so far instead of waiting for the full old
 	/// committee.
 	ready_window_closed: bool,
+	/// Set by [`Self::set_expected_active_set`]: the old committee members the
+	/// transport layer expects to be reachable. When set, the leader proposes
+	/// `Act` as soon as every expected member has committed, without waiting
+	/// for the full old committee or a `close_ready_window` timeout.
+	expected_active_set: Option<Vec<ParticipantId>>,
 
 	// ========================================================================
 	// Round 3-4: Sub-share commitment and delivery
@@ -469,6 +474,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			session_seed: None,
 			active_set: None,
 			ready_window_closed: false,
+			expected_active_set: None,
 			my_subshares: BTreeMap::new(),
 			my_round3: None,
 			round3_broadcasts: BTreeMap::new(),
@@ -586,6 +592,57 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		Ok(())
 	}
 
+	/// Declare which old committee members the transport layer expects to be
+	/// reachable (leader only). The leader then proposes the active set as
+	/// soon as every expected member has sent its Round 1 commitment, instead
+	/// of waiting for the full old committee or a `close_ready_window`
+	/// timeout.
+	///
+	/// Use this when the transport topology makes some old members
+	/// *structurally* unreachable — e.g. NEAR MPC's resharing mesh spans only
+	/// the new participant set, so old-only members can never connect and the
+	/// fast path (all old members ready) would stall forever.
+	///
+	/// This is deterministic where `close_ready_window` is timing-dependent:
+	/// commitments from members outside the expected set are still accepted
+	/// (and included in `Act`) if they arrive before the proposal, so this
+	/// never excludes a live member, and safety is unaffected — every party
+	/// still validates the proposed `Act` and reveals only after holding all
+	/// of `Act`'s commitments.
+	///
+	/// Call before or during Rounds 1-2, on the leader. Requires
+	/// `expected ⊆ old committee` and `|expected| ≥ t_old`.
+	pub fn set_expected_active_set(
+		&mut self,
+		expected: &[ParticipantId],
+	) -> Result<(), ResharingProtocolError> {
+		if self.config.my_party_id() != self.leader() {
+			return Err(ResharingProtocolError::InvalidState(format!(
+				"only the session leader ({}) can set the expected active set",
+				self.leader()
+			)));
+		}
+		if self.active_set.is_some() {
+			return Ok(());
+		}
+		let mut expected: Vec<ParticipantId> = expected.to_vec();
+		expected.sort_unstable();
+		expected.dedup();
+		if !expected.iter().all(|p| self.config.old_participants().contains(*p)) {
+			return Err(ResharingProtocolError::InvalidState(
+				"expected active set must be a subset of the old committee".to_string(),
+			));
+		}
+		if expected.len() < self.config.old_threshold() as usize {
+			return Err(ResharingProtocolError::InsufficientParties {
+				required: self.config.old_threshold() as usize,
+				received: expected.len(),
+			});
+		}
+		self.expected_active_set = Some(expected);
+		Ok(())
+	}
+
 	/// Whether `party` is in the agreed active set. `false` until `Act` is known.
 	fn is_active(&self, party: ParticipantId) -> bool {
 		self.active_set.as_ref().is_some_and(|act| act.binary_search(&party).is_ok())
@@ -594,10 +651,11 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// Leader-side active-set proposal.
 	///
 	/// Returns `Some(SendMany(..))` when this party is the leader and the
-	/// proposal is due: either every old committee member has sent its Round 1
-	/// commitment (fast path), or the caller closed the ready window. Aborts
-	/// with `InsufficientParties` if the window was closed with fewer than
-	/// `t_old` ready members.
+	/// proposal is due: every old committee member has sent its Round 1
+	/// commitment (fast path), every *expected* member has committed (when
+	/// [`Self::set_expected_active_set`] was called), or the caller closed
+	/// the ready window. Aborts with `InsufficientParties` if the window was
+	/// closed with fewer than `t_old` ready members.
 	fn maybe_propose_act(
 		&mut self,
 	) -> Result<Option<Action<ResharingOutput>>, ResharingProtocolError> {
@@ -605,7 +663,10 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			return Ok(None);
 		}
 		let have_all = self.round1_entropy_commits.len() >= self.config.old_participants().len();
-		if !have_all && !self.ready_window_closed {
+		let have_expected = self.expected_active_set.as_ref().is_some_and(|expected| {
+			expected.iter().all(|p| self.round1_entropy_commits.contains_key(p))
+		});
+		if !have_all && !have_expected && !self.ready_window_closed {
 			return Ok(None);
 		}
 
@@ -817,10 +878,15 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		if let Some(action) = self.maybe_propose_act()? {
 			return Ok(action);
 		}
-		// Advance once the active set is agreed. Round 1 commitments from Act
-		// members are awaited in Round2Waiting before the session seed is
-		// computed, so there is no need to block on them here.
-		if self.active_set.is_some() {
+		// Advance only once the active set is agreed AND we hold a Round 1
+		// commitment from every Act member. Our Round 2 reveal must not be
+		// broadcast while any Act member's entropy is still unfixed: a
+		// malicious leader could otherwise list a colluding member that
+		// commits only after observing honest reveals, choosing its entropy
+		// adaptively to bias the session seed. (An Act member that never
+		// commits stalls the session, like any active party going silent;
+		// abort on a transport timeout and restart without it.)
+		if self.have_act_commitments() {
 			self.state = ResharingState::Round2Generate;
 			self.poke()
 		} else {
@@ -852,6 +918,15 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			return;
 		}
 		self.round1_entropy_commits.insert(from, msg.commitment);
+	}
+
+	/// Round 1 commitment present for every active-set member. `false` until
+	/// the active set is known.
+	fn have_act_commitments(&self) -> bool {
+		match &self.active_set {
+			Some(act) => act.iter().all(|p| self.round1_entropy_commits.contains_key(p)),
+			None => false,
+		}
 	}
 
 	/// Entropy data (Round 1 commitment + Round 2 reveal) present for every

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -6,20 +6,19 @@
 //! See `resharing/mod.rs` for a full description of the cryptographic protocol.
 //! In short:
 //!
-//! - **Round 1 (Entropy commitment / Ready)**: Old committee members commit to fresh entropy.
-//!   The commitment doubles as a *Ready* signal for active-set selection.
-//! - **Act proposal**: The session leader (lowest-ID new committee member) proposes the active
-//!   set `Act` of old members that will participate: all old members once everyone has committed
-//!   (fast path), or the committed subset after the caller closes the ready window
-//!   ([`ResharingProtocol::close_ready_window`]). Every party checks `Act` is a subset of the
-//!   old committee with `|Act| >= t_old`, which guarantees every old RSS subset intersects `Act`.
-//! - **Round 2 (Entropy reveal)**: Active old committee members reveal entropy. All parties
-//!   compute the public session seed from the active members' reveals after checking the
-//!   commitments.
-//! - **Round 3 (Sub-share commitments)**: Each designated dealer (lowest-ID member of
-//!   `I ∩ Act`) broadcasts hash commitments to deterministic sub-shares `r_{I→J}` derived from
-//!   `s_I^old` and the public session seed. Other active members of the same subset recompute
-//!   and verify those commitments before Round 4.
+//! - **Round 1 (Entropy commitment / Ready)**: Old committee members commit to fresh entropy. The
+//!   commitment doubles as a *Ready* signal for active-set selection.
+//! - **Act proposal**: The session leader (lowest-ID new committee member) proposes the active set
+//!   `Act` of old members that will participate: all old members once everyone has committed (fast
+//!   path), or the committed subset after the caller closes the ready window
+//!   ([`ResharingProtocol::close_ready_window`]). Every party checks `Act` is a subset of the old
+//!   committee with `|Act| >= t_old`, which guarantees every old RSS subset intersects `Act`.
+//! - **Round 2 (Entropy reveal)**: Active old committee members reveal entropy. All parties compute
+//!   the public session seed from the active members' reveals after checking the commitments.
+//! - **Round 3 (Sub-share commitments)**: Each designated dealer (lowest-ID member of `I ∩ Act`)
+//!   broadcasts hash commitments to deterministic sub-shares `r_{I→J}` derived from `s_I^old` and
+//!   the public session seed. Other active members of the same subset recompute and verify those
+//!   commitments before Round 4.
 //! - **Round 4 (Private delivery)**: Dealers privately deliver `r_{I→J}` to new committee members.
 //! - **Round 5 (Verification)**: New committee members verify received sub-shares, sum them into
 //!   new shares `s_J^new`, and broadcast commitments so each new subset can cross-verify.
@@ -60,12 +59,11 @@ use crate::{
 
 use super::types::{
 	compute_accept_hash, compute_resharing_ssid, NewShareData, ResharingAccept,
-	ResharingActProposal, ResharingCertificate, ResharingConfig, ResharingMessage,
-	ResharingOutput, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
-	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast,
-	ResharingSignerConfig, SubsetMask, SubsetPair, COMMITMENT_HASH_SIZE, ENTROPY_SIZE,
-	RESHARING_PROTOCOL_VERSION, RESHARING_SSID_SIZE, RESHARING_SUITE_ML_DSA_87,
-	SUBSHARE_COEFF_BOUND,
+	ResharingActProposal, ResharingCertificate, ResharingConfig, ResharingMessage, ResharingOutput,
+	ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal, ResharingRound3Broadcast,
+	ResharingRound4Message, ResharingRound5Broadcast, ResharingSignerConfig, SubsetMask,
+	SubsetPair, COMMITMENT_HASH_SIZE, ENTROPY_SIZE, RESHARING_PROTOCOL_VERSION,
+	RESHARING_SSID_SIZE, RESHARING_SUITE_ML_DSA_87, SUBSHARE_COEFF_BOUND,
 };
 use crate::keygen::dkg::TranscriptSigner;
 
@@ -244,8 +242,8 @@ impl fmt::Display for ResharingProtocolError {
 /// # Protocol Rounds (session-randomized protocol with active-set liveness)
 ///
 /// - **Round 1**: Entropy commitment / Ready (old committee broadcasts `H(entropy)`)
-/// - **Act proposal**: Leader proposes the active set of ready old members (within the
-///   Round 1/2 waiting states)
+/// - **Act proposal**: Leader proposes the active set of ready old members (within the Round 1/2
+///   waiting states)
 /// - **Round 2**: Entropy reveal (active members reveal entropy, session seed computed)
 /// - **Round 3**: Sub-share commitments (designated dealers broadcast `H(r_{I→J})`)
 /// - **Round 4**: Private delivery (dealers send `r_{I→J}` to new committee)
@@ -430,8 +428,8 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	///   keys, used for Round 6 transcript acceptance
 	/// * `seed` - 32 bytes of cryptographic randomness for this party's entropy contribution
 	/// * `session_nonce` - Unique nonce for SSID computation (prevents cross-session replay)
-	/// * `epoch` - Monotonic handoff counter for this public key (0 for the first resharing
-	///   after keygen; the transport layer should increment for each subsequent handoff)
+	/// * `epoch` - Monotonic handoff counter for this public key (0 for the first resharing after
+	///   keygen; the transport layer should increment for each subsequent handoff)
 	pub fn new(
 		config: ResharingConfig,
 		signer_config: ResharingSignerConfig<S>,
@@ -538,7 +536,10 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// be online for resharing to succeed (they receive the new shares), so the
 	/// leader is always reachable in a viable session.
 	pub fn leader(&self) -> ParticipantId {
-		self.config.new_participants().get(0).expect("new committee is non-empty (validated)")
+		self.config
+			.new_participants()
+			.get(0)
+			.expect("new committee is non-empty (validated)")
 	}
 
 	/// The agreed active set `Act`, once known.
@@ -603,8 +604,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		if self.active_set.is_some() || self.config.my_party_id() != self.leader() {
 			return Ok(None);
 		}
-		let have_all =
-			self.round1_entropy_commits.len() >= self.config.old_participants().len();
+		let have_all = self.round1_entropy_commits.len() >= self.config.old_participants().len();
 		if !have_all && !self.ready_window_closed {
 			return Ok(None);
 		}
@@ -613,8 +613,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		let act: Vec<ParticipantId> = self.round1_entropy_commits.keys().copied().collect();
 		let required = self.config.old_threshold() as usize;
 		if act.len() < required {
-			let err =
-				ResharingProtocolError::InsufficientParties { required, received: act.len() };
+			let err = ResharingProtocolError::InsufficientParties { required, received: act.len() };
 			self.state = ResharingState::Failed(err.to_string());
 			return Err(err);
 		}
@@ -1536,9 +1535,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		Ok(Action::SendMany(data))
 	}
 
-	fn handle_accept_waiting(
-		&mut self,
-	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
+	fn handle_accept_waiting(&mut self) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
 		let transcript_hash = self.transcript_hash.ok_or_else(|| {
 			ResharingProtocolError::InternalError(
 				"AcceptWaiting reached without a transcript hash".to_string(),
@@ -1546,8 +1543,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		})?;
 
 		// Need an acceptance from every new committee member.
-		let new_participants: Vec<ParticipantId> =
-			self.config.new_participants().iter().collect();
+		let new_participants: Vec<ParticipantId> = self.config.new_participants().iter().collect();
 		if !new_participants.iter().all(|p| self.accepts.contains_key(p)) {
 			return Ok(Action::Wait);
 		}
@@ -2778,10 +2774,7 @@ mod tests {
 	}
 
 	/// Build a `ResharingSignerConfig<TestSigner>` covering `participants`.
-	fn test_signer_config(
-		my_id: u32,
-		participants: &[u32],
-	) -> ResharingSignerConfig<TestSigner> {
+	fn test_signer_config(my_id: u32, participants: &[u32]) -> ResharingSignerConfig<TestSigner> {
 		let keys: BTreeMap<u32, u32> = participants.iter().map(|&p| (p, p)).collect();
 		ResharingSignerConfig::new(TestSigner { id: my_id }, keys, participants)
 			.expect("keys cover participants")

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -64,7 +64,8 @@ use super::types::{
 	ResharingOutput, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
 	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast,
 	ResharingSignerConfig, SubsetMask, SubsetPair, COMMITMENT_HASH_SIZE, ENTROPY_SIZE,
-	RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
+	RESHARING_PROTOCOL_VERSION, RESHARING_SSID_SIZE, RESHARING_SUITE_ML_DSA_87,
+	SUBSHARE_COEFF_BOUND,
 };
 use crate::keygen::dkg::TranscriptSigner;
 
@@ -301,6 +302,9 @@ pub struct ResharingProtocol<S: TranscriptSigner> {
 	/// Included in all messages to prevent cross-session replay attacks.
 	ssid: [u8; RESHARING_SSID_SIZE],
 
+	/// Monotonic handoff counter for this public key (included in the SSID).
+	epoch: u64,
+
 	/// Seed for entropy generation (provided by caller).
 	seed: [u8; 32],
 
@@ -379,27 +383,40 @@ pub struct ResharingProtocol<S: TranscriptSigner> {
 
 impl<S: TranscriptSigner> Drop for ResharingProtocol<S> {
 	fn drop(&mut self) {
-		// Zeroize all secret-bearing fields
-		self.seed.zeroize();
-		if let Some(ref mut entropy) = self.my_entropy {
-			entropy.zeroize();
-		}
-		if let Some(ref mut seed) = self.session_seed {
-			seed.zeroize();
-		}
-		// NewShareData implements ZeroizeOnDrop, but we explicitly clear the maps
-		// to ensure all values are dropped and zeroized
-		self.my_subshares.clear();
-		self.new_shares.clear();
-		// Also clear Round 4 messages which contain NewShareData contributions
-		self.pending_round4.clear();
-		self.round4_messages.clear();
-		// Note: ResharingConfig contains existing_share which has ZeroizeOnDrop,
-		// so it will be zeroized when config is dropped
+		self.zeroize_session_secrets();
 	}
 }
 
 impl<S: TranscriptSigner> ResharingProtocol<S> {
+	/// Securely erase all session secrets and intermediate share material.
+	///
+	/// Called automatically on successful completion and again on drop. The
+	/// completed output (if any) is preserved until [`Self::take_output`].
+	fn zeroize_session_secrets(&mut self) {
+		self.seed.zeroize();
+		if let Some(ref mut entropy) = self.my_entropy {
+			entropy.zeroize();
+		}
+		self.my_entropy = None;
+		if let Some(ref mut seed) = self.session_seed {
+			seed.zeroize();
+		}
+		self.session_seed = None;
+		// NewShareData implements ZeroizeOnDrop; clearing the maps drops values.
+		self.my_subshares.clear();
+		self.new_shares.clear();
+		self.pending_round4.clear();
+		self.round4_messages.clear();
+		self.config.zeroize_existing_share();
+	}
+
+	/// Whether the old committee share has been erased from the config.
+	///
+	/// After a successful handoff, old committee members should have `true`.
+	pub fn old_share_erased(&self) -> bool {
+		self.config.existing_share().is_none()
+	}
+
 	/// Create a new resharing protocol instance.
 	///
 	/// The config must be created using `ResharingConfig::new_for_old_member` (for old committee
@@ -413,15 +430,21 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	///   keys, used for Round 6 transcript acceptance
 	/// * `seed` - 32 bytes of cryptographic randomness for this party's entropy contribution
 	/// * `session_nonce` - Unique nonce for SSID computation (prevents cross-session replay)
+	/// * `epoch` - Monotonic handoff counter for this public key (0 for the first resharing
+	///   after keygen; the transport layer should increment for each subsequent handoff)
 	pub fn new(
 		config: ResharingConfig,
 		signer_config: ResharingSignerConfig<S>,
 		seed: [u8; 32],
 		session_nonce: &[u8; 32],
+		epoch: u64,
 	) -> Self {
 		let old_participants: Vec<_> = config.old_participants().iter().collect();
 		let new_participants: Vec<_> = config.new_participants().iter().collect();
 		let ssid = compute_resharing_ssid(
+			RESHARING_PROTOCOL_VERSION,
+			RESHARING_SUITE_ML_DSA_87,
+			epoch,
 			config.old_threshold(),
 			config.old_participants().len() as u32,
 			&old_participants,
@@ -438,6 +461,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			signer_config,
 			state: ResharingState::Round1Generate,
 			ssid,
+			epoch,
 			seed,
 			old_subset_order,
 			new_subset_order,
@@ -467,6 +491,11 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// to prevent cross-session replay attacks.
 	pub fn ssid(&self) -> &[u8; RESHARING_SSID_SIZE] {
 		&self.ssid
+	}
+
+	/// The handoff epoch baked into the SSID for this session.
+	pub fn epoch(&self) -> u64 {
+		self.epoch
 	}
 
 	/// Get the current protocol state.
@@ -1281,8 +1310,14 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		// broadcast commitments, sum them into new subset shares, and commit.
 		if self.config.role().is_new_committee() {
 			match self.verify_and_aggregate_new_shares() {
-				Ok(commits) => match self.verify_recovered_partial_norms() {
-					Ok(()) => share_commitments = commits,
+				Ok(commits) => match self.verify_stored_new_share_norms() {
+					Ok(()) => match self.verify_recovered_partial_norms() {
+						Ok(()) => share_commitments = commits,
+						Err(e) => {
+							success = false;
+							error_message = Some(e.to_string());
+						},
+					},
 					Err(e) => {
 						success = false;
 						error_message = Some(e.to_string());
@@ -1548,6 +1583,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		};
 
 		let output = self.build_output(certificate)?;
+		self.zeroize_session_secrets();
 		self.completed_output = Some(output.clone());
 		self.state = ResharingState::Done;
 		Ok(Action::Return(output))
@@ -1848,6 +1884,41 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 					"recovered partial for signing set {:?} exceeds partial-secret norm \
 					 bound: sqrt(tau) * weighted_norm = {:.0}, B = {:.0}",
 					signing_set, challenge_bound, bound
+				)));
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Per-subset stored-share norm guard (`B_G` analog).
+	///
+	/// Before checking recovered signing partials (which sum several stored
+	/// subset shares and where zero-sum inflation can partially cancel), verify
+	/// each individual aggregated new subset share `s_J^new` is within the
+	/// single-share norm envelope. Defense in depth against attacks that
+	/// inflate individual stored shares while arranging cancellation in the
+	/// specific combinations the recovered-partial check sums.
+	fn verify_stored_new_share_norms(&self) -> Result<(), ResharingProtocolError> {
+		let threshold = self.config.new_threshold();
+		let parties = self.config.new_participants().len() as u32;
+		let (_, _, nu) = crate::protocol::signing::get_hyperball_params(threshold, parties)
+			.ok_or_else(|| {
+				ResharingProtocolError::ShareVerificationFailed(format!(
+					"no hyperball parameters for new configuration ({}, {})",
+					threshold, parties
+				))
+			})?;
+
+		let bound = stored_subset_share_norm_bound(threshold, parties, nu);
+
+		for (&j_mask, share) in &self.new_shares {
+			let weighted_norm = single_share_weighted_norm(share, nu);
+			if weighted_norm > bound {
+				return Err(ResharingProtocolError::ShareVerificationFailed(format!(
+					"stored new subset share {:b} exceeds single-share norm bound: \
+					 weighted_norm = {:.0}, B_G = {:.0}",
+					j_mask, weighted_norm, bound
 				)));
 			}
 		}
@@ -2170,17 +2241,56 @@ fn binomial(n: u32, k: u32) -> u64 {
 /// challenge amplification (`E_c[‖c·u‖₂²] = τ·‖u‖₂²`); both follow Mithril §3.4
 /// and footnote 3.
 fn partial_secret_norm_bound(threshold: u32, parties: u32, nu: f64) -> f64 {
-	let n = N as f64;
-	let dim = n * (K as f64 + L as f64 / (nu * nu));
-	let var_eta = ETA as f64 * (ETA as f64 + 1.0) / 3.0;
-	// Max number of base secrets a party aggregates in one signing session
-	// (RSSRecover balanced partition, Mithril §B): ⌈C(N, T−1)/T⌉.
 	let num_secrets = {
 		let c = binomial(parties, threshold - 1) as f64;
 		(c / threshold as f64).ceil()
 	};
+	partial_secret_norm_bound_with_num_secrets(threshold, parties, nu, num_secrets)
+}
+
+/// Norm bound for a single stored RSS subset share (`B_G` analog).
+///
+/// Uses the same Mithril §3.4 calibration as [`partial_secret_norm_bound`], but
+/// with `num_secrets = 1` because each stored subset share aggregates one base
+/// secret's worth of material rather than the `⌈C(N,T−1)/T⌉` shares summed at
+/// signing recovery time.
+fn stored_subset_share_norm_bound(threshold: u32, parties: u32, nu: f64) -> f64 {
+	partial_secret_norm_bound_with_num_secrets(threshold, parties, nu, 1.0)
+}
+
+fn partial_secret_norm_bound_with_num_secrets(
+	threshold: u32,
+	parties: u32,
+	nu: f64,
+	num_secrets: f64,
+) -> f64 {
+	let n = N as f64;
+	let dim = n * (K as f64 + L as f64 / (nu * nu));
+	let var_eta = ETA as f64 * (ETA as f64 + 1.0) / 3.0;
 	let base = 1.3 * (TAU as f64).sqrt() * (dim * var_eta * num_secrets).sqrt();
 	base * resharing_norm_enlargement(threshold, parties)
+}
+
+fn single_share_weighted_norm(share: &NewShareData, nu: f64) -> f64 {
+	let s1_sq: f64 = share
+		.s1
+		.iter()
+		.flat_map(|poly| poly.iter())
+		.map(|&c| {
+			let x = center_mod_q(c) as f64;
+			x * x
+		})
+		.sum();
+	let s2_sq: f64 = share
+		.s2
+		.iter()
+		.flat_map(|poly| poly.iter())
+		.map(|&c| {
+			let x = center_mod_q(c) as f64;
+			x * x
+		})
+		.sum();
+	(s1_sq / (nu * nu) + s2_sq).sqrt()
 }
 
 /// Per-config enlargement factor `κ` applied to the keygen-calibrated bound `B`.
@@ -3007,6 +3117,7 @@ mod tests {
 			test_signer_config(1, &[0, 1, 2]),
 			[1u8; 32],
 			&[2u8; 32],
+			0,
 		);
 		let session_seed = [9u8; 32];
 		protocol.session_seed = Some(session_seed);
@@ -3071,6 +3182,7 @@ mod tests {
 			test_signer_config(1, &[0, 1, 2]),
 			[1u8; 32],
 			&[2u8; 32],
+			0,
 		);
 
 		// This models a bounded zero-sum reshaping attack: +delta on one new RSS

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -6,12 +6,20 @@
 //! See `resharing/mod.rs` for a full description of the cryptographic protocol.
 //! In short:
 //!
-//! - **Round 1 (Entropy commitment)**: Old committee members commit to fresh entropy.
-//! - **Round 2 (Entropy reveal)**: Old committee members reveal entropy. All parties compute the
-//!   public session seed from these reveals after checking the commitments.
-//! - **Round 3 (Sub-share commitments)**: Each designated dealer broadcasts hash commitments to
-//!   deterministic sub-shares `r_{I→J}` derived from `s_I^old` and the public session seed. Other
-//!   old members of the same subset recompute and verify those commitments before Round 4.
+//! - **Round 1 (Entropy commitment / Ready)**: Old committee members commit to fresh entropy.
+//!   The commitment doubles as a *Ready* signal for active-set selection.
+//! - **Act proposal**: The session leader (lowest-ID new committee member) proposes the active
+//!   set `Act` of old members that will participate: all old members once everyone has committed
+//!   (fast path), or the committed subset after the caller closes the ready window
+//!   ([`ResharingProtocol::close_ready_window`]). Every party checks `Act` is a subset of the
+//!   old committee with `|Act| >= t_old`, which guarantees every old RSS subset intersects `Act`.
+//! - **Round 2 (Entropy reveal)**: Active old committee members reveal entropy. All parties
+//!   compute the public session seed from the active members' reveals after checking the
+//!   commitments.
+//! - **Round 3 (Sub-share commitments)**: Each designated dealer (lowest-ID member of
+//!   `I ∩ Act`) broadcasts hash commitments to deterministic sub-shares `r_{I→J}` derived from
+//!   `s_I^old` and the public session seed. Other active members of the same subset recompute
+//!   and verify those commitments before Round 4.
 //! - **Round 4 (Private delivery)**: Dealers privately deliver `r_{I→J}` to new committee members.
 //! - **Round 5 (Verification)**: New committee members verify received sub-shares, sum them into
 //!   new shares `s_J^new`, and broadcast commitments so each new subset can cross-verify.
@@ -27,6 +35,9 @@
 //! Round1Generate -> Round1Waiting -> Round2Generate -> Round2Waiting
 //!     -> Round3Generate -> Round3Waiting -> Combining -> Done
 //! ```
+//!
+//! The Act proposal is emitted and consumed within `Round1Waiting` / `Round2Waiting`; parties
+//! do not advance past those states until they know `Act`.
 
 use alloc::{
 	collections::BTreeMap,
@@ -48,10 +59,10 @@ use crate::{
 };
 
 use super::types::{
-	compute_resharing_ssid, NewShareData, ResharingConfig, ResharingMessage, ResharingOutput,
-	ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal, ResharingRound3Broadcast,
-	ResharingRound4Message, ResharingRound5Broadcast, SubsetMask, SubsetPair, COMMITMENT_HASH_SIZE,
-	ENTROPY_SIZE, RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
+	compute_resharing_ssid, NewShareData, ResharingActProposal, ResharingConfig, ResharingMessage,
+	ResharingOutput, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
+	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast, SubsetMask,
+	SubsetPair, COMMITMENT_HASH_SIZE, ENTROPY_SIZE, RESHARING_SSID_SIZE, SUBSHARE_COEFF_BOUND,
 };
 
 /// Domain separator for the per-subset PRF seed (includes public session seed for randomization).
@@ -223,22 +234,24 @@ impl fmt::Display for ResharingProtocolError {
 
 /// Current state of the resharing protocol.
 ///
-/// # Protocol Rounds (5-round session-randomized protocol)
+/// # Protocol Rounds (session-randomized protocol with active-set liveness)
 ///
-/// - **Round 1**: Entropy commitment (old committee broadcasts `H(entropy)`)
-/// - **Round 2**: Entropy reveal (old committee reveals entropy, session seed computed)
+/// - **Round 1**: Entropy commitment / Ready (old committee broadcasts `H(entropy)`)
+/// - **Act proposal**: Leader proposes the active set of ready old members (within the
+///   Round 1/2 waiting states)
+/// - **Round 2**: Entropy reveal (active members reveal entropy, session seed computed)
 /// - **Round 3**: Sub-share commitments (designated dealers broadcast `H(r_{I→J})`)
 /// - **Round 4**: Private delivery (dealers send `r_{I→J}` to new committee)
 /// - **Round 5**: Verification (share commitments, partial PKs)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResharingState {
-	/// Generating Round 1 message (entropy commitment).
+	/// Generating Round 1 message (entropy commitment / Ready).
 	Round1Generate,
-	/// Waiting for Round 1 messages from old committee members.
+	/// Waiting for the active-set proposal (and, as leader, for Ready signals).
 	Round1Waiting,
-	/// Generating Round 2 message (entropy reveal).
+	/// Generating Round 2 message (entropy reveal, active members only).
 	Round2Generate,
-	/// Waiting for Round 2 messages from old committee members.
+	/// Waiting for Round 2 messages from active old committee members.
 	Round2Waiting,
 	/// Generating Round 3 message (commitments to per-subset sub-shares).
 	Round3Generate,
@@ -290,11 +303,25 @@ pub struct ResharingProtocol {
 	/// This party's generated entropy (old committee members only).
 	my_entropy: Option<[u8; ENTROPY_SIZE]>,
 	/// Round 1 entropy commitments received from old committee members.
+	/// A commitment doubles as that member's *Ready* signal.
 	round1_entropy_commits: BTreeMap<ParticipantId, [u8; COMMITMENT_HASH_SIZE]>,
-	/// Round 2 entropy reveals received from old committee members.
+	/// Round 2 entropy reveals received from active old committee members.
 	round2_entropy_reveals: BTreeMap<ParticipantId, [u8; ENTROPY_SIZE]>,
-	/// Session seed computed from all entropy contributions (computed after Round 2).
+	/// Session seed computed from the active set's entropy contributions
+	/// (computed after Round 2).
 	session_seed: Option<[u8; 32]>,
+
+	// ========================================================================
+	// Active-set selection (Ready-round liveness)
+	// ========================================================================
+	/// The agreed active set `Act`: old committee members that contribute
+	/// entropy and deal sub-shares. Sorted. Set by the leader when proposing,
+	/// or by receiving a valid `ActProposal`.
+	active_set: Option<Vec<ParticipantId>>,
+	/// Set by [`Self::close_ready_window`] on the leader: propose `Act` from
+	/// the Ready signals received so far instead of waiting for the full old
+	/// committee.
+	ready_window_closed: bool,
 
 	// ========================================================================
 	// Round 3-4: Sub-share commitment and delivery
@@ -387,6 +414,8 @@ impl ResharingProtocol {
 			round1_entropy_commits: BTreeMap::new(),
 			round2_entropy_reveals: BTreeMap::new(),
 			session_seed: None,
+			active_set: None,
+			ready_window_closed: false,
 			my_subshares: BTreeMap::new(),
 			my_round3: None,
 			round3_broadcasts: BTreeMap::new(),
@@ -439,6 +468,103 @@ impl ResharingProtocol {
 	/// Check if the protocol has failed.
 	pub fn is_failed(&self) -> bool {
 		matches!(self.state, ResharingState::Failed(_))
+	}
+
+	/// The session leader: the lowest-ID new committee member.
+	///
+	/// The leader proposes the active set `Act`. New committee members must all
+	/// be online for resharing to succeed (they receive the new shares), so the
+	/// leader is always reachable in a viable session.
+	pub fn leader(&self) -> ParticipantId {
+		self.config.new_participants().get(0).expect("new committee is non-empty (validated)")
+	}
+
+	/// The agreed active set `Act`, once known.
+	///
+	/// `None` until the leader's proposal is made (leader) or received
+	/// (everyone else). Sorted.
+	pub fn active_set(&self) -> Option<&[ParticipantId]> {
+		self.active_set.as_deref()
+	}
+
+	/// Close the Ready window (leader only): propose the active set from the
+	/// Ready signals (Round 1 entropy commitments) received so far, instead of
+	/// waiting for the full old committee.
+	///
+	/// Call this on the leader after a transport-level timeout when some old
+	/// committee members appear offline. The next `poke()` broadcasts the
+	/// proposal if at least `t_old` old members are ready, and aborts with
+	/// [`ResharingProtocolError::InsufficientParties`] otherwise.
+	///
+	/// Idempotent; a no-op if the active set has already been proposed.
+	pub fn close_ready_window(&mut self) -> Result<(), ResharingProtocolError> {
+		if self.config.my_party_id() != self.leader() {
+			return Err(ResharingProtocolError::InvalidState(format!(
+				"only the session leader ({}) can close the ready window",
+				self.leader()
+			)));
+		}
+		if self.active_set.is_some() {
+			return Ok(());
+		}
+		if !matches!(
+			self.state,
+			ResharingState::Round1Generate |
+				ResharingState::Round1Waiting |
+				ResharingState::Round2Generate |
+				ResharingState::Round2Waiting
+		) {
+			return Err(ResharingProtocolError::InvalidState(format!(
+				"cannot close ready window in state {:?}",
+				self.state
+			)));
+		}
+		self.ready_window_closed = true;
+		Ok(())
+	}
+
+	/// Whether `party` is in the agreed active set. `false` until `Act` is known.
+	fn is_active(&self, party: ParticipantId) -> bool {
+		self.active_set.as_ref().is_some_and(|act| act.binary_search(&party).is_ok())
+	}
+
+	/// Leader-side active-set proposal.
+	///
+	/// Returns `Some(SendMany(..))` when this party is the leader and the
+	/// proposal is due: either every old committee member has sent its Round 1
+	/// commitment (fast path), or the caller closed the ready window. Aborts
+	/// with `InsufficientParties` if the window was closed with fewer than
+	/// `t_old` ready members.
+	fn maybe_propose_act(
+		&mut self,
+	) -> Result<Option<Action<ResharingOutput>>, ResharingProtocolError> {
+		if self.active_set.is_some() || self.config.my_party_id() != self.leader() {
+			return Ok(None);
+		}
+		let have_all =
+			self.round1_entropy_commits.len() >= self.config.old_participants().len();
+		if !have_all && !self.ready_window_closed {
+			return Ok(None);
+		}
+
+		// BTreeMap keys iterate in sorted order, so `act` is sorted.
+		let act: Vec<ParticipantId> = self.round1_entropy_commits.keys().copied().collect();
+		let required = self.config.old_threshold() as usize;
+		if act.len() < required {
+			let err =
+				ResharingProtocolError::InsufficientParties { required, received: act.len() };
+			self.state = ResharingState::Failed(err.to_string());
+			return Err(err);
+		}
+
+		let proposal = ResharingActProposal {
+			ssid: self.ssid,
+			party_id: self.config.my_party_id(),
+			active_set: act.clone(),
+		};
+		self.active_set = Some(act);
+		let data = Self::serialize_message(&ResharingMessage::ActProposal(proposal))?;
+		Ok(Some(Action::SendMany(data)))
 	}
 
 	fn serialize_message(msg: &ResharingMessage) -> Result<Vec<u8>, ResharingProtocolError> {
@@ -532,9 +658,62 @@ impl ResharingProtocol {
 			ResharingMessage::Round3(broadcast) => self.handle_round3_message(from, broadcast),
 			ResharingMessage::Round4(m) => self.handle_round4_message(from, m),
 			ResharingMessage::Round5(broadcast) => self.handle_round5_message(from, broadcast),
+			ResharingMessage::ActProposal(m) => self.handle_act_proposal(from, m),
 		}
 
 		Ok(())
+	}
+
+	// ========================================================================
+	// Active-set proposal handling
+	// ========================================================================
+
+	fn handle_act_proposal(&mut self, from: ParticipantId, msg: ResharingActProposal) {
+		// Parties beyond the Round 1-2 waiting states already know Act;
+		// anything arriving later is a stale duplicate.
+		if !matches!(
+			self.state,
+			ResharingState::Round1Generate |
+				ResharingState::Round1Waiting |
+				ResharingState::Round2Generate |
+				ResharingState::Round2Waiting
+		) {
+			return;
+		}
+		if from != self.leader() {
+			log::warn!("Resharing: ignoring Act proposal from non-leader {}", from);
+			return;
+		}
+
+		// Validate: strictly sorted (thus unique), subset of the old committee,
+		// at least t_old members. An invalid proposal from the genuine leader is
+		// unrecoverable (no valid session can proceed), so fail fast rather than
+		// stalling until a transport timeout.
+		let act = &msg.active_set;
+		let sorted_unique = act.windows(2).all(|w| w[0] < w[1]);
+		let all_old = act.iter().all(|p| self.config.old_participants().contains(*p));
+		let enough = act.len() >= self.config.old_threshold() as usize;
+		if act.is_empty() || !sorted_unique || !all_old || !enough {
+			self.state = ResharingState::Failed(format!(
+				"invalid Act proposal from leader {}: {:?} (t_old = {})",
+				from,
+				act,
+				self.config.old_threshold()
+			));
+			return;
+		}
+
+		match &self.active_set {
+			None => self.active_set = Some(msg.active_set),
+			Some(existing) if *existing == msg.active_set => {}, // duplicate, ignore
+			Some(_) => {
+				// Two different proposals from the leader: equivocation.
+				self.state = ResharingState::Failed(format!(
+					"leader {} equivocated on the Act proposal",
+					from
+				));
+			},
+		}
 	}
 
 	// ========================================================================
@@ -570,7 +749,14 @@ impl ResharingProtocol {
 	}
 
 	fn handle_round1_waiting(&mut self) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		if self.have_all_round1_entropy_commits() {
+		// If we are the leader, propose the active set once it is due.
+		if let Some(action) = self.maybe_propose_act()? {
+			return Ok(action);
+		}
+		// Advance once the active set is agreed. Round 1 commitments from Act
+		// members are awaited in Round2Waiting before the session seed is
+		// computed, so there is no need to block on them here.
+		if self.active_set.is_some() {
 			self.state = ResharingState::Round2Generate;
 			self.poke()
 		} else {
@@ -604,9 +790,16 @@ impl ResharingProtocol {
 		self.round1_entropy_commits.insert(from, msg.commitment);
 	}
 
-	fn have_all_round1_entropy_commits(&self) -> bool {
-		// We need entropy commitments from all old committee members
-		self.round1_entropy_commits.len() >= self.config.old_participants().len()
+	/// Entropy data (Round 1 commitment + Round 2 reveal) present for every
+	/// active-set member. `false` until the active set is known.
+	fn have_act_entropy_data(&self) -> bool {
+		match &self.active_set {
+			Some(act) => act.iter().all(|p| {
+				self.round1_entropy_commits.contains_key(p) &&
+					self.round2_entropy_reveals.contains_key(p)
+			}),
+			None => false,
+		}
 	}
 
 	/// Generate this party's entropy contribution from the constructor seed.
@@ -628,9 +821,9 @@ impl ResharingProtocol {
 	fn handle_round2_generate(
 		&mut self,
 	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		// Only old committee members participate in Round 2 (entropy reveal).
-		// New-only parties stay in Round 2 waiting.
-		if !self.config.role().is_old_committee() {
+		// Only *active* old committee members reveal entropy. New-only parties
+		// and old members outside the active set observe from Round 2 waiting.
+		if !self.is_active(self.config.my_party_id()) {
 			self.state = ResharingState::Round2Waiting;
 			return Ok(Action::Wait);
 		}
@@ -653,8 +846,14 @@ impl ResharingProtocol {
 	}
 
 	fn handle_round2_waiting(&mut self) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		if self.have_all_round2_entropy_reveals() {
-			// Verify all reveals match their commitments and compute session seed
+		// A new-only leader collects Ready signals from this state; propose the
+		// active set once it is due.
+		if let Some(action) = self.maybe_propose_act()? {
+			return Ok(action);
+		}
+		if self.have_act_entropy_data() {
+			// Verify the active set's reveals match their commitments and
+			// compute the session seed.
 			self.verify_entropy_and_compute_session_seed()?;
 			self.state = ResharingState::Round3Generate;
 			self.poke()
@@ -664,10 +863,18 @@ impl ResharingProtocol {
 	}
 
 	fn handle_round2_message(&mut self, from: ParticipantId, msg: ResharingRound2EntropyReveal) {
-		// Accept Round 2 messages during Round 1-3 (for late arrivals)
+		// Accept Round 2 messages from protocol start through Round 3. The
+		// window includes `Round1Generate`: a party that lags past the ready
+		// window (and is excluded from Act) drains its inbound backlog before
+		// its first poke, while still in the initial state. Reveals are only
+		// *used* after `have_act_entropy_data` confirms the matching Round 1
+		// commitment, so early acceptance cannot bypass the commit-reveal
+		// binding; Act membership already fixes every contributor's commitment
+		// before any honest reveal is sent.
 		if !matches!(
 			self.state,
-			ResharingState::Round1Waiting |
+			ResharingState::Round1Generate |
+				ResharingState::Round1Waiting |
 				ResharingState::Round2Generate |
 				ResharingState::Round2Waiting |
 				ResharingState::Round3Generate |
@@ -686,19 +893,32 @@ impl ResharingProtocol {
 		self.round2_entropy_reveals.insert(from, msg.entropy);
 	}
 
-	fn have_all_round2_entropy_reveals(&self) -> bool {
-		// We need entropy reveals from all old committee members
-		self.round2_entropy_reveals.len() >= self.config.old_participants().len()
-	}
-
-	/// Verify all entropy reveals match their commitments and compute the session seed.
+	/// Verify the active set's entropy reveals match their commitments and
+	/// compute the session seed.
+	///
+	/// Only active-set members contribute: the set of contributors must be
+	/// agreed by every party (it determines the seed), and `Act` is exactly
+	/// the agreed set. Reveals from non-active members (e.g. a late Round 1
+	/// commitment excluded from `Act`) are ignored.
 	fn verify_entropy_and_compute_session_seed(&mut self) -> Result<(), ResharingProtocolError> {
-		// Verify each reveal matches its commitment
-		for (&party_id, &entropy) in &self.round2_entropy_reveals {
-			let expected_commit = commit_entropy(&entropy);
+		let act = self.active_set.clone().ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"Computing session seed before active set is agreed".to_string(),
+			)
+		})?;
+
+		// Verify each active member's reveal matches its commitment.
+		for &party_id in &act {
+			let entropy = self.round2_entropy_reveals.get(&party_id).ok_or_else(|| {
+				ResharingProtocolError::InternalError(format!(
+					"Missing entropy reveal from active party {} during verification",
+					party_id
+				))
+			})?;
+			let expected_commit = commit_entropy(entropy);
 			let actual_commit = self.round1_entropy_commits.get(&party_id).ok_or_else(|| {
 				ResharingProtocolError::InternalError(format!(
-					"Missing entropy commitment from party {} during verification",
+					"Missing entropy commitment from active party {} during verification",
 					party_id
 				))
 			})?;
@@ -708,18 +928,16 @@ impl ResharingProtocol {
 		}
 
 		// Compute session seed: SHAKE256("resharing-session-seed-v1" || ssid || party_id_1 ||
-		// entropy_1 || ...). The SSID is included so that even if parties reuse entropy seeds
-		// across different resharing sessions, the session_seed (and thus the sub-share
-		// derivation) will differ. Process parties in sorted order for determinism.
-		let mut sorted_parties: Vec<_> = self.round2_entropy_reveals.iter().collect();
-		sorted_parties.sort_by_key(|(party_id, _)| *party_id);
-
+		// entropy_1 || ...) over active members in sorted order (Act is sorted). The SSID is
+		// included so that even if parties reuse entropy seeds across different resharing
+		// sessions, the session_seed (and thus the sub-share derivation) will differ.
 		let mut state = fips202::KeccakState::default();
 		fips202::shake256_absorb(&mut state, SESSION_SEED_DOMAIN);
 		fips202::shake256_absorb(&mut state, &self.ssid);
-		for (&party_id, entropy) in &sorted_parties {
+		for &party_id in &act {
+			let entropy = self.round2_entropy_reveals.get(&party_id).expect("checked above");
 			fips202::shake256_absorb(&mut state, &party_id.to_le_bytes());
-			fips202::shake256_absorb(&mut state, *entropy);
+			fips202::shake256_absorb(&mut state, entropy);
 		}
 		fips202::shake256_finalize(&mut state);
 		let mut session_seed = [0u8; 32];
@@ -736,8 +954,9 @@ impl ResharingProtocol {
 	fn handle_round3_generate(
 		&mut self,
 	) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		// Only old committee members participate in Round 3.
-		if !self.config.role().is_old_committee() {
+		// Only active old committee members deal in Round 3. New-only parties
+		// and old members outside the active set wait for Round 4 traffic.
+		if !self.is_active(self.config.my_party_id()) {
 			self.state = ResharingState::Round4Waiting;
 			return Ok(Action::Wait);
 		}
@@ -792,10 +1011,18 @@ impl ResharingProtocol {
 	}
 
 	fn handle_round3_message(&mut self, from: ParticipantId, broadcast: ResharingRound3Broadcast) {
-		// Accept Round 3 messages during Round 2-4 states (for late arrivals and NewOnly parties)
+		// Accept Round 3 messages from protocol start through Round 4: a slow
+		// party excluded from Act can receive dealers' broadcasts while still
+		// in the Round 1-2 states (see `handle_round2_message`). The broadcasts
+		// are hash commitments, verified later against deterministic
+		// recomputation (old-subset peers) or delivered sub-shares (recipients),
+		// so early acceptance is harmless.
 		if !matches!(
 			self.state,
-			ResharingState::Round2Waiting |
+			ResharingState::Round1Generate |
+				ResharingState::Round1Waiting |
+				ResharingState::Round2Generate |
+				ResharingState::Round2Waiting |
 				ResharingState::Round3Generate |
 				ResharingState::Round3Waiting |
 				ResharingState::Round4Generate |
@@ -813,9 +1040,14 @@ impl ResharingProtocol {
 	}
 
 	fn have_enough_round3(&self) -> bool {
-		// We need a Round 3 broadcast from every party that is a designated dealer for at
-		// least one old subset. Conservative requirement: all old participants.
-		self.round3_broadcasts.len() >= self.config.old_participants().len()
+		// We need a Round 3 broadcast from every active member. Every designated
+		// dealer is active by construction (dealers are chosen from `I ∩ Act`),
+		// and active non-dealers broadcast an empty commitment map, so this is
+		// both sufficient and satisfiable with offline non-active members.
+		match &self.active_set {
+			Some(act) => act.iter().all(|p| self.round3_broadcasts.contains_key(p)),
+			None => false,
+		}
 	}
 
 	/// Old-subset peer verification for Round 3 dealer commitments.
@@ -1076,11 +1308,14 @@ impl ResharingProtocol {
 	}
 
 	fn have_all_round5(&self) -> bool {
-		// Round 5 has contributions from BOTH old and new committee members
-		// (old members broadcast status; new members commit to new shares),
-		// so we need broadcasts from every party that is in either committee.
-		let union = self.config.all_participants();
-		union.iter().all(|p| self.round5_broadcasts.contains_key(p))
+		// Round 5 has contributions from active old members (status) and new
+		// committee members (new-share commitments + partial PKs). Old members
+		// outside the active set may be offline, so they are not required —
+		// though if an online one reports failure, Combining still honors it.
+		let Some(act) = &self.active_set else { return false };
+		let required: alloc::collections::BTreeSet<ParticipantId> =
+			act.iter().copied().chain(self.config.new_participants().iter()).collect();
+		required.iter().all(|p| self.round5_broadcasts.contains_key(p))
 	}
 
 	// ========================================================================
@@ -1207,16 +1442,26 @@ impl ResharingProtocol {
 		}
 	}
 
-	/// Find the designated dealer for an old subset: the lowest-ID old
-	/// participant that is a member of the subset.
+	/// Find the designated dealer for an old subset: the lowest-ID *active*
+	/// old participant that is a member of the subset (`min(I ∩ Act)`).
 	///
 	/// Bit positions in `i_mask` correspond to indices in the (sorted)
-	/// `old_participants` list, so the dealer is the party at the lowest
-	/// set bit. Works for every party — in particular NewOnly parties that
-	/// don't hold an `existing_share`.
+	/// `old_participants` list. Works for every party — in particular NewOnly
+	/// parties that don't hold an `existing_share`.
+	///
+	/// The active-set rule `|Act| >= t_old` guarantees `I ∩ Act` is non-empty
+	/// for every old subset `I` (which has `n_old - t_old + 1` members), so
+	/// once `Act` is agreed this returns `Some` for every valid subset. All
+	/// members of `I` hold the same `s_I^old` and the sub-share derivation is
+	/// deterministic, so any of them produces identical sub-shares — dealer
+	/// identity affects only message routing, not the derived values.
+	///
+	/// Returns `None` before the active set is agreed; all call sites run
+	/// after Round 2 completes, which requires `Act`.
 	fn designated_dealer_for(&self, i_mask: SubsetMask) -> Option<ParticipantId> {
+		self.active_set.as_ref()?;
 		for (bit, party) in self.config.old_participants().iter().enumerate() {
-			if (i_mask & (1 << bit)) != 0 {
+			if (i_mask & (1 << bit)) != 0 && self.is_active(party) {
 				return Some(party);
 			}
 		}
@@ -2491,6 +2736,8 @@ mod tests {
 		let mut protocol = ResharingProtocol::new(resharing_config, [1u8; 32], &[2u8; 32]);
 		let session_seed = [9u8; 32];
 		protocol.session_seed = Some(session_seed);
+		// Model the post-Act state: the full old committee is active.
+		protocol.active_set = Some(vec![0, 1, 2]);
 
 		let i_mask = 0b011u16;
 		let s_i = shares[0].shares().get(&i_mask).expect("old subset share");

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -728,12 +728,12 @@ impl ResharingCertificate {
 		verifying_keys: &BTreeMap<ParticipantId, S::PublicKey>,
 	) -> bool {
 		let accept_hash = compute_accept_hash(&self.ssid, &self.transcript_hash);
-		new_participants.iter().all(|p| {
-			match (verifying_keys.get(p), self.accepts.get(p)) {
+		new_participants
+			.iter()
+			.all(|p| match (verifying_keys.get(p), self.accepts.get(p)) {
 				(Some(pk), Some(sig)) => S::verify_bytes(pk, &accept_hash, sig),
 				_ => false,
-			}
-		})
+			})
 	}
 }
 
@@ -1136,8 +1136,8 @@ pub struct ResharingOutput {
 ///
 /// * `protocol_version` - Wire/logic version ([`RESHARING_PROTOCOL_VERSION`])
 /// * `suite_id` - Cryptographic suite ([`RESHARING_SUITE_ML_DSA_87`])
-/// * `epoch` - Monotonic handoff counter for this public key (0 for the first
-///   resharing after keygen; increment for each subsequent handoff)
+/// * `epoch` - Monotonic handoff counter for this public key (0 for the first resharing after
+///   keygen; increment for each subsequent handoff)
 /// * `old_threshold` - Threshold of the old committee
 /// * `old_n` - Total parties in the old committee
 /// * `old_participants` - Participant IDs in the old committee

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -28,6 +28,14 @@ pub const ENTROPY_SIZE: usize = 32;
 /// Size of session identifier (SSID) in bytes.
 pub const RESHARING_SSID_SIZE: usize = 32;
 
+/// Current resharing protocol version baked into the SSID.
+///
+/// Bump when the round structure or wire format changes incompatibly.
+pub const RESHARING_PROTOCOL_VERSION: u32 = 2;
+
+/// Cryptographic suite identifier for threshold ML-DSA-87 RSS resharing.
+pub const RESHARING_SUITE_ML_DSA_87: u32 = 1;
+
 /// Maximum absolute value for sub-share coefficients in resharing.
 ///
 /// This bound defends against malicious dealers who might inject arbitrarily large
@@ -45,8 +53,8 @@ pub const RESHARING_SSID_SIZE: usize = 32;
 /// attacks that could compromise hyperball security (e.g., injecting Q/2 ≈ 4.2M).
 pub const SUBSHARE_COEFF_BOUND: i32 = 500;
 
-/// Domain separator for SSID computation.
-const DOMAIN_RESHARING_SSID: &[u8] = b"RESHARING_SSID_V1";
+/// Domain separator for SSID computation (V2 includes version, suite, epoch).
+const DOMAIN_RESHARING_SSID: &[u8] = b"RESHARING_SSID_V2";
 
 /// Subset mask - a bitmask indicating which parties are in a subset.
 /// Uses u16 to support up to 16 parties.
@@ -250,6 +258,17 @@ impl ResharingConfig {
 	/// Returns `Some` for OldOnly and Both roles, `None` for NewOnly.
 	pub fn existing_share(&self) -> Option<&PrivateKeyShare> {
 		self.existing_share.as_ref()
+	}
+
+	/// Securely erase the old committee share held in this config.
+	///
+	/// Called automatically when the protocol completes successfully. Integrators
+	/// should treat the returned new share as the only live key material after
+	/// a successful handoff.
+	pub fn zeroize_existing_share(&mut self) {
+		if let Some(mut share) = self.existing_share.take() {
+			share.zeroize();
+		}
 	}
 
 	/// Get old threshold config.
@@ -1096,7 +1115,10 @@ pub struct ResharingOutput {
 ///
 /// ```text
 /// SSID = SHAKE256(
-///     "RESHARING_SSID_V1" ||
+///     "RESHARING_SSID_V2" ||
+///     protocol_version (u32 LE) ||
+///     suite_id (u32 LE) ||
+///     epoch (u64 LE) ||
 ///     old_threshold (u32 LE) ||
 ///     old_n (u32 LE) ||
 ///     old_num_participants (u32 LE) ||
@@ -1112,6 +1134,10 @@ pub struct ResharingOutput {
 ///
 /// # Arguments
 ///
+/// * `protocol_version` - Wire/logic version ([`RESHARING_PROTOCOL_VERSION`])
+/// * `suite_id` - Cryptographic suite ([`RESHARING_SUITE_ML_DSA_87`])
+/// * `epoch` - Monotonic handoff counter for this public key (0 for the first
+///   resharing after keygen; increment for each subsequent handoff)
 /// * `old_threshold` - Threshold of the old committee
 /// * `old_n` - Total parties in the old committee
 /// * `old_participants` - Participant IDs in the old committee
@@ -1120,7 +1146,11 @@ pub struct ResharingOutput {
 /// * `new_participants` - Participant IDs in the new committee
 /// * `public_key` - The public key being reshared
 /// * `session_nonce` - Unique nonce for this session (e.g., from transport layer)
+#[allow(clippy::too_many_arguments)] // flat list of independent hash inputs
 pub fn compute_resharing_ssid(
+	protocol_version: u32,
+	suite_id: u32,
+	epoch: u64,
 	old_threshold: u32,
 	old_n: u32,
 	old_participants: &[ParticipantId],
@@ -1137,6 +1167,11 @@ pub fn compute_resharing_ssid(
 
 	// Domain separator
 	fips202::shake256_absorb(&mut state, DOMAIN_RESHARING_SSID);
+
+	// Protocol binding (version, suite, epoch)
+	fips202::shake256_absorb(&mut state, &protocol_version.to_le_bytes());
+	fips202::shake256_absorb(&mut state, &suite_id.to_le_bytes());
+	fips202::shake256_absorb(&mut state, &epoch.to_le_bytes());
 
 	// Old committee configuration
 	fips202::shake256_absorb(&mut state, &old_threshold.to_le_bytes());
@@ -1696,5 +1731,46 @@ mod tests {
 		let truncated = &serialized[..serialized.len() / 2];
 		let result: Result<NewShareData, _> = borsh::from_slice(truncated);
 		assert!(result.is_err(), "Should reject truncated data");
+	}
+
+	#[test]
+	fn test_resharing_ssid_binds_version_suite_and_epoch() {
+		let pk = make_test_public_key();
+		let nonce = [0x55u8; 32];
+		let old = vec![0u32, 1u32, 2u32];
+		let newp = vec![0u32, 1u32, 3u32];
+
+		let base = |epoch: u64| {
+			compute_resharing_ssid(
+				RESHARING_PROTOCOL_VERSION,
+				RESHARING_SUITE_ML_DSA_87,
+				epoch,
+				2,
+				3,
+				&old,
+				2,
+				3,
+				&newp,
+				&pk,
+				&nonce,
+			)
+		};
+
+		assert_ne!(base(0), base(1), "epoch must change the SSID");
+
+		let other_suite = compute_resharing_ssid(
+			RESHARING_PROTOCOL_VERSION,
+			RESHARING_SUITE_ML_DSA_87 + 1,
+			0,
+			2,
+			3,
+			&old,
+			2,
+			3,
+			&newp,
+			&pk,
+			&nonce,
+		);
+		assert_ne!(base(0), other_suite, "suite must change the SSID");
 	}
 }

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -356,6 +356,8 @@ pub enum ResharingConfigError {
 	PublicKeyMismatch,
 	/// Share's threshold doesn't match the old_threshold parameter.
 	ThresholdMismatch { share_threshold: u32, config_threshold: u32 },
+	/// Signer configuration is missing the verifying key for a new committee member.
+	MissingVerifyingKey(ParticipantId),
 }
 
 impl fmt::Display for ResharingConfigError {
@@ -375,6 +377,9 @@ impl fmt::Display for ResharingConfigError {
 			},
 			ResharingConfigError::PartyNotInEitherCommittee { party_id } => {
 				write!(f, "Party {} is not in either old or new committee", party_id)
+			},
+			ResharingConfigError::MissingVerifyingKey(party_id) => {
+				write!(f, "Missing verifying key for new committee member {}", party_id)
 			},
 			ResharingConfigError::DuplicateParticipant => {
 				write!(f, "Duplicate participant ID in committee")
@@ -441,6 +446,9 @@ pub enum ResharingMessage {
 	/// Appended after the round variants to preserve Borsh variant indices of
 	/// the pre-existing wire format.
 	ActProposal(ResharingActProposal),
+	/// Round 6: Signed acceptance of the session transcript from new committee
+	/// members. Appended to preserve Borsh variant indices.
+	Accept(ResharingAccept),
 }
 
 impl ResharingMessage {
@@ -453,6 +461,7 @@ impl ResharingMessage {
 			ResharingMessage::Round4(msg) => &msg.ssid,
 			ResharingMessage::Round5(msg) => &msg.ssid,
 			ResharingMessage::ActProposal(msg) => &msg.ssid,
+			ResharingMessage::Accept(msg) => &msg.ssid,
 		}
 	}
 
@@ -465,6 +474,7 @@ impl ResharingMessage {
 			ResharingMessage::Round4(msg) => msg.from_party_id,
 			ResharingMessage::Round5(msg) => msg.party_id,
 			ResharingMessage::ActProposal(msg) => msg.party_id,
+			ResharingMessage::Accept(msg) => msg.party_id,
 		}
 	}
 
@@ -480,6 +490,7 @@ impl ResharingMessage {
 			ResharingMessage::Round3(_) => 3,
 			ResharingMessage::Round4(_) => 4,
 			ResharingMessage::Round5(_) => 5,
+			ResharingMessage::Accept(_) => 6,
 		}
 	}
 }
@@ -562,6 +573,169 @@ pub struct ResharingActProposal {
 	/// Proposed active set: old committee members that will contribute entropy
 	/// and deal sub-shares. Strictly sorted, unique, `|active_set| >= t_old`.
 	pub active_set: Vec<ParticipantId>,
+}
+
+// ============================================================================
+// Round 6: Signed Transcript Acceptance
+// ============================================================================
+
+/// Maximum accepted signature length in bytes (bounds deserialization).
+///
+/// Large enough for ML-DSA-87 signatures (4627 bytes) with headroom; small
+/// enough to bound memory on malformed input.
+pub const MAX_ACCEPT_SIGNATURE_LEN: usize = 8192;
+
+/// Round 6 broadcast: a new committee member's signed acceptance of the
+/// session transcript.
+///
+/// After completing all Round 5 verifications (sub-share commitment checks,
+/// new-share consistency, recovered-partial norm guard, and public-key
+/// preservation), each new committee member signs the session's transcript
+/// hash with its long-term key (see
+/// [`TranscriptSigner`](crate::keygen::dkg::TranscriptSigner)) and broadcasts
+/// the signature.
+///
+/// # What agreement on the transcript hash provides
+///
+/// The transcript hash covers the active set, the session seed, every active
+/// member's Round 3 dealer commitments, and every required Round 5 broadcast.
+/// Each party verifies every received acceptance against its *own* computed
+/// transcript hash, so a valid set of acceptances from the full new committee
+/// implies all of them observed identical protocol broadcasts. A dealer that
+/// equivocates (sends different Round 3/5 broadcasts to different parties)
+/// causes signature verification to fail on at least one honest party, which
+/// then aborts.
+///
+/// The signature is over `SHAKE256("resharing-accept-v1" || ssid ||
+/// transcript_hash)`, domain-separating acceptances from any other use of the
+/// same long-term key.
+#[derive(Debug, Clone, BorshSerialize)]
+pub struct ResharingAccept {
+	/// Session identifier binding this message to the resharing session.
+	pub ssid: [u8; RESHARING_SSID_SIZE],
+	/// Party ID of the sender (must be a new committee member).
+	pub party_id: ParticipantId,
+	/// Signature over the acceptance hash (raw bytes, scheme-dependent).
+	pub signature: Vec<u8>,
+}
+
+impl BorshDeserialize for ResharingAccept {
+	fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+		let ssid = <[u8; RESHARING_SSID_SIZE]>::deserialize_reader(reader)?;
+		let party_id = ParticipantId::deserialize_reader(reader)?;
+		let sig_len = u32::deserialize_reader(reader)? as usize;
+		if sig_len > MAX_ACCEPT_SIGNATURE_LEN {
+			return Err(borsh::io::Error::new(
+				borsh::io::ErrorKind::InvalidData,
+				"ResharingAccept.signature exceeds MAX_ACCEPT_SIGNATURE_LEN",
+			));
+		}
+		let mut signature = alloc::vec![0u8; sig_len];
+		reader.read_exact(&mut signature)?;
+		Ok(Self { ssid, party_id, signature })
+	}
+}
+
+/// Long-term-key signing configuration for the resharing protocol.
+///
+/// Mirrors the DKG's signer configuration: this party's signer plus the
+/// verifying keys of (at least) every new committee member. Only new
+/// committee members produce acceptance signatures, but every participant
+/// verifies them, so every participant needs the new committee's keys.
+#[derive(Clone)]
+pub struct ResharingSignerConfig<S: crate::keygen::dkg::TranscriptSigner> {
+	/// This party's signer for transcript acceptance (used only if this party
+	/// is in the new committee).
+	pub my_signer: S,
+	/// Verifying keys, keyed by participant ID. Must cover every new
+	/// committee member; extra entries are ignored.
+	pub verifying_keys: BTreeMap<ParticipantId, S::PublicKey>,
+}
+
+impl<S: crate::keygen::dkg::TranscriptSigner> ResharingSignerConfig<S> {
+	/// Create a signer configuration, checking that `verifying_keys` covers
+	/// every new committee member.
+	pub fn new(
+		my_signer: S,
+		verifying_keys: BTreeMap<ParticipantId, S::PublicKey>,
+		new_participants: &[ParticipantId],
+	) -> Result<Self, ResharingConfigError> {
+		for p in new_participants {
+			if !verifying_keys.contains_key(p) {
+				return Err(ResharingConfigError::MissingVerifyingKey(*p));
+			}
+		}
+		Ok(Self { my_signer, verifying_keys })
+	}
+}
+
+/// Publicly verifiable certificate of a completed resharing session.
+///
+/// The no-ZK analog of a handoff certificate: it attests *process integrity*
+/// and *public-key preservation* — every new committee member verified its
+/// shares, observed the same transcript, and confirmed the reshared key still
+/// reconstructs the original public key. It does **not** prove statements
+/// about share distributions (that would require the deferred ZK machinery).
+///
+/// Verification requires only the new committee's verifying keys — no share
+/// material. A verifier that additionally holds the broadcast transcript can
+/// recompute `transcript_hash` and the `Σ_J t_J^new = T` public-key check
+/// independently.
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct ResharingCertificate {
+	/// Session identifier of the completed session.
+	pub ssid: [u8; RESHARING_SSID_SIZE],
+	/// The active set of old committee members that dealt in this session.
+	pub active_set: Vec<ParticipantId>,
+	/// Hash of the session transcript (active set, session seed, Round 3
+	/// dealer commitments, Round 5 broadcasts).
+	pub transcript_hash: [u8; COMMITMENT_HASH_SIZE],
+	/// Acceptance signatures from every new committee member, keyed by
+	/// participant ID.
+	pub accepts: BTreeMap<ParticipantId, Vec<u8>>,
+}
+
+impl ResharingCertificate {
+	/// Verify the certificate: every new committee member has a valid
+	/// acceptance signature over this certificate's `ssid` and
+	/// `transcript_hash`.
+	///
+	/// `verifying_keys` must contain a key for every member of
+	/// `new_participants`; returns `false` if any key or signature is missing
+	/// or invalid.
+	pub fn verify<S: crate::keygen::dkg::TranscriptSigner>(
+		&self,
+		new_participants: &[ParticipantId],
+		verifying_keys: &BTreeMap<ParticipantId, S::PublicKey>,
+	) -> bool {
+		let accept_hash = compute_accept_hash(&self.ssid, &self.transcript_hash);
+		new_participants.iter().all(|p| {
+			match (verifying_keys.get(p), self.accepts.get(p)) {
+				(Some(pk), Some(sig)) => S::verify_bytes(pk, &accept_hash, sig),
+				_ => false,
+			}
+		})
+	}
+}
+
+/// Domain separator for the acceptance hash.
+const ACCEPT_DOMAIN: &[u8] = b"resharing-accept-v1";
+
+/// Compute the 32-byte hash that new committee members sign to accept the
+/// session transcript: `SHAKE256("resharing-accept-v1" || ssid || transcript_hash)`.
+pub fn compute_accept_hash(
+	ssid: &[u8; RESHARING_SSID_SIZE],
+	transcript_hash: &[u8; COMMITMENT_HASH_SIZE],
+) -> [u8; 32] {
+	use qp_rusty_crystals_dilithium::fips202;
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, ACCEPT_DOMAIN);
+	fips202::shake256_absorb(&mut state, ssid);
+	fips202::shake256_absorb(&mut state, transcript_hash);
+	fips202::shake256_finalize(&mut state);
+	let mut out = [0u8; 32];
+	fips202::shake256_squeeze(&mut out, &mut state);
+	out
 }
 
 // ============================================================================
@@ -903,6 +1077,10 @@ pub struct ResharingOutput {
 	pub public_key: PublicKey,
 	/// The new threshold configuration.
 	pub new_config: ThresholdConfig,
+	/// Certificate of the completed session: acceptance signatures from every
+	/// new committee member over the agreed transcript hash. Verifiable by any
+	/// third party holding the new committee's verifying keys.
+	pub certificate: ResharingCertificate,
 }
 
 // ============================================================================

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -416,25 +416,31 @@ impl fmt::Display for ResharingConfigError {
 /// This allows messages to be serialized/deserialized without knowing
 /// the specific round at deserialization time.
 ///
-/// # Protocol Rounds (5-round session-randomized protocol)
+/// # Protocol Rounds (session-randomized protocol with active-set liveness)
 ///
-/// - **Round 1**: Entropy commitment (old committee broadcasts `H(entropy)`)
-/// - **Round 2**: Entropy reveal (old committee reveals entropy, session seed computed)
+/// - **Round 1**: Entropy commitment / Ready (old committee broadcasts `H(entropy)`)
+/// - **Act proposal**: Leader proposes the active set `Act` of ready old members
+/// - **Round 2**: Entropy reveal (active members reveal entropy, session seed computed)
 /// - **Round 3**: Sub-share commitments (designated dealers broadcast `H(r_{I→J})`)
 /// - **Round 4**: Private delivery (dealers send `r_{I→J}` to new committee)
 /// - **Round 5**: Verification (share commitments, partial PKs)
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub enum ResharingMessage {
-	/// Round 1: Entropy commitment from old committee members.
+	/// Round 1: Entropy commitment from old committee members (doubles as Ready).
 	Round1(ResharingRound1EntropyCommitment),
-	/// Round 2: Entropy reveal from old committee members.
+	/// Round 2: Entropy reveal from active old committee members.
 	Round2(ResharingRound2EntropyReveal),
-	/// Round 3: Hash commitments to per-subset sub-shares from old committee.
+	/// Round 3: Hash commitments to per-subset sub-shares from active old committee.
 	Round3(ResharingRound3Broadcast),
 	/// Round 4: New share distributions to new committee.
 	Round4(ResharingRound4Message),
 	/// Round 5: Verification commitments from new committee.
 	Round5(ResharingRound5Broadcast),
+	/// Active-set proposal from the session leader (between Rounds 1 and 2).
+	///
+	/// Appended after the round variants to preserve Borsh variant indices of
+	/// the pre-existing wire format.
+	ActProposal(ResharingActProposal),
 }
 
 impl ResharingMessage {
@@ -446,6 +452,7 @@ impl ResharingMessage {
 			ResharingMessage::Round3(msg) => &msg.ssid,
 			ResharingMessage::Round4(msg) => &msg.ssid,
 			ResharingMessage::Round5(msg) => &msg.ssid,
+			ResharingMessage::ActProposal(msg) => &msg.ssid,
 		}
 	}
 
@@ -457,13 +464,18 @@ impl ResharingMessage {
 			ResharingMessage::Round3(msg) => msg.party_id,
 			ResharingMessage::Round4(msg) => msg.from_party_id,
 			ResharingMessage::Round5(msg) => msg.party_id,
+			ResharingMessage::ActProposal(msg) => msg.party_id,
 		}
 	}
 
 	/// Get the round number of this message.
+	///
+	/// The Act proposal sits between Rounds 1 and 2; it reports round 1
+	/// (it concludes the Ready phase that Round 1 commitments open).
 	pub fn round(&self) -> u8 {
 		match self {
 			ResharingMessage::Round1(_) => 1,
+			ResharingMessage::ActProposal(_) => 1,
 			ResharingMessage::Round2(_) => 2,
 			ResharingMessage::Round3(_) => 3,
 			ResharingMessage::Round4(_) => 4,
@@ -497,6 +509,59 @@ pub struct ResharingRound1EntropyCommitment {
 	pub party_id: ParticipantId,
 	/// Hash commitment to the entropy: `SHAKE256("resharing-entropy-commit-v1" || entropy)`.
 	pub commitment: [u8; COMMITMENT_HASH_SIZE],
+}
+
+// ============================================================================
+// Active-Set Proposal (Ready-Round Liveness)
+// ============================================================================
+
+/// Active-set ("Act") proposal broadcast by the session leader.
+///
+/// Round 1 entropy commitments double as *Ready* signals: an old committee
+/// member that broadcasts its commitment is declaring itself online and
+/// willing to participate. The session leader (the lowest-ID new committee
+/// member) collects these and proposes the active set `Act` — the old
+/// committee members that will contribute entropy and deal sub-shares.
+///
+/// The leader proposes automatically once every old committee member has
+/// committed (fast path). If some old members are offline, the caller invokes
+/// [`ResharingProtocol::close_ready_window`](super::ResharingProtocol::close_ready_window)
+/// on the leader after a transport-level timeout, and the leader proposes
+/// `Act` = the members that committed so far.
+///
+/// # Validity
+///
+/// Every party independently verifies the proposal and aborts on violation:
+///
+/// - sender is the session leader,
+/// - `active_set` is strictly sorted, unique, and a subset of the old committee,
+/// - `|active_set| >= t_old`.
+///
+/// The threshold requirement guarantees every old RSS subset `I` (size
+/// `n_old - t_old + 1`) intersects `Act`, so a live dealer exists for every
+/// subset: dealers are reassigned to the lowest-ID member of `I ∩ Act`.
+///
+/// # Trust in the leader
+///
+/// The leader cannot break safety: it cannot forge Ready signals (parties
+/// only advance once they have seen the Round 1 commitment of every `Act`
+/// member), and the deterministic sub-share derivation means dealer *identity*
+/// does not affect the derived shares. A malicious leader can at most deny
+/// service (abort/stall) or select *which* committed members participate —
+/// the session seed remains unbiased because `|Act| >= t_old` guarantees at
+/// least one honest member whose entropy is unpredictable at proposal time
+/// (commitments hide entropy until Round 2). Equivocating proposals put the
+/// receiving parties in different sessions; their deterministic sub-share
+/// commitments then disagree and the protocol aborts.
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct ResharingActProposal {
+	/// Session identifier binding this message to the resharing session.
+	pub ssid: [u8; RESHARING_SSID_SIZE],
+	/// Party ID of the sender (must be the session leader).
+	pub party_id: ParticipantId,
+	/// Proposed active set: old committee members that will contribute entropy
+	/// and deal sub-shares. Strictly sorted, unique, `|active_set| >= t_old`.
+	pub active_set: Vec<ParticipantId>,
 }
 
 // ============================================================================
@@ -535,12 +600,13 @@ pub struct ResharingRound2EntropyReveal {
 
 /// Round 3 broadcast from old committee members.
 ///
-/// Each old committee member broadcasts hash commitments to the per-subset
-/// "sub-share" contributions they will privately deliver in Round 4. A party
-/// only commits to subsets where they are the *designated dealer* (the
-/// lowest-ID old participant in the subset). Other members of the same old
-/// subset independently recompute the same contributions and verify the
-/// commitments before Round 4 private delivery begins.
+/// Each active old committee member broadcasts hash commitments to the
+/// per-subset "sub-share" contributions they will privately deliver in Round 4.
+/// A party only commits to subsets where they are the *designated dealer* (the
+/// lowest-ID *active* old participant in the subset, `min(I ∩ Act)`). Other
+/// active members of the same old subset independently recompute the same
+/// contributions and verify the commitments before Round 4 private delivery
+/// begins.
 ///
 /// # Security
 ///

--- a/threshold/tests/common/mod.rs
+++ b/threshold/tests/common/mod.rs
@@ -1,0 +1,71 @@
+//! Shared test helpers for integration tests.
+
+use std::collections::BTreeMap;
+
+use qp_rusty_crystals_threshold::resharing::{
+	ResharingConfig, ResharingProtocol, ResharingSignerConfig, TranscriptSigner,
+};
+
+/// Minimal transcript signer for tests: "signature" = party_id || hash.
+///
+/// Mirrors the DKG unit-test signer. Verification checks that the embedded
+/// party ID matches the public key (which is just the party ID) and that the
+/// embedded hash matches, so signatures over a *different* transcript hash
+/// fail verification exactly like a real scheme.
+#[derive(Clone)]
+pub struct TestSigner {
+	pub id: u32,
+}
+
+impl TranscriptSigner for TestSigner {
+	type Signature = Vec<u8>;
+	type PublicKey = u32;
+
+	fn sign(&self, hash: &[u8; 32]) -> Self::Signature {
+		let mut sig = vec![0u8; 36];
+		sig[..4].copy_from_slice(&self.id.to_le_bytes());
+		sig[4..36].copy_from_slice(hash);
+		sig
+	}
+
+	fn verify(pk: &Self::PublicKey, hash: &[u8; 32], sig: &Self::Signature) -> bool {
+		Self::verify_bytes(pk, hash, sig)
+	}
+
+	fn verify_bytes(pk: &Self::PublicKey, hash: &[u8; 32], sig: &[u8]) -> bool {
+		if sig.len() < 36 {
+			return false;
+		}
+		let sig_id = u32::from_le_bytes(sig[..4].try_into().unwrap());
+		sig_id == *pk && &sig[4..36] == hash
+	}
+
+	fn public_key(&self) -> Self::PublicKey {
+		self.id
+	}
+}
+
+/// Build a `ResharingSignerConfig<TestSigner>` for the given config: this
+/// party's signer plus verifying keys for every participant.
+pub fn test_signer_config(config: &ResharingConfig) -> ResharingSignerConfig<TestSigner> {
+	let new_participants: Vec<u32> = config.new_participants().iter().collect();
+	let keys: BTreeMap<u32, u32> = config
+		.old_participants()
+		.iter()
+		.chain(config.new_participants().iter())
+		.map(|p| (p, p))
+		.collect();
+	ResharingSignerConfig::new(TestSigner { id: config.my_party_id() }, keys, &new_participants)
+		.expect("keys cover the new committee")
+}
+
+/// Construct a `ResharingProtocol<TestSigner>` with a signer config derived
+/// from the resharing config (drop-in for the pre-Round-6 constructor).
+pub fn new_test_protocol(
+	config: ResharingConfig,
+	seed: [u8; 32],
+	session_nonce: &[u8; 32],
+) -> ResharingProtocol<TestSigner> {
+	let signer_config = test_signer_config(&config);
+	ResharingProtocol::new(config, signer_config, seed, session_nonce)
+}

--- a/threshold/tests/common/mod.rs
+++ b/threshold/tests/common/mod.rs
@@ -66,6 +66,16 @@ pub fn new_test_protocol(
 	seed: [u8; 32],
 	session_nonce: &[u8; 32],
 ) -> ResharingProtocol<TestSigner> {
+	new_test_protocol_with_epoch(config, seed, session_nonce, 0)
+}
+
+/// Like [`new_test_protocol`], but with an explicit handoff epoch.
+pub fn new_test_protocol_with_epoch(
+	config: ResharingConfig,
+	seed: [u8; 32],
+	session_nonce: &[u8; 32],
+	epoch: u64,
+) -> ResharingProtocol<TestSigner> {
 	let signer_config = test_signer_config(&config);
-	ResharingProtocol::new(config, signer_config, seed, session_nonce)
+	ResharingProtocol::new(config, signer_config, seed, session_nonce, epoch)
 }

--- a/threshold/tests/coverage_tests.rs
+++ b/threshold/tests/coverage_tests.rs
@@ -11,7 +11,9 @@ use qp_rusty_crystals_threshold::{
 	Round3Broadcast, ThresholdConfig, ThresholdSigner,
 };
 
-use qp_rusty_crystals_threshold::resharing::{ResharingConfig, ResharingProtocol};
+use qp_rusty_crystals_threshold::resharing::ResharingConfig;
+
+mod common;
 
 // ============================================================================
 // HIGH PRIORITY: Security Tests
@@ -588,7 +590,7 @@ mod resharing_edge_cases {
 
 		let protocol_seed = [42u8; 32];
 		let session_nonce = [0x77u8; 32];
-		let mut protocol = ResharingProtocol::new(resharing_config, protocol_seed, &session_nonce);
+		let mut protocol = crate::common::new_test_protocol(resharing_config, protocol_seed, &session_nonce);
 
 		// Before completion, take_output should return None
 		let output1 = protocol.take_output();

--- a/threshold/tests/coverage_tests.rs
+++ b/threshold/tests/coverage_tests.rs
@@ -590,7 +590,8 @@ mod resharing_edge_cases {
 
 		let protocol_seed = [42u8; 32];
 		let session_nonce = [0x77u8; 32];
-		let mut protocol = crate::common::new_test_protocol(resharing_config, protocol_seed, &session_nonce);
+		let mut protocol =
+			crate::common::new_test_protocol(resharing_config, protocol_seed, &session_nonce);
 
 		// Before completion, take_output should return None
 		let output1 = protocol.take_output();

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -89,10 +89,7 @@ fn run_resharing_protocol_full(
 		new_participants.iter().all(|p| !offline.contains(p)),
 		"new committee members must be online (they receive the new shares)"
 	);
-	assert!(
-		slow.iter().all(|p| !offline.contains(p)),
-		"a party cannot be both slow and offline"
-	);
+	assert!(slow.iter().all(|p| !offline.contains(p)), "a party cannot be both slow and offline");
 
 	// Determine all parties involved (union of old and new), minus offline ones.
 	let mut all_parties: Vec<u32> =
@@ -4056,8 +4053,9 @@ fn test_tampered_accept_signature_aborts() {
 #[test]
 fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
 	use common::TestSigner as Signer;
-	use qp_rusty_crystals_threshold::resharing::{compute_accept_hash, ResharingCertificate};
-	use qp_rusty_crystals_threshold::resharing::TranscriptSigner as _;
+	use qp_rusty_crystals_threshold::resharing::{
+		compute_accept_hash, ResharingCertificate, TranscriptSigner as _,
+	};
 	use std::collections::BTreeMap;
 
 	let ssid = [7u8; 32];

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -46,13 +46,61 @@ fn run_resharing_protocol_with_tamper(
 	new_participants: Vec<u32>,
 	old_shares: &HashMap<u32, PrivateKeyShare>,
 	public_key: &PublicKey,
-	mut tamper: Option<TamperFn>,
+	tamper: Option<TamperFn>,
 ) -> Result<HashMap<u32, PrivateKeyShare>, String> {
-	// Determine all parties involved (union of old and new)
+	run_resharing_protocol_full(
+		old_threshold,
+		old_participants,
+		new_threshold,
+		new_participants,
+		old_shares,
+		public_key,
+		tamper,
+		&[],
+		&[],
+	)
+}
+
+/// Full-options harness: like `run_resharing_protocol_with_tamper`, but parties
+/// listed in `offline` are never instantiated and receive no messages —
+/// simulating dead nodes — and parties listed in `slow` are frozen (not poked,
+/// no message delivery) until the ready window closes — simulating live nodes
+/// that lag past the leader's ready timeout and are therefore excluded from the
+/// active set. When the protocol goes quiescent (no progress because the leader
+/// is waiting for Ready signals that will never arrive), the harness calls
+/// `close_ready_window()` on the leader once, mimicking a production transport
+/// timeout, and unfreezes slow parties so they catch up as non-active observers.
+#[allow(clippy::too_many_arguments)]
+fn run_resharing_protocol_full(
+	old_threshold: u32,
+	old_participants: Vec<u32>,
+	new_threshold: u32,
+	new_participants: Vec<u32>,
+	old_shares: &HashMap<u32, PrivateKeyShare>,
+	public_key: &PublicKey,
+	mut tamper: Option<TamperFn>,
+	offline: &[u32],
+	slow: &[u32],
+) -> Result<HashMap<u32, PrivateKeyShare>, String> {
+	assert!(
+		new_participants.iter().all(|p| !offline.contains(p)),
+		"new committee members must be online (they receive the new shares)"
+	);
+	assert!(
+		slow.iter().all(|p| !offline.contains(p)),
+		"a party cannot be both slow and offline"
+	);
+
+	// Determine all parties involved (union of old and new), minus offline ones.
 	let mut all_parties: Vec<u32> =
 		old_participants.iter().chain(new_participants.iter()).cloned().collect();
 	all_parties.sort();
 	all_parties.dedup();
+	all_parties.retain(|p| !offline.contains(p));
+
+	// The session leader: lowest-ID new committee member.
+	let leader = *new_participants.iter().min().expect("non-empty new committee");
+	assert!(!slow.contains(&leader), "the leader cannot be slow (it closes the ready window)");
 
 	// Session nonce for SSID computation (shared by all parties in this resharing)
 	let session_nonce = [0x99u8; 32];
@@ -96,6 +144,8 @@ fn run_resharing_protocol_with_tamper(
 	// Run the protocol until all parties are done
 	let max_iterations = 1000;
 	let mut iteration = 0;
+	let mut ready_window_closed = false;
+	let mut quiescent_iterations = 0;
 
 	loop {
 		iteration += 1;
@@ -110,8 +160,19 @@ fn run_resharing_protocol_with_tamper(
 			break;
 		}
 
+		// Whether any message was delivered or any non-Wait action was produced
+		// this iteration. If not, the protocol is quiescent (stalled waiting for
+		// offline parties).
+		let mut any_activity = false;
+
 		// Process each party
 		for &party_id in &all_parties {
+			// Slow parties are frozen (no delivery, no poke) until the ready
+			// window closes; their inbound messages accumulate in the queue.
+			if !ready_window_closed && slow.contains(&party_id) {
+				continue;
+			}
+
 			let protocol = protocols.get_mut(&party_id).unwrap();
 
 			// Skip if already done or failed
@@ -124,6 +185,7 @@ fn run_resharing_protocol_with_tamper(
 			let messages_to_deliver: Vec<_> = std::mem::take(messages);
 
 			for (from, data) in messages_to_deliver {
+				any_activity = true;
 				protocol.message(from, data).unwrap();
 			}
 
@@ -133,6 +195,7 @@ fn run_resharing_protocol_with_tamper(
 					// Nothing to do
 				},
 				Ok(Action::SendMany(data)) => {
+					any_activity = true;
 					let payload = match tamper.as_mut() {
 						Some(f) => f(party_id, None, data),
 						None => data,
@@ -147,6 +210,7 @@ fn run_resharing_protocol_with_tamper(
 					}
 				},
 				Ok(Action::SendPrivate(to, data)) => {
+					any_activity = true;
 					// Send to specific party. We deliberately do NOT loop self-private
 					// messages back: the protocol must handle self-deals locally and
 					// never emit SendPrivate(self, _).
@@ -160,7 +224,10 @@ fn run_resharing_protocol_with_tamper(
 						Some(f) => f(party_id, Some(to), data),
 						None => data,
 					};
-					message_queues.get_mut(&to).unwrap().push((party_id, payload));
+					// Messages to offline parties are dropped (dead node).
+					if let Some(queue) = message_queues.get_mut(&to) {
+						queue.push((party_id, payload));
+					}
 				},
 				Ok(Action::Return(_)) => {
 					// Protocol complete for this party
@@ -168,6 +235,32 @@ fn run_resharing_protocol_with_tamper(
 				Err(e) => {
 					return Err(format!("Protocol error for party {}: {}", party_id, e));
 				},
+			}
+		}
+
+		// Quiescence handling: with offline old members, the leader waits for
+		// Ready signals that never arrive. Mimic a production transport timeout
+		// by closing the ready window on the leader once.
+		if !any_activity {
+			if !ready_window_closed {
+				ready_window_closed = true;
+				protocols
+					.get_mut(&leader)
+					.expect("leader is online")
+					.close_ready_window()
+					.map_err(|e| format!("close_ready_window failed: {}", e))?;
+			} else {
+				quiescent_iterations += 1;
+				if quiescent_iterations > 5 {
+					let states: Vec<String> = all_parties
+						.iter()
+						.map(|p| format!("{}: {:?}", p, protocols[p].state()))
+						.collect();
+					return Err(format!(
+						"Protocol deadlocked after ready window closed; states: [{}]",
+						states.join(", ")
+					));
+				}
 			}
 		}
 	}
@@ -3626,4 +3719,244 @@ fn test_recovered_partial_variance_3_of_5() {
 // overshoot ≤ κ assertion runs in the default suite alongside the cheaper configs.
 fn test_recovered_partial_variance_4_of_6() {
 	analyze_recovered_partials(4, 6, 10);
+}
+
+// ============================================================================
+// Active-Set Liveness Tests (Ready round + dealer failover)
+// ============================================================================
+
+/// Resharing away from a dead node: the main operational reason to reshare.
+/// Old committee {0,1,2} (t=2) with party 2 offline; new committee {0,1,3}.
+/// The leader (party 0) closes the ready window, Act = {0,1} >= t_old, and
+/// dealers for subsets containing party 2 fail over to the other member.
+#[test]
+fn test_resharing_succeeds_with_offline_old_party() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let result = run_resharing_protocol_full(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![0, 1, 3],
+		&old_shares,
+		&public_key,
+		None,
+		&[2], // party 2 is offline
+		&[],
+	);
+
+	assert!(result.is_ok(), "Resharing with offline old party failed: {:?}", result.err());
+	let new_shares = result.unwrap();
+	assert_eq!(new_shares.len(), 3);
+	assert!(new_shares.contains_key(&0));
+	assert!(new_shares.contains_key(&1));
+	assert!(new_shares.contains_key(&3));
+
+	// The new committee can sign under the unchanged public key, including a
+	// signer pair containing the joining party.
+	let new_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let signing_shares =
+		vec![new_shares.get(&0).unwrap().clone(), new_shares.get(&3).unwrap().clone()];
+	let is_valid =
+		run_signing_and_verify(&signing_shares, &public_key, new_config, b"offline reshare", b"");
+	assert!(is_valid, "Signature with reshared shares should verify");
+}
+
+/// Dealer failover for the lowest-ID old participant: party 0 previously dealt
+/// every subset containing it; with party 0 offline, dealers must fail over to
+/// `min(I ∩ Act)`. Also exercises a leader (party 1) that differs from the
+/// lowest old ID.
+#[test]
+fn test_resharing_offline_lowest_id_dealer_fails_over() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let result = run_resharing_protocol_full(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![1, 2, 3],
+		&old_shares,
+		&public_key,
+		None,
+		&[0], // the would-be default dealer for every subset containing it
+		&[],
+	);
+
+	assert!(result.is_ok(), "Resharing with offline dealer failed: {:?}", result.err());
+	let new_shares = result.unwrap();
+	assert_eq!(new_shares.len(), 3);
+
+	let new_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let signing_shares =
+		vec![new_shares.get(&2).unwrap().clone(), new_shares.get(&3).unwrap().clone()];
+	let is_valid =
+		run_signing_and_verify(&signing_shares, &public_key, new_config, b"dealer failover", b"");
+	assert!(is_valid, "Signature with reshared shares should verify");
+}
+
+/// Below-threshold participation must abort: with only 1 of 3 old members
+/// online and t_old = 2, closing the ready window aborts with
+/// InsufficientParties instead of producing shares.
+#[test]
+fn test_resharing_aborts_below_old_threshold() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let result = run_resharing_protocol_full(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![0, 3],
+		&old_shares,
+		&public_key,
+		None,
+		&[1, 2], // only old party 0 remains: |Act| = 1 < t_old = 2
+		&[],
+	);
+
+	let err = result.expect_err("resharing below the old threshold must abort");
+	assert!(
+		err.contains("Insufficient parties"),
+		"expected InsufficientParties abort, got: {}",
+		err
+	);
+}
+
+/// Only the session leader (lowest-ID new committee member) may close the
+/// ready window.
+#[test]
+fn test_close_ready_window_requires_leader() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let session_nonce = [0x77u8; 32];
+	let make_protocol = |party_id: u32| {
+		let share = shares.iter().find(|s| s.party_id() == party_id).cloned();
+		let config = ResharingConfig::new(
+			share,
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 3],
+			party_id,
+			public_key.clone(),
+		)
+		.expect("valid config");
+		ResharingProtocol::new(config, [9u8; 32], &session_nonce)
+	};
+
+	// Party 1 is not the leader (leader = min{0,1,3} = 0).
+	let mut non_leader = make_protocol(1);
+	assert_eq!(non_leader.leader(), 0);
+	assert!(non_leader.close_ready_window().is_err(), "non-leader must be rejected");
+
+	// Party 0 is the leader; closing is accepted (and idempotent).
+	let mut leader = make_protocol(0);
+	assert!(leader.close_ready_window().is_ok());
+	assert!(leader.close_ready_window().is_ok());
+}
+
+/// A slow-but-online old member that misses the ready window is excluded from
+/// `Act` but, as a new committee member, must still catch up as an observer and
+/// receive its new shares. Old committee {0,1,2} (t=2), new committee {1,2,3};
+/// party 2 (in both committees) is frozen until the leader closes the ready
+/// window, so Act = {0,1}. Party 2 contributes no entropy and deals nothing,
+/// yet must end up with a working share of the unchanged key.
+#[test]
+fn test_slow_old_member_excluded_from_act_still_gets_new_shares() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let result = run_resharing_protocol_full(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![1, 2, 3],
+		&old_shares,
+		&public_key,
+		None,
+		&[],
+		&[2], // party 2 lags past the ready window
+	);
+
+	assert!(result.is_ok(), "Resharing with slow old member failed: {:?}", result.err());
+	let new_shares = result.unwrap();
+	assert_eq!(new_shares.len(), 3);
+
+	// The slow party's share must be genuine: sign with a pair that includes it.
+	let new_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let signing_shares =
+		vec![new_shares.get(&2).unwrap().clone(), new_shares.get(&3).unwrap().clone()];
+	let is_valid =
+		run_signing_and_verify(&signing_shares, &public_key, new_config, b"slow observer", b"");
+	assert!(is_valid, "Signature with the slow party's reshared share should verify");
+}
+
+/// A slow-but-online OldOnly member (leaving the committee) that misses the
+/// ready window is excluded from `Act` and participates purely as an observer:
+/// it contributes no entropy, deals nothing, receives no shares — but must
+/// still complete the session cleanly. The harness requires every online party
+/// (including the observer) to reach Done without a protocol error before it
+/// returns, so a successful run is the assertion.
+#[test]
+fn test_slow_old_only_member_observes_and_completes() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let result = run_resharing_protocol_full(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![0, 1, 3],
+		&old_shares,
+		&public_key,
+		None,
+		&[],
+		&[2], // party 2 is OldOnly and lags past the ready window
+	);
+
+	assert!(result.is_ok(), "Resharing with slow OldOnly observer failed: {:?}", result.err());
+	let new_shares = result.unwrap();
+	assert_eq!(new_shares.len(), 3);
+	assert!(!new_shares.contains_key(&2), "OldOnly observer must not receive a share");
+
+	let new_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let signing_shares =
+		vec![new_shares.get(&1).unwrap().clone(), new_shares.get(&3).unwrap().clone()];
+	let is_valid =
+		run_signing_and_verify(&signing_shares, &public_key, new_config, b"oldonly observer", b"");
+	assert!(is_valid, "Signature with reshared shares should verify");
 }

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -306,6 +306,14 @@ fn run_resharing_protocol_full(
 				},
 		}
 
+		// Old committee members must erase their pre-handoff share on success.
+		if old_participants.contains(&party_id) && !protocol.old_share_erased() {
+			return Err(format!(
+				"Party {} did not erase its old share after successful resharing",
+				party_id
+			));
+		}
+
 		if new_participants.contains(&party_id) {
 			if let Some(share) = output.private_share {
 				new_shares.insert(party_id, share);

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -61,6 +61,7 @@ fn run_resharing_protocol_with_tamper(
 		tamper,
 		&[],
 		&[],
+		None,
 	)
 }
 
@@ -73,6 +74,11 @@ fn run_resharing_protocol_with_tamper(
 /// is waiting for Ready signals that will never arrive), the harness calls
 /// `close_ready_window()` on the leader once, mimicking a production transport
 /// timeout, and unfreezes slow parties so they catch up as non-active observers.
+///
+/// When `expected_act` is `Some`, the harness calls `set_expected_active_set`
+/// on the leader after construction and *fails* on quiescence instead of
+/// closing the ready window — proving the expected set alone (no transport
+/// timeout) unblocks the session.
 #[allow(clippy::too_many_arguments)]
 fn run_resharing_protocol_full(
 	old_threshold: u32,
@@ -84,6 +90,7 @@ fn run_resharing_protocol_full(
 	mut tamper: Option<TamperFn>,
 	offline: &[u32],
 	slow: &[u32],
+	expected_act: Option<&[u32]>,
 ) -> Result<HashMap<u32, PrivateKeyShare>, String> {
 	assert!(
 		new_participants.iter().all(|p| !offline.contains(p)),
@@ -133,6 +140,16 @@ fn run_resharing_protocol_full(
 
 		let protocol = new_test_protocol(config, seed, &session_nonce);
 		protocols.insert(party_id, protocol);
+	}
+
+	// With an expected active set, the leader proposes as soon as every
+	// expected member has committed — no transport timeout needed.
+	if let Some(expected) = expected_act {
+		protocols
+			.get_mut(&leader)
+			.expect("leader is online")
+			.set_expected_active_set(expected)
+			.map_err(|e| format!("set_expected_active_set failed: {}", e))?;
 	}
 
 	// Message queues for each party
@@ -230,7 +247,10 @@ fn run_resharing_protocol_full(
 					}
 				},
 				Ok(Action::Return(_)) => {
-					// Protocol complete for this party
+					// Protocol complete for this party. Counts as activity so
+					// the iteration where the last parties finish is not
+					// mistaken for quiescence.
+					any_activity = true;
 				},
 				Err(e) => {
 					return Err(format!("Protocol error for party {}: {}", party_id, e));
@@ -242,6 +262,18 @@ fn run_resharing_protocol_full(
 		// Ready signals that never arrive. Mimic a production transport timeout
 		// by closing the ready window on the leader once.
 		if !any_activity {
+			if expected_act.is_some() && !ready_window_closed {
+				// The expected active set must unblock the session on its own;
+				// needing a timeout means the deterministic path failed.
+				let states: Vec<String> = all_parties
+					.iter()
+					.map(|p| format!("{}: {:?}", p, protocols[p].state()))
+					.collect();
+				return Err(format!(
+					"protocol went quiescent despite an expected active set; states: [{}]",
+					states.join(", ")
+				));
+			}
 			if !ready_window_closed {
 				ready_window_closed = true;
 				protocols
@@ -3779,6 +3811,7 @@ fn test_resharing_succeeds_with_offline_old_party() {
 		None,
 		&[2], // party 2 is offline
 		&[],
+		None,
 	);
 
 	assert!(result.is_ok(), "Resharing with offline old party failed: {:?}", result.err());
@@ -3823,6 +3856,7 @@ fn test_resharing_offline_lowest_id_dealer_fails_over() {
 		None,
 		&[0], // the would-be default dealer for every subset containing it
 		&[],
+		None,
 	);
 
 	assert!(result.is_ok(), "Resharing with offline dealer failed: {:?}", result.err());
@@ -3861,6 +3895,7 @@ fn test_resharing_aborts_below_old_threshold() {
 		None,
 		&[1, 2], // only old party 0 remains: |Act| = 1 < t_old = 2
 		&[],
+		None,
 	);
 
 	let err = result.expect_err("resharing below the old threshold must abort");
@@ -3933,6 +3968,7 @@ fn test_slow_old_member_excluded_from_act_still_gets_new_shares() {
 		None,
 		&[],
 		&[2], // party 2 lags past the ready window
+		None,
 	);
 
 	assert!(result.is_ok(), "Resharing with slow old member failed: {:?}", result.err());
@@ -3975,6 +4011,7 @@ fn test_slow_old_only_member_observes_and_completes() {
 		None,
 		&[],
 		&[2], // party 2 is OldOnly and lags past the ready window
+		None,
 	);
 
 	assert!(result.is_ok(), "Resharing with slow OldOnly observer failed: {:?}", result.err());
@@ -4091,4 +4128,223 @@ fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
 	let mut forged = cert;
 	forged.accepts.insert(1, Signer { id: 0 }.sign(&accept_hash));
 	assert!(!forged.verify::<Signer>(&new_participants, &keys));
+}
+
+// ============================================================================
+// Commit-reveal binding vs the Act proposal
+// ============================================================================
+
+/// An honest active member must not broadcast its Round 2 entropy reveal until
+/// it holds a Round 1 commitment from *every* Act member. Otherwise a
+/// malicious leader could list a colluding member that commits only after
+/// observing honest reveals, choosing its entropy adaptively to bias the
+/// session seed.
+///
+/// Old = new = {0, 1, 2} (t = 2), leader = 0. Party 2's commitment is
+/// delivered to the leader (so the fast-path Act = {0, 1, 2}) but withheld
+/// from party 1. After receiving the Act proposal, party 1 must keep waiting;
+/// only once party 2's commitment arrives may it reveal.
+#[test]
+fn test_no_reveal_until_all_act_commitments_held() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let session_nonce = [0x55u8; 32];
+	let make_protocol = |party_id: u32| {
+		let share = shares.iter().find(|s| s.party_id() == party_id).cloned();
+		let config = ResharingConfig::new(
+			share,
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 2],
+			party_id,
+			public_key.clone(),
+		)
+		.expect("valid config");
+		let mut seed = [9u8; 32];
+		seed[0..4].copy_from_slice(&party_id.to_le_bytes());
+		new_test_protocol(config, seed, &session_nonce)
+	};
+
+	let mut leader = make_protocol(0);
+	let mut party1 = make_protocol(1);
+	let mut party2 = make_protocol(2);
+
+	// Round 1: everyone emits its entropy commitment.
+	let commit0 = match leader.poke().expect("leader round 1") {
+		Action::SendMany(data) => data,
+		other => panic!("expected leader commitment broadcast, got {:?}", other),
+	};
+	let commit1 = match party1.poke().expect("party 1 round 1") {
+		Action::SendMany(data) => data,
+		other => panic!("expected party 1 commitment broadcast, got {:?}", other),
+	};
+	let commit2 = match party2.poke().expect("party 2 round 1") {
+		Action::SendMany(data) => data,
+		other => panic!("expected party 2 commitment broadcast, got {:?}", other),
+	};
+
+	// Leader receives all commitments and proposes Act = {0, 1, 2} (fast path).
+	leader.message(1, commit1).expect("deliver c1 to leader");
+	leader.message(2, commit2.clone()).expect("deliver c2 to leader");
+	let act_proposal = match leader.poke().expect("leader act proposal") {
+		Action::SendMany(data) => data,
+		other => panic!("expected Act proposal broadcast, got {:?}", other),
+	};
+	assert_eq!(leader.active_set(), Some(&[0u32, 1, 2][..]));
+
+	// Party 1 receives the leader's commitment and the Act proposal, but NOT
+	// party 2's commitment. It must not reveal yet.
+	party1.message(0, commit0).expect("deliver c0 to party 1");
+	party1.message(0, act_proposal).expect("deliver act proposal to party 1");
+	assert_eq!(party1.active_set(), Some(&[0u32, 1, 2][..]));
+	assert!(
+		matches!(party1.poke().expect("party 1 waits"), Action::Wait),
+		"party 1 must not reveal while an Act member's commitment is missing"
+	);
+	assert!(
+		matches!(party1.state(), ResharingState::Round1Waiting),
+		"party 1 must stay in Round1Waiting, was {:?}",
+		party1.state()
+	);
+
+	// Once party 2's commitment arrives, party 1 reveals.
+	party1.message(2, commit2).expect("deliver c2 to party 1");
+	match party1.poke().expect("party 1 reveals") {
+		Action::SendMany(data) => {
+			let msg: ResharingMessage = borsh::from_slice(&data).expect("decode reveal");
+			assert!(
+				matches!(msg, ResharingMessage::Round2(_)),
+				"expected a Round 2 entropy reveal"
+			);
+		},
+		other => panic!("expected party 1's Round 2 reveal, got {:?}", other),
+	}
+}
+
+// ============================================================================
+// Expected active set (deterministic Act proposal for partial-mesh transports)
+// ============================================================================
+
+/// With `set_expected_active_set`, the leader proposes Act as soon as every
+/// expected member has committed — no `close_ready_window` transport timeout
+/// is needed. Models NEAR MPC's topology, where the resharing mesh spans only
+/// the new participant set and old-only members are structurally unreachable:
+/// old {0, 1, 2} (t = 2), new {1, 2, 3}, party 0 offline, expected = {1, 2}.
+/// The harness fails on quiescence when an expected set is provided, so
+/// success proves the deterministic path unblocked the session by itself.
+#[test]
+fn test_expected_active_set_completes_without_timeout() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let result = run_resharing_protocol_full(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![1, 2, 3],
+		&old_shares,
+		&public_key,
+		None,
+		&[0], // structurally unreachable (not in the new mesh)
+		&[],
+		Some(&[1, 2]),
+	);
+
+	assert!(result.is_ok(), "Resharing with expected active set failed: {:?}", result.err());
+	let new_shares = result.unwrap();
+	assert_eq!(new_shares.len(), 3);
+
+	let new_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let signing_shares =
+		vec![new_shares.get(&1).unwrap().clone(), new_shares.get(&3).unwrap().clone()];
+	let is_valid =
+		run_signing_and_verify(&signing_shares, &public_key, new_config, b"expected act", b"");
+	assert!(is_valid, "Signature with reshared shares should verify");
+}
+
+/// A committed member outside the expected set is still included in Act: the
+/// expected set is a liveness floor, not a cap. Everyone is online here, and
+/// messages flow freely, so whether Act ends up {1, 2} or {0, 1, 2} depends on
+/// arrival order — either way the session must complete without a timeout.
+#[test]
+fn test_expected_active_set_does_not_exclude_live_members() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	let result = run_resharing_protocol_full(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![0, 1, 2],
+		&old_shares,
+		&public_key,
+		None,
+		&[],
+		&[],
+		Some(&[0, 1]),
+	);
+
+	assert!(result.is_ok(), "Resharing with expected subset failed: {:?}", result.err());
+	let new_shares = result.unwrap();
+	assert_eq!(new_shares.len(), 3);
+
+	let new_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let signing_shares =
+		vec![new_shares.get(&0).unwrap().clone(), new_shares.get(&2).unwrap().clone()];
+	let is_valid =
+		run_signing_and_verify(&signing_shares, &public_key, new_config, b"expected floor", b"");
+	assert!(is_valid, "Signature with reshared shares should verify");
+}
+
+/// `set_expected_active_set` validation: leader-only, must be a subset of the
+/// old committee, and must have at least `t_old` members.
+#[test]
+fn test_set_expected_active_set_validation() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let session_nonce = [0x66u8; 32];
+	let make_protocol = |party_id: u32| {
+		let share = shares.iter().find(|s| s.party_id() == party_id).cloned();
+		let config = ResharingConfig::new(
+			share,
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![1, 2, 3],
+			party_id,
+			public_key.clone(),
+		)
+		.expect("valid config");
+		new_test_protocol(config, [9u8; 32], &session_nonce)
+	};
+
+	// Leader = min{1, 2, 3} = 1. Non-leaders are rejected.
+	let mut non_leader = make_protocol(2);
+	assert_eq!(non_leader.leader(), 1);
+	assert!(non_leader.set_expected_active_set(&[1, 2]).is_err(), "non-leader must be rejected");
+
+	let mut leader = make_protocol(1);
+	// Not a subset of the old committee.
+	assert!(leader.set_expected_active_set(&[1, 3]).is_err(), "must be a subset of old");
+	// Below the old threshold.
+	assert!(leader.set_expected_active_set(&[1]).is_err(), "must have at least t_old members");
+	// Valid (duplicates tolerated).
+	assert!(leader.set_expected_active_set(&[2, 1, 2]).is_ok());
 }

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -16,6 +16,9 @@ use qp_rusty_crystals_threshold::resharing::{
 	ResharingProtocol, ResharingState,
 };
 
+mod common;
+use common::{new_test_protocol, TestSigner};
+
 /// Helper to run the resharing protocol locally with simulated message passing.
 fn run_resharing_protocol(
 	old_threshold: u32,
@@ -106,7 +109,7 @@ fn run_resharing_protocol_full(
 	let session_nonce = [0x99u8; 32];
 
 	// Create protocol instances for each party
-	let mut protocols: HashMap<u32, ResharingProtocol> = HashMap::new();
+	let mut protocols: HashMap<u32, ResharingProtocol<TestSigner>> = HashMap::new();
 
 	for &party_id in &all_parties {
 		let existing_share = old_shares.get(&party_id).cloned();
@@ -131,7 +134,7 @@ fn run_resharing_protocol_full(
 			*byte = ((party_id as u8).wrapping_mul(i as u8)).wrapping_add(0x42);
 		}
 
-		let protocol = ResharingProtocol::new(config, seed, &session_nonce);
+		let protocol = new_test_protocol(config, seed, &session_nonce);
 		protocols.insert(party_id, protocol);
 	}
 
@@ -265,10 +268,14 @@ fn run_resharing_protocol_full(
 		}
 	}
 
-	// Collect new shares from new committee members
+	// Collect outputs from every online party (new members carry shares;
+	// old-only observers carry just the certificate).
 	let mut new_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	let verifying_keys: std::collections::BTreeMap<u32, u32> =
+		all_parties.iter().map(|&p| (p, p)).collect();
+	let mut reference_transcript_hash: Option<[u8; 32]> = None;
 
-	for &party_id in &new_participants {
+	for &party_id in &all_parties {
 		let protocol = protocols.get_mut(&party_id).unwrap();
 
 		if protocol.is_failed() {
@@ -279,13 +286,30 @@ fn run_resharing_protocol_full(
 			return Err(format!("Party {} not done", party_id));
 		}
 
-		// Get the output using take_output
-		if let Some(output) = protocol.take_output() {
+		let Some(output) = protocol.take_output() else {
+			return Err(format!("Party {} has no output", party_id));
+		};
+
+		// Every party must emit a valid certificate over the same transcript.
+		let cert = &output.certificate;
+		if !cert.verify::<TestSigner>(&new_participants, &verifying_keys) {
+			return Err(format!("Party {}'s certificate does not verify", party_id));
+		}
+		match reference_transcript_hash {
+			None => reference_transcript_hash = Some(cert.transcript_hash),
+			Some(reference) =>
+				if cert.transcript_hash != reference {
+					return Err(format!(
+						"Party {} disagrees on the certificate transcript hash",
+						party_id
+					));
+				},
+		}
+
+		if new_participants.contains(&party_id) {
 			if let Some(share) = output.private_share {
 				new_shares.insert(party_id, share);
 			}
-		} else {
-			return Err(format!("Party {} has no output", party_id));
 		}
 	}
 
@@ -527,7 +551,7 @@ fn test_resharing_protocol_creation() {
 
 	let protocol_seed = [42u8; 32];
 	let session_nonce = [0x88u8; 32];
-	let protocol = ResharingProtocol::new(resharing_config, protocol_seed, &session_nonce);
+	let protocol = new_test_protocol(resharing_config, protocol_seed, &session_nonce);
 	assert_eq!(*protocol.state(), ResharingState::Round1Generate);
 }
 
@@ -550,7 +574,7 @@ fn test_resharing_protocol_round1_generation() {
 
 	let protocol_seed = [42u8; 32];
 	let session_nonce = [0x55u8; 32];
-	let mut protocol = ResharingProtocol::new(resharing_config, protocol_seed, &session_nonce);
+	let mut protocol = new_test_protocol(resharing_config, protocol_seed, &session_nonce);
 
 	// First poke should generate Round 1 message (entropy commitment)
 	let action = protocol.poke().expect("poke should succeed");
@@ -594,7 +618,7 @@ fn test_resharing_new_party_skips_round1() {
 
 	let protocol_seed = [42u8; 32];
 	let session_nonce = [0x66u8; 32];
-	let mut protocol = ResharingProtocol::new(resharing_config, protocol_seed, &session_nonce);
+	let mut protocol = new_test_protocol(resharing_config, protocol_seed, &session_nonce);
 
 	// New party should skip Round 1-2 (entropy commit-reveal) and wait
 	let action = protocol.poke().expect("poke should succeed");
@@ -945,7 +969,7 @@ fn test_valid_resharing_configuration_succeeds() {
 	.expect("valid config");
 
 	let session_nonce = [0xFFu8; 32];
-	let _protocol = ResharingProtocol::new(resharing_config, [42u8; 32], &session_nonce);
+	let _protocol = new_test_protocol(resharing_config, [42u8; 32], &session_nonce);
 
 	// Valid: NewOnly with None
 	let resharing_config2 = ResharingConfig::new(
@@ -959,7 +983,7 @@ fn test_valid_resharing_configuration_succeeds() {
 	)
 	.expect("valid config for NewOnly");
 
-	let _protocol2 = ResharingProtocol::new(resharing_config2, [42u8; 32], &session_nonce);
+	let _protocol2 = new_test_protocol(resharing_config2, [42u8; 32], &session_nonce);
 }
 
 #[test]
@@ -1024,7 +1048,7 @@ fn test_resharing_round1_message_from_non_member_ignored() {
 	.expect("valid config");
 
 	let session_nonce = [0x44u8; 32];
-	let mut protocol = ResharingProtocol::new(resharing_config, [42u8; 32], &session_nonce);
+	let mut protocol = new_test_protocol(resharing_config, [42u8; 32], &session_nonce);
 
 	// Generate Round 1 message first
 	let _ = protocol.poke().expect("poke should succeed");
@@ -1072,8 +1096,8 @@ fn test_resharing_duplicate_message_ignored() {
 	.expect("valid config");
 
 	let session_nonce = [0x33u8; 32];
-	let mut protocol0 = ResharingProtocol::new(config0, [0u8; 32], &session_nonce);
-	let mut protocol1 = ResharingProtocol::new(config1, [1u8; 32], &session_nonce);
+	let mut protocol0 = new_test_protocol(config0, [0u8; 32], &session_nonce);
+	let mut protocol1 = new_test_protocol(config1, [1u8; 32], &session_nonce);
 
 	// Generate Round 0 messages
 	let msg0 = match protocol0.poke().expect("poke should succeed") {
@@ -1138,7 +1162,7 @@ fn test_old_only_party_behavior() {
 	.expect("valid config");
 
 	let session_nonce = [0x22u8; 32];
-	let mut protocol = ResharingProtocol::new(resharing_config, [42u8; 32], &session_nonce);
+	let mut protocol = new_test_protocol(resharing_config, [42u8; 32], &session_nonce);
 
 	// Party should participate in Round 0 (entropy commitment)
 	let action = protocol.poke().expect("poke should succeed");
@@ -1169,7 +1193,7 @@ fn test_new_only_party_behavior() {
 	.expect("valid config");
 
 	let session_nonce = [0x11u8; 32];
-	let mut protocol = ResharingProtocol::new(resharing_config, [42u8; 32], &session_nonce);
+	let mut protocol = new_test_protocol(resharing_config, [42u8; 32], &session_nonce);
 
 	// New party should skip Round 1-2 (entropy commit-reveal) and wait
 	let action = protocol.poke().expect("poke should succeed");
@@ -1658,7 +1682,7 @@ fn run_resharing_protocol_with_seeds(
 	let session_nonce = [0xCCu8; 32];
 
 	// Create protocol instances for each party with the provided seeds
-	let mut protocols: HashMap<u32, ResharingProtocol> = HashMap::new();
+	let mut protocols: HashMap<u32, ResharingProtocol<TestSigner>> = HashMap::new();
 
 	for &party_id in &all_parties {
 		let existing_share = old_shares.get(&party_id).cloned();
@@ -1676,7 +1700,7 @@ fn run_resharing_protocol_with_seeds(
 
 		// Use the provided seed for this party
 		let seed = party_seeds.get(&party_id).copied().unwrap_or([0u8; 32]);
-		let protocol = ResharingProtocol::new(config, seed, &session_nonce);
+		let protocol = new_test_protocol(config, seed, &session_nonce);
 		protocols.insert(party_id, protocol);
 	}
 
@@ -3863,7 +3887,7 @@ fn test_close_ready_window_requires_leader() {
 			public_key.clone(),
 		)
 		.expect("valid config");
-		ResharingProtocol::new(config, [9u8; 32], &session_nonce)
+		new_test_protocol(config, [9u8; 32], &session_nonce)
 	};
 
 	// Party 1 is not the leader (leader = min{0,1,3} = 0).
@@ -3959,4 +3983,106 @@ fn test_slow_old_only_member_observes_and_completes() {
 	let is_valid =
 		run_signing_and_verify(&signing_shares, &public_key, new_config, b"oldonly observer", b"");
 	assert!(is_valid, "Signature with reshared shares should verify");
+}
+
+// ============================================================================
+// Round 6: Signed Transcript Acceptance (Certificate)
+// ============================================================================
+//
+// Certificate coverage for the happy path is built into the harness: every
+// successful `run_resharing_protocol_full` call verifies each party's
+// certificate against the new committee's keys and checks that all parties
+// agree on the transcript hash.
+
+/// A corrupted acceptance signature must abort the protocol on every party
+/// that receives it: signature verification against the local transcript hash
+/// fails in the Accept round.
+#[test]
+fn test_tampered_accept_signature_aborts() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	// Corrupt party 1's broadcast Accept signature in flight.
+	let tamper: TamperFn = Box::new(move |sender, _recipient, data| {
+		if sender != 1 {
+			return data;
+		}
+		let msg: ResharingMessage = match borsh::from_slice(&data) {
+			Ok(m) => m,
+			Err(_) => return data,
+		};
+		if let ResharingMessage::Accept(mut accept) = msg {
+			accept.signature[4] ^= 0xFF;
+			return borsh::to_vec(&ResharingMessage::Accept(accept))
+				.expect("re-serialize tampered accept");
+		}
+		data
+	});
+
+	let result = run_resharing_protocol_with_tamper(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![0, 1, 2],
+		&old_shares,
+		&public_key,
+		Some(tamper),
+	);
+
+	let err = result.expect_err("tampered acceptance signature must be detected");
+	assert!(
+		err.contains("invalid transcript acceptance"),
+		"expected acceptance verification failure, got: {}",
+		err
+	);
+}
+
+/// Certificate verification must fail when an acceptance is missing or when
+/// the transcript hash it signs differs from the certificate's.
+#[test]
+fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
+	use common::TestSigner as Signer;
+	use qp_rusty_crystals_threshold::resharing::{compute_accept_hash, ResharingCertificate};
+	use qp_rusty_crystals_threshold::resharing::TranscriptSigner as _;
+	use std::collections::BTreeMap;
+
+	let ssid = [7u8; 32];
+	let transcript_hash = [9u8; 32];
+	let accept_hash = compute_accept_hash(&ssid, &transcript_hash);
+	let new_participants = vec![0u32, 1u32];
+	let keys: BTreeMap<u32, u32> = new_participants.iter().map(|&p| (p, p)).collect();
+
+	let mut accepts: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
+	accepts.insert(0, Signer { id: 0 }.sign(&accept_hash));
+	accepts.insert(1, Signer { id: 1 }.sign(&accept_hash));
+
+	let cert = ResharingCertificate {
+		ssid,
+		active_set: vec![0, 1],
+		transcript_hash,
+		accepts: accepts.clone(),
+	};
+	assert!(cert.verify::<Signer>(&new_participants, &keys), "valid certificate must verify");
+
+	// Missing an acceptance.
+	let mut missing = cert.clone();
+	missing.accepts.remove(&1);
+	assert!(!missing.verify::<Signer>(&new_participants, &keys));
+
+	// Acceptance over a different transcript hash.
+	let other_hash = compute_accept_hash(&ssid, &[10u8; 32]);
+	let mut wrong = cert.clone();
+	wrong.accepts.insert(1, Signer { id: 1 }.sign(&other_hash));
+	assert!(!wrong.verify::<Signer>(&new_participants, &keys));
+
+	// Signature by the wrong party.
+	let mut forged = cert;
+	forged.accepts.insert(1, Signer { id: 0 }.sign(&accept_hash));
+	assert!(!forged.verify::<Signer>(&new_participants, &keys));
 }


### PR DESCRIPTION
## Summary

Three security/robustness upgrades to the threshold ML-DSA-87 resharing protocol, in dependency order:

1. **Active-set liveness** — resharing now succeeds with up to `n_old − t_old` old committee members offline, so we can reshare *away from a dead node*.
2. **Signed transcript acceptance (Round 6)** — every new committee member signs the session transcript hash with a long-term key; the protocol output includes a publicly verifiable `ResharingCertificate`, and dealer equivocation now causes an attributable abort.
3. **SSID v2 + erasure at finalize** — the SSID binds protocol version, suite ID, and a monotonic handoff epoch (blocking cross-version/suite/epoch transcript replay), and all session secrets — including the old share held in the config — are zeroized when the protocol returns its output.

## Changes

### Active-set liveness (Ready round + dealer failover)

- Round 1 entropy commitments double as **Ready signals**.
- The session leader (lowest-ID new committee member) proposes the active set `Act`: all old members on the fast path, or the committed subset after `close_ready_window()` is called on a transport timeout. Every party verifies the proposal (sender is the leader, `Act ⊆` old committee, `|Act| ≥ t_old`).
- Dealers fail over to `min(I ∩ Act)`; round quorums relax from the full old committee to `Act`. Since sub-share derivation is deterministic and `Act` is fixed before entropy reveals, a malicious leader can at most deny service — equivocating proposals produce mismatched deterministic commitments and abort.
- Also widens the Round 2/3 message-acceptance windows to include the initial protocol states, fixing a stall where a slow party excluded from `Act` dropped its backlog and never progressed as an observer.

### Round 6: signed transcript acceptance + `ResharingCertificate`

- After Round 5 checks pass, each party computes the transcript hash `SHAKE256("resharing-transcript-v1" || ssid || Act || session_seed || Round 3 broadcasts || Round 5 broadcasts)`.
- Each **new** committee member signs `SHAKE256("resharing-accept-v1" || ssid || transcript_hash)` with its long-term `TranscriptSigner` key and broadcasts the signature. Every party verifies every acceptance against its *own* transcript hash, so completion implies all parties saw identical broadcasts.
- The output now includes a `ResharingCertificate` (ssid, `Act`, transcript hash, acceptance signatures) that any third party holding the new committee's verifying keys can verify. It attests process integrity and public-key preservation, not share-distribution properties.

### SSID v2, erasure at finalize, stored-share norm guard

- `RESHARING_SSID_V2` absorbs a protocol version, suite ID, and a monotonic handoff **epoch**, alongside the existing old/new committees, public key, and session nonce. Transcripts cannot be replayed across versions, suites, or epochs.
- On `Action::Return`, the protocol zeroizes in place: the caller-provided seed, this party's entropy, the session seed, all derived sub-shares, received Round 4 messages, the aggregated new-share working set, and the old share held in the config (`old_share_erased()` exposes this; the harness asserts it on every successful run). The same erasure runs on `Drop` for abort paths. This is the compensating control for the protocol's lack of post-compromise forward secrecy: sub-shares are recomputable from the public transcript plus old shares, so erasing pre-handoff state is what makes recorded transcripts useless.
- Round 5 adds a per-subset **stored-share norm guard** (`B_G` analog, `num_secrets = 1`) as defense in depth against inflating an individual stored share in ways that cancel in the recovered-partial sums checked by the existing guard.

## API changes (breaking)

- `ResharingProtocol` is now generic over the transcript signer: `ResharingProtocol<S: TranscriptSigner>`.
- `ResharingProtocol::new(config, signer_config, seed, session_nonce, epoch)` — takes a new `ResharingSignerConfig` (which validates verifying-key coverage of the entire new committee at construction) and the handoff `epoch`.
- `ResharingOutput` gains a `certificate: ResharingCertificate` field; `old_share_erased()` is new.
- New public types: `ResharingSignerConfig`, `ResharingCertificate`, `TranscriptSigner` trait, `ActProposal` message; `close_ready_window()` for leader-side timeout handling.

Callers must supply long-term signing keys for Round 6 (the near-mpc integration reuses the nodes' P2P Ed25519 keys; the accept hash is domain-separated, so there is no cross-protocol replay with DKG transcript signatures).

## Testing

All 29 resharing tests pass (`cargo test -p qp-rusty-crystals-threshold resharing`). New tests in this PR:

**Liveness**
- `test_resharing_succeeds_with_offline_old_party`
- `test_resharing_offline_lowest_id_dealer_fails_over`
- `test_resharing_aborts_below_old_threshold`
- `test_close_ready_window_requires_leader`
- `test_slow_old_member_excluded_from_act_still_gets_new_shares`
- `test_slow_old_only_member_observes_and_completes`

**Certificate**
- `test_tampered_accept_signature_aborts`
- `test_certificate_verification_rejects_missing_or_wrong_accepts`

The shared harness additionally asserts, on every successful run across the existing end-to-end tests (same committee, add party, replace party, disjoint committees): certificate validity against the new committee's verifying keys, and `old_share_erased()` for every old member.

## Docs

`threshold/src/resharing/README.md` updated: new round diagram (Ready/Act/Round 6), security-properties table rows for liveness and transcript agreement, the mandatory-erasure section, and updated usage example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core committee-handoff cryptography (SSID, liveness, transcript attestation, share erasure) and breaks the public constructor/output shape; integrators must wire long-term keys, epoch, and leader timeout behavior correctly.
> 
> **Overview**
> This PR upgrades threshold resharing so handoffs can complete when up to **`n_old − t_old`** old members are offline, and so successful sessions produce a **publicly verifiable `ResharingCertificate`**.
> 
> **Active-set liveness:** Round 1 commitments act as Ready signals; the lowest-ID new committee leader proposes **`Act`** (full old committee or subset after `close_ready_window()`). Dealers become **`min(I ∩ Act)`**, session seed and round quorums use only active members, and message acceptance windows widen so slow/excluded parties can still observe.
> 
> **Round 6:** After Round 5, parties hash the transcript; each new member signs with **`TranscriptSigner`**; output includes **`ResharingCertificate`**; mismatched transcripts abort on signature verify.
> 
> **SSID v2 + erasure:** SSID binds protocol version, suite, and monotonic **`epoch`**. On success (and on `Drop`), the protocol zeroizes session secrets and the **old share in config** (`old_share_erased()`).
> 
> **Round 5:** Adds per-subset **stored-share norm guard** (`B_G` analog) before the existing recovered-partial check.
> 
> **Breaking API:** `ResharingProtocol<S: TranscriptSigner>::new(config, signer_config, seed, session_nonce, epoch)`; `ResharingOutput.certificate`; new types/messages (`ResharingSignerConfig`, `ActProposal`, `Accept`). Docs and integration tests updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7c3a1ff2c1abbb5888d3ae1fbcec81ac0b16dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->