### PR TITLE
Better constant time

### DIFF
--- a/dilithium/CONSTANT_TIME_TESTING.md
+++ b/dilithium/CONSTANT_TIME_TESTING.md
@@ -1,128 +1,130 @@
 # Constant-Time Testing for qp-rusty-crystals-dilithium
 
-This project uses [dudect-bencher](https://github.com/rozbb/dudect-bencher) to test whether the Dilithium ML-DSA-87 digital signature and key generation operations execute in constant time, resisting timing side-channel attacks.
+This project uses [dudect-bencher](https://github.com/rozbb/dudect-bencher) to test that the
+secret-dependent components of the ML-DSA-87 implementation execute in constant time.
 
 ## Quick Start
 
-Run all constant-time tests:
+```bash
+cargo run --release -p qp-rusty-crystals-dilithium --example ct_bench
+```
+
+Run a single test (with continuous sampling until interrupted):
 
 ```bash
-cd dilithium
-cargo run --release --features ct-testing --bin ct_bench
+cargo run --release -p qp-rusty-crystals-dilithium --example ct_bench -- --continuous sign_norm_check
 ```
+
+## What we measure — and what we deliberately do not
+
+This is the important part, and it is where a naive test setup goes wrong.
+
+ML-DSA signing is **Fiat-Shamir with aborts**: the signer retries (on average ~4 times for
+ML-DSA-87) until a candidate signature passes four rejection checks. The *number of attempts*
+is independent of the long-term secret key and is treated as **public information** in the
+FIPS 204 security analysis — every mainstream implementation (reference C, PQClean, AWS-LC)
+uses a plain early-exit rejection loop. End-to-end signing time therefore varies from call to
+call *by design*.
+
+Consequence: timing the whole `sign()` call with dudect (fixed key vs. random key, or fixed
+message vs. random message) produces a large t-statistic that looks like a leak but is not —
+dudect is simply detecting the public abort count. The same applies to whole
+`Keypair::generate()` calls: expanding the matrix A uses rejection sampling on `rho`, and
+`rho` is published in the public key.
+
+What must NOT depend on secrets is the work done **inside** each attempt and around it.
+The harness (`examples/ct_bench.rs`) therefore isolates each secret-consuming component and
+compares a fixed secret input (Class Left) against fresh random secret inputs (Class Right):
+
+| Test                   | Component under test                                        |
+|------------------------|-------------------------------------------------------------|
+| `keygen_s1s2_sampling` | Sampling secret vectors s1/s2 from rho' (keygen)            |
+| `rej_eta_one_block`    | Raw eta rejection sampler over one SHAKE block              |
+| `sign_sk_expansion`    | Secret-key unpack + NTT of s1/s2/t0 (per-sign setup)        |
+| `sign_mask_expansion`  | Mask vector y expansion from rho' (ExpandMask)              |
+| `sign_norm_check`      | Infinity-norm rejection check on z = y + c·s1               |
+| `sign_make_hint`       | Hint computation from secret-derived w0/w1                  |
+| `ntt_pointwise`        | NTT + pointwise multiplication on secret operands           |
+
+Deliberately excluded:
+
+- **Whole `sign()` / keygen calls** — timing varies with public information (abort count,
+  `rho`), see above.
+- **`poly::challenge()`** — variable-time by design. Its input `c~ = H(mu, w1)` is a hash
+  output: published in the signature for accepted attempts, and unexploitable (a preimage
+  of an unpublished hash) for rejected ones. No secret-key material flows into it.
+- **`packing::pack_sig()`** — only called for the accepted attempt, so its inputs are
+  exactly the published signature bytes. (The hint loop is branchless anyway as
+  defense-in-depth, but its hint-weight-dependent store footprint is not a secret channel.)
+- **`verify()`** — operates exclusively on public data.
 
 ## Understanding Results
 
-Each test shows output like:
+Each test prints a line like:
+
 ```
-test_keypair_generation_ct        : n == +0.005M, max t = +1.83452, max tau = +0.08201, (5/tau)^2 = 3715
+bench sign_norm_check ... : n == +0.149M, max t = +1.53271, max tau = +0.00397, (5/tau)^2 = 1587037
 ```
 
-- **n**: Number of measurements taken (in millions)
-- **max t**: Raw t-statistic from Welch's t-test
-- **max tau**: Normalized t-statistic (more reliable for large sample sizes)
-- **(5/tau)²**: Detection threshold - higher numbers are BETTER
+- **n**: number of measurements used (in millions, after outlier trimming)
+- **max t**: worst Welch t-statistic over all measurement crops
+- **max tau**: t normalized by sqrt(n) — comparable across sample sizes
+- **(5/tau)²**: roughly how many measurements would be needed to confirm a leak
 
-### Interpretation Guidelines
+Interpretation:
 
-- **|max t| < 5.0**: ✅ GOOD - No timing leakage detected
-- **|max tau| < 0.1**: ✅ GOOD - No timing leakage detected
-- **|max tau| ≥ 0.1**: ⚠️ CONCERN - Potential timing side-channel detected
-- **Higher (5/tau)² values**: ✅ GOOD - Higher numbers indicates more measurements would be needed to detect any leakage
-
-## Tests Included
-
-### Key Generation
-- `test_keypair_generation_ct` - Tests ML-DSA-87 keypair generation with different entropy sources
-
-### Signing Operations  
-- `test_signing_small_ct` - Small messages (32 bytes)
-- `test_signing_medium_ct` - Medium messages (256 bytes)  
-- `test_signing_large_ct` - Large messages (1KB)
-- `test_signing_xlarge_ct` - Extra large messages (4KB)
-
-### Advanced Signing Modes
-- `test_hedged_signing_small_ct` - Randomized (hedged) signing mode
-- `test_signing_with_context_ct` - Signing with context strings
-- `test_edge_cases_ct` - Single-byte and small message edge cases
-
-## Test Methodology
-
-The tests use a two-class approach to detect timing differences:
-
-- **Class A (Left)**: Fixed, deterministic inputs
-  - Fixed seeds for key generation
-  - Fixed message patterns for signing
-  - Fixed keys for signing
-  
-- **Class B (Right)**: Random inputs  
-  - Random entropy for key generation
-  - Random message content for signing
-  - Random keys for signing
-
-This ensures the input classes are statistically distinguishable before timing analysis begins.
+- **|max t| < 5**: no timing leakage detected — pass
+- **|max t| ≥ 5**: potential leak — re-run several times on an idle machine; a real leak
+  reproduces and its |max t| *grows* with more samples, noise does not
 
 ## Best Practices
 
-### System Setup
-- **Use release builds**: Always run with `--release` for accurate timing
-- **Idle system**: Close other applications during testing
-- **Stable environment**: Run on a system with consistent performance
-- **Multiple runs**: Execute tests multiple times to confirm results
+- Always run with `--release`.
+- Run on an idle machine; close other applications.
+- On laptops, pin the CPU governor / disable turbo if results are noisy:
 
-### Troubleshooting Noisy Results
-If you see inconsistent results:
-
-1. **Check system load**: Ensure CPU is not under heavy load
-2. **Disable frequency scaling**: Set CPU governor to 'performance' mode
-3. **Increase sample size**: Modify iteration counts in the test functions
-
-### Example: Disabling CPU Frequency Scaling (Linux)
 ```bash
-# Set all CPUs to performance mode
+# Linux
 echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-
-# Run tests
-cargo run --release --features ct-testing --bin ct_bench
-
-# Restore power saving mode
-echo powersave | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 ```
 
-## Implementation Details
+- Re-run marginal results several times before drawing conclusions. dudect maximizes t over
+  many crops of the data, so |max t| in the 2–4 range is common for perfectly constant-time
+  code.
 
-### Cache Disruption
-Each measurement includes cache disruption to prevent microarchitectural state from affecting subsequent measurements:
+## Implementation notes
 
-- Large memory allocation (8MB) to evict cache lines
-- Random memory access patterns to disrupt prefetchers
-- Memory barriers and dummy computations
+The constant-time strategy of the library itself:
 
-This makes the tests more realistic as a real world user will not typically sign thousands of messages in a row without doing something else. 
-
-### Statistical Analysis
-
-The implementation uses Welch's t-test to compare timing distributions between the two input classes. The test is designed to detect even small timing differences that could be exploited by attackers.
-
-### Implementation Strategy
-
-Broadly speaking, we have made the rejection sampling "lumpy", in that a fixed size batch of samples is processed at a time, regardless of which of them satisfy the condition. This approach also allows us to tune the tradeoff of performance to constant-timeness. Those wishing to squeeze more performance out of the library for signing may set MIN_SIGNING_ATTEMPTS to a lower value, like 1, which reduces the amount of extra work done.
+- All secret-dependent arithmetic (Keccak, NTT, Montgomery/Barrett-style reductions,
+  pack/unpack of secret polynomials) is branchless with data-independent memory access.
+- The norm checks (`poly::check_norm`) scan every coefficient with a bitwise-OR accumulator —
+  no early exit, since the index of the first failing coefficient of z = y + c·s1 is
+  secret-derived.
+- `rej_eta` processes every input byte and stores accepted coefficients through a masked,
+  clamped (`min`, compiles to conditional move) index — no secret-dependent division
+  (KyberSlash class) and no early exit.
+- `rounding::make_hint` and the hint loop in `packing::pack_sig` are branchless, because
+  hints of *rejected* attempts are never published.
+- The rejection loop itself exits as soon as an attempt is accepted. The abort count is
+  public (see above), so no batching or dummy work is performed to disguise it.
 
 ## Security Implications
 
-This implementation is described as "reasonably constant-time" because
+This implementation is described as "reasonably constant-time":
 
-- Both keygen and signing have low tau values 
-- Rejection sampling makes it difficult to be perfectly constant time
-- There is a natural tenstion between constant-timeness and readability and performance
+- Timing reveals only information that is public under the FIPS 204 security analysis
+  (abort count, message length, `rho`).
+- All operations on secret-key material are constant-time to the extent the compiler
+  preserves the branchless constructs used (standard caveat for any Rust/C implementation).
 
-Anyone wishing to fully protect against side channel attacks should test on specific hardware relative to a specific threat vector. 
-
-1. **Key Generation**: Timing attacks could reveal information about the secret key material
-2. **Signing Process**: Non-constant-time operations could leak private key bits
+Anyone wishing to fully protect against side-channel attacks (including power/EM and
+microarchitectural attacks) should evaluate on their specific hardware against their
+specific threat model.
 
 ## Further Reading
 
-- [Timing Attacks on Implementations of Diffie-Hellman, RSA, DSS, and Other Systems](https://www.paulkocher.com/doc/TimingAttacks.pdf)
+- [FIPS 204: Module-Lattice-Based Digital Signature Standard](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf)
 - [dudect: dude, is my code constant time?](https://github.com/oreparaz/dudect)
-- [Extracting Trezor's Private Key with $80 Oscilloscope](https://jochen-hoenicke.de/crypto/trezor-power-analysis/)
+- [KyberSlash: division timing attacks on Kyber implementations](https://kyberslash.cr.yp.to/)
+- [Timing Attacks on Implementations of Diffie-Hellman, RSA, DSS, and Other Systems](https://www.paulkocher.com/doc/TimingAttacks.pdf)

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -24,6 +24,10 @@ path = "examples/stack_usage_demo.rs"
 name = "stack_probe"
 path = "examples/stack_probe.rs"
 
+[[example]]
+name = "ct_bench"
+path = "examples/ct_bench.rs"
+
 [dependencies]
 zeroize = { workspace = true }
 

--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -29,13 +29,13 @@
 //!
 //! Intentionally not tested:
 //!
-//! - whole `sign()` / `Keypair::generate()` calls (their duration varies with public
-//!   values: the abort count and rho, which is published in the public key)
-//! - `poly::challenge()` (variable-time by design; its input c~ = H(mu, w1) is a hash
-//!   output that is published for accepted attempts and unexploitable for rejected ones)
-//! - `packing::pack_sig()` (only called for the accepted attempt, so its inputs are
-//!   exactly the published signature bytes; the hint loop is branchless anyway as
-//!   defense-in-depth, but its weight-dependent store pattern is not a secret channel)
+//! - whole `sign()` / `Keypair::generate()` calls (their duration varies with public values: the
+//!   abort count and rho, which is published in the public key)
+//! - `poly::challenge()` (variable-time by design; its input c~ = H(mu, w1) is a hash output that
+//!   is published for accepted attempts and unexploitable for rejected ones)
+//! - `packing::pack_sig()` (only called for the accepted attempt, so its inputs are exactly the
+//!   published signature bytes; the hint loop is branchless anyway as defense-in-depth, but its
+//!   weight-dependent store pattern is not a secret channel)
 //! - `verify()` (operates exclusively on public data)
 //!
 //! # Harness design notes

--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -1,0 +1,369 @@
+//! dudect-based constant-time tests for the ML-DSA-87 implementation.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --release -p qp-rusty-crystals-dilithium --example ct_bench
+//! ```
+//!
+//! # What we measure — and what we deliberately do not
+//!
+//! ML-DSA signing is "Fiat-Shamir with aborts": it retries until a candidate signature
+//! passes four rejection checks. The *number of attempts* is independent of the long-term
+//! secret key and is treated as public information in the FIPS 204 security analysis, so
+//! end-to-end signing time is *expected* to vary from call to call. Timing the whole
+//! `sign()` call with dudect therefore produces a meaningless "leak" signal: the variance
+//! it detects is the public abort count, not the secret key.
+//!
+//! What must NOT depend on secrets is the work done *inside* each attempt and around it.
+//! So each test below isolates one secret-consuming component and compares a fixed secret
+//! input (Class Left) against fresh random secret inputs (Class Right):
+//!
+//! - `keygen_s1s2_sampling`     — sampling the secret vectors s1/s2 from rho' (keygen)
+//! - `rej_eta_one_block`        — the raw eta rejection-sampler over one SHAKE block
+//! - `sign_sk_expansion`        — unpacking the secret key and NTT-transforming s1/s2/t0
+//! - `sign_mask_expansion`      — expanding the secret mask vector y from rho'
+//! - `sign_norm_check`          — the infinity-norm rejection check on z = y + c*s1
+//! - `sign_make_hint`           — hint computation from secret-derived w0/w1
+//! - `ntt_pointwise`            — core polynomial arithmetic on secret operands
+//!
+//! Intentionally not tested:
+//!
+//! - whole `sign()` / `Keypair::generate()` calls (their duration varies with public
+//!   values: the abort count and rho, which is published in the public key)
+//! - `poly::challenge()` (variable-time by design; its input c~ = H(mu, w1) is a hash
+//!   output that is published for accepted attempts and unexploitable for rejected ones)
+//! - `packing::pack_sig()` (only called for the accepted attempt, so its inputs are
+//!   exactly the published signature bytes; the hint loop is branchless anyway as
+//!   defense-in-depth, but its weight-dependent store pattern is not a secret channel)
+//! - `verify()` (operates exclusively on public data)
+//!
+//! # Harness design notes
+//!
+//! To avoid measuring artifacts of the harness itself, both classes perform *identical*
+//! preparation before every timed sample: a fresh random input is always generated into a
+//! scratch buffer, and then either the fixed input (Left) or the scratch input (Right) is
+//! copied into a single reusable working buffer. This keeps RNG work, copy work and cache
+//! state of the working buffer the same for both classes; only the *values* differ.
+//! Sub-microsecond operations are batched inside the timed closure so each measurement is
+//! several microseconds long (the macOS/Apple-Silicon monotonic timer ticks at ~41 ns).
+//!
+//! # Interpreting results
+//!
+//! For each test dudect reports a t-statistic; |max t| < 5 is the usual "no leakage
+//! detected" threshold. dudect maximizes t over many crops of the data, so values in the
+//! 2-4 range are common for perfectly constant-time code. A real leak reproduces across
+//! runs and its |max t| grows with more samples.
+
+use core::hint::black_box;
+use dudect_bencher::{
+	ctbench_main,
+	rand::{Rng, RngExt},
+	BenchRng, Class, CtRunner,
+};
+
+use qp_rusty_crystals_dilithium::{
+	ml_dsa_87::Keypair,
+	packing, params, poly,
+	poly::Poly,
+	polyvec,
+	polyvec::{Polyveck, Polyvecl},
+};
+
+const L: usize = params::L;
+const Q: i32 = params::Q;
+
+/// Pick a class uniformly at random so Left/Right samples are interleaved.
+fn random_class(rng: &mut BenchRng) -> (bool, Class) {
+	let is_left = rng.random::<bool>();
+	(is_left, if is_left { Class::Left } else { Class::Right })
+}
+
+/// Fill a Poly with uniform coefficients in [-bound, bound].
+fn fill_poly(p: &mut Poly, bound: i32, rng: &mut BenchRng) {
+	for c in p.coeffs.iter_mut() {
+		*c = rng.random_range(-bound..=bound);
+	}
+}
+
+/// Fill a Polyvecl with uniform coefficients in [-bound, bound].
+fn fill_polyvecl(v: &mut Polyvecl, bound: i32, rng: &mut BenchRng) {
+	for p in v.vec.iter_mut() {
+		fill_poly(p, bound, rng);
+	}
+}
+
+/// Fill a Polyveck with uniform coefficients in [-bound, bound].
+fn fill_polyveck(v: &mut Polyveck, bound: i32, rng: &mut BenchRng) {
+	for p in v.vec.iter_mut() {
+		fill_poly(p, bound, rng);
+	}
+}
+
+/// Plain coefficient copy (no allocation, no zeroize-on-drop of the destination).
+fn copy_polyvecl(dst: &mut Polyvecl, src: &Polyvecl) {
+	for (d, s) in dst.vec.iter_mut().zip(src.vec.iter()) {
+		d.coeffs = s.coeffs;
+	}
+}
+
+/// Plain coefficient copy (no allocation, no zeroize-on-drop of the destination).
+fn copy_polyveck(dst: &mut Polyveck, src: &Polyveck) {
+	for (d, s) in dst.vec.iter_mut().zip(src.vec.iter()) {
+		d.coeffs = s.coeffs;
+	}
+}
+
+/// Keygen: sampling the secret vectors s1 (length L) and s2 (length K) from rho'.
+///
+/// This is the secret-dependent part of key generation. (Matrix expansion from rho is
+/// public and excluded.) Fixed vs random rho' seed.
+fn keygen_s1s2_sampling(runner: &mut CtRunner, rng: &mut BenchRng) {
+	const SAMPLES: usize = 100_000;
+	let mut fixed = [0u8; params::CRHBYTES];
+	rng.fill_bytes(&mut fixed);
+	let mut scratch = [0u8; params::CRHBYTES];
+	let mut seed = [0u8; params::CRHBYTES];
+
+	for _ in 0..SAMPLES {
+		let (is_left, class) = random_class(rng);
+		// Identical prep for both classes: RNG fill, then memcpy.
+		rng.fill_bytes(&mut scratch);
+		seed.copy_from_slice(if is_left { &fixed } else { &scratch });
+		runner.run_one(class, || {
+			let mut s1 = Polyvecl::default();
+			let mut s2 = Polyveck::default();
+			polyvec::l_uniform_eta(&mut s1, black_box(&seed), 0);
+			polyvec::k_uniform_eta(&mut s2, black_box(&seed), L as u16);
+			black_box((&s1, &s2));
+		});
+	}
+}
+
+/// The raw eta rejection sampler over a single SHAKE256 block.
+///
+/// Called exactly as `uniform_eta` calls it in production: a 1000-slot output buffer, so
+/// the counter never saturates the index clamp. (Benching with a tight 256-slot buffer
+/// instead makes the clamp pin the store index to the last slot for the tail of the block,
+/// and the resulting same-address read-modify-write chain shows up as a large timing
+/// signal that production never exhibits.) Fixed vs random block.
+fn rej_eta_one_block(runner: &mut CtRunner, rng: &mut BenchRng) {
+	const SAMPLES: usize = 300_000;
+	const BATCH: usize = 8;
+
+	let mut fixed = [0u8; 136];
+	rng.fill_bytes(&mut fixed);
+	let mut scratch = [0u8; 136];
+	let mut block = [0u8; 136];
+
+	for _ in 0..SAMPLES {
+		let (is_left, class) = random_class(rng);
+		rng.fill_bytes(&mut scratch);
+		block.copy_from_slice(if is_left { &fixed } else { &scratch });
+		runner.run_one(class, || {
+			for _ in 0..BATCH {
+				// Same shape as the call in `uniform_eta`.
+				let mut out = [0i32; 1000];
+				let accepted = poly::rej_eta(&mut out, black_box(&block));
+				black_box((accepted, &out));
+			}
+		});
+	}
+}
+
+/// Signing: unpacking the packed secret key and NTT-transforming s1, s2 and t0.
+///
+/// This is the per-call secret-key setup phase of `sign()`. Fixed key vs random keys
+/// (drawn from a pregenerated pool; per-sample keygen would dominate the harness).
+fn sign_sk_expansion(runner: &mut CtRunner, rng: &mut BenchRng) {
+	const SAMPLES: usize = 50_000;
+
+	let gen_sk = |rng: &mut BenchRng| -> [u8; params::SECRETKEYBYTES] {
+		let mut entropy = [0u8; 32];
+		rng.fill_bytes(&mut entropy);
+		let keypair = Keypair::generate((&mut entropy).into());
+		keypair.secret.to_bytes()
+	};
+
+	let fixed = gen_sk(rng);
+	let pool: Vec<[u8; params::SECRETKEYBYTES]> = (0..256).map(|_| gen_sk(rng)).collect();
+	let mut sk = [0u8; params::SECRETKEYBYTES];
+
+	for _ in 0..SAMPLES {
+		let (is_left, class) = random_class(rng);
+		// Draw the pool index for both classes so RNG work is identical.
+		let idx = rng.random_range(0..pool.len());
+		sk.copy_from_slice(if is_left { &fixed } else { &pool[idx] });
+		runner.run_one(class, || {
+			let mut rho = [0u8; params::SEEDBYTES];
+			let mut tr = [0u8; params::TR_BYTES];
+			let mut key = [0u8; params::SEEDBYTES];
+			let mut t0 = Polyveck::default();
+			let mut s1 = Polyvecl::default();
+			let mut s2 = Polyveck::default();
+			packing::unpack_sk(
+				&mut rho,
+				&mut tr,
+				&mut key,
+				&mut t0,
+				&mut s1,
+				&mut s2,
+				black_box(&sk),
+			);
+			polyvec::l_ntt(&mut s1);
+			polyvec::k_ntt(&mut s2);
+			polyvec::k_ntt(&mut t0);
+			black_box((&s1, &s2, &t0));
+		});
+	}
+}
+
+/// Signing: expanding the secret mask vector y from rho' (ExpandMask).
+///
+/// Uses no rejection sampling, so this should be strictly constant-time.
+/// Fixed vs random rho'.
+fn sign_mask_expansion(runner: &mut CtRunner, rng: &mut BenchRng) {
+	const SAMPLES: usize = 100_000;
+	let mut fixed = [0u8; params::CRHBYTES];
+	rng.fill_bytes(&mut fixed);
+	let mut scratch = [0u8; params::CRHBYTES];
+	let mut seed = [0u8; params::CRHBYTES];
+
+	for _ in 0..SAMPLES {
+		let (is_left, class) = random_class(rng);
+		rng.fill_bytes(&mut scratch);
+		seed.copy_from_slice(if is_left { &fixed } else { &scratch });
+		runner.run_one(class, || {
+			let mut y = Polyvecl::default();
+			polyvec::l_uniform_gamma1(&mut y, black_box(&seed), 0);
+			black_box(&y);
+		});
+	}
+}
+
+/// Signing: the infinity-norm rejection check on secret-derived z = y + c*s1.
+///
+/// Must scan every coefficient without early exit; an early exit would leak the index of
+/// the first out-of-bound coefficient. Fixed vs random z (coefficients in the post-reduce32
+/// range, checked against the gamma1 - beta bound as in signing).
+fn sign_norm_check(runner: &mut CtRunner, rng: &mut BenchRng) {
+	const SAMPLES: usize = 200_000;
+	const BATCH: usize = 4;
+	const REDUCE32_RANGE: i32 = 6283008;
+	let bound = (params::GAMMA1 - params::BETA) as i32;
+
+	let mut fixed = Polyvecl::default();
+	fill_polyvecl(&mut fixed, REDUCE32_RANGE, rng);
+	let mut scratch = Polyvecl::default();
+	let mut z = Polyvecl::default();
+
+	for _ in 0..SAMPLES {
+		let (is_left, class) = random_class(rng);
+		fill_polyvecl(&mut scratch, REDUCE32_RANGE, rng);
+		copy_polyvecl(&mut z, if is_left { &fixed } else { &scratch });
+		runner.run_one(class, || {
+			for _ in 0..BATCH {
+				let ok = polyvec::polyvecl_is_norm_within_bound(black_box(&z), bound);
+				black_box(ok);
+			}
+		});
+	}
+}
+
+/// Signing: hint computation from secret-derived low/high parts.
+///
+/// Runs on rejected attempts whose hints are never published, so the per-coefficient hint
+/// decision must be branchless. Inputs span +/- 2*gamma2 so both hint outcomes occur.
+fn sign_make_hint(runner: &mut CtRunner, rng: &mut BenchRng) {
+	const SAMPLES: usize = 200_000;
+	const BATCH: usize = 4;
+	let gamma2 = params::GAMMA2 as i32;
+
+	let fill_w1 = |v: &mut Polyveck, rng: &mut BenchRng| {
+		for p in v.vec.iter_mut() {
+			for c in p.coeffs.iter_mut() {
+				*c = rng.random_range(0..16);
+			}
+		}
+	};
+
+	let mut fixed_w0 = Polyveck::default();
+	let mut fixed_w1 = Polyveck::default();
+	fill_polyveck(&mut fixed_w0, 2 * gamma2, rng);
+	fill_w1(&mut fixed_w1, rng);
+
+	let mut scratch_w0 = Polyveck::default();
+	let mut scratch_w1 = Polyveck::default();
+	let mut w0 = Polyveck::default();
+	let mut w1 = Polyveck::default();
+
+	for _ in 0..SAMPLES {
+		let (is_left, class) = random_class(rng);
+		fill_polyveck(&mut scratch_w0, 2 * gamma2, rng);
+		fill_w1(&mut scratch_w1, rng);
+		if is_left {
+			copy_polyveck(&mut w0, &fixed_w0);
+			copy_polyveck(&mut w1, &fixed_w1);
+		} else {
+			copy_polyveck(&mut w0, &scratch_w0);
+			copy_polyveck(&mut w1, &scratch_w1);
+		}
+		runner.run_one(class, || {
+			for _ in 0..BATCH {
+				let mut h = Polyveck::default();
+				let weight = polyvec::k_make_hint(&mut h, black_box(&w0), black_box(&w1));
+				black_box((weight, &h));
+			}
+		});
+	}
+}
+
+/// Core polynomial arithmetic on secret operands: forward NTT, pointwise multiply,
+/// inverse NTT.
+fn ntt_pointwise(runner: &mut CtRunner, rng: &mut BenchRng) {
+	const SAMPLES: usize = 200_000;
+	const BATCH: usize = 4;
+
+	let mut fixed_a = Poly::default();
+	let mut fixed_b = Poly::default();
+	fill_poly(&mut fixed_a, Q - 1, rng);
+	fill_poly(&mut fixed_b, Q - 1, rng);
+
+	let mut scratch_a = Poly::default();
+	let mut scratch_b = Poly::default();
+	let mut a = Poly::default();
+	let mut b = Poly::default();
+
+	for _ in 0..SAMPLES {
+		let (is_left, class) = random_class(rng);
+		fill_poly(&mut scratch_a, Q - 1, rng);
+		fill_poly(&mut scratch_b, Q - 1, rng);
+		if is_left {
+			a.coeffs = fixed_a.coeffs;
+			b.coeffs = fixed_b.coeffs;
+		} else {
+			a.coeffs = scratch_a.coeffs;
+			b.coeffs = scratch_b.coeffs;
+		}
+		runner.run_one(class, || {
+			for _ in 0..BATCH {
+				let mut a_ntt = black_box(&a).clone();
+				poly::ntt(&mut a_ntt);
+				let mut prod = Poly::default();
+				poly::pointwise_montgomery(&mut prod, &a_ntt, black_box(&b));
+				poly::invntt_tomont(&mut prod);
+				black_box(&prod);
+			}
+		});
+	}
+}
+
+ctbench_main!(
+	keygen_s1s2_sampling,
+	rej_eta_one_block,
+	sign_sk_expansion,
+	sign_mask_expansion,
+	sign_norm_check,
+	sign_make_hint,
+	ntt_pointwise
+);

--- a/dilithium/src/packing.rs
+++ b/dilithium/src/packing.rs
@@ -129,33 +129,25 @@ pub fn pack_sig(
 	idx += L * params::POLYZ_PACKEDBYTES;
 	sig[idx..idx + params::OMEGA + K].copy_from_slice(&[0u8; params::OMEGA + K]);
 
-	let mut k = 0;
-	let mut write_idx: u32;
+	// Branchless hint packing: the hint pattern is secret on rejected attempts, so no
+	// data-dependent branches. The write index is clamped with `min` (conditional move) and
+	// the store is masked; the counter advances with arithmetic instead of a branch.
+	let mut k: usize = 0;
 	for i in 0..K {
 		for j in 0..N {
 			let is_nonzero = h.vec[i].coeffs[j] != 0;
 			let has_space = k < params::OMEGA;
 			let should_store = is_nonzero & has_space;
 
-			let in_bounds_idx = (idx + k) as u32;
-			let out_bounds_idx = (idx + params::OMEGA - 1) as u32;
-			let has_space_choice = k < params::OMEGA;
-			if has_space_choice {
-				write_idx = in_bounds_idx;
-			} else {
-				write_idx = out_bounds_idx;
-			}
+			let write_idx = idx + k.min(params::OMEGA - 1);
 
 			// Create a mask from should_store (0x00 or 0xFF)
 			let mask = (should_store as i8).wrapping_neg() as u8;
 
-			// Branchless selection using bitwise operations
 			// if should_store { sig[write_idx] = j }
-			sig[write_idx as usize] = (j as u8 & mask) | (sig[write_idx as usize] & !mask);
+			sig[write_idx] = (j as u8 & mask) | (sig[write_idx] & !mask);
 
-			if is_nonzero {
-				k += 1;
-			}
+			k += is_nonzero as usize;
 		}
 		sig[idx + params::OMEGA + i] = k as u8;
 	}
@@ -178,8 +170,8 @@ pub fn unpack_sig(
 
 	let mut k: usize = 0;
 	for i in 0..K {
-		if sig[idx + params::OMEGA + i] < k as u8 ||
-			sig[idx + params::OMEGA + i] > params::OMEGA as u8
+		if sig[idx + params::OMEGA + i] < k as u8
+			|| sig[idx + params::OMEGA + i] > params::OMEGA as u8
 		{
 			return false;
 		}

--- a/dilithium/src/packing.rs
+++ b/dilithium/src/packing.rs
@@ -170,8 +170,8 @@ pub fn unpack_sig(
 
 	let mut k: usize = 0;
 	for i in 0..K {
-		if sig[idx + params::OMEGA + i] < k as u8
-			|| sig[idx + params::OMEGA + i] > params::OMEGA as u8
+		if sig[idx + params::OMEGA + i] < k as u8 ||
+			sig[idx + params::OMEGA + i] > params::OMEGA as u8
 		{
 			return false;
 		}

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -126,15 +126,14 @@ pub fn check_norm(a: &Poly, b: i32) -> bool {
 		result = true;
 	}
 
-	// Always process all coefficients to avoid early returns
+	// Always process all coefficients: an early exit would leak the index of the first
+	// out-of-bound coefficient of secret-derived data (e.g. z = y + c*s1).
 	for i in 0..N {
 		let mut t = a.coeffs[i] >> 31;
 		t = a.coeffs[i] - (t & 2 * a.coeffs[i]);
 
-		// Use bitwise OR to accumulate any failures without early exit
-		if t >= b {
-			result = true;
-		}
+		// Bitwise OR accumulation instead of a data-dependent branch
+		result |= t >= b;
 	}
 	result
 }
@@ -385,9 +384,14 @@ pub fn rej_eta(a: &mut [i32], buf: &[u8]) -> usize {
 			let nibble_valid = nibble < 15;
 			let has_space = ctr < alen;
 			let inc_ctr = nibble_valid & has_space;
-			let store_mask = -((inc_ctr & has_space) as i32);
-			// assign coeff to a[ctr] if store_mask == true
-			a[ctr % alen] = (coeff & store_mask) | (a[ctr % alen] & !store_mask);
+			let store_mask = -(inc_ctr as i32);
+			// Clamp the index instead of `ctr % alen`: division/modulo latency can be
+			// operand-dependent on some CPUs (KyberSlash class), and ctr is secret-derived.
+			// `min` compiles to a conditional move, and when ctr == alen the store mask is
+			// zero so the clamped slot is rewritten with its own value.
+			let idx = ctr.min(alen - 1);
+			// assign coeff to a[idx] if store_mask is all-ones
+			a[idx] = (coeff & store_mask) | (a[idx] & !store_mask);
 			ctr += inc_ctr as usize;
 		}
 	}

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -442,7 +442,10 @@ pub fn uniform_gamma1(a: &mut Poly, seed: &[u8; params::CRHBYTES], nonce: u16) {
 /// Implementation of H. Samples polynomial with TAU nonzero coefficients in {-1,1} using the output
 /// stream of SHAKE256(seed).
 ///
-/// Includes timing countermeasures using dummy operations to reduce side-channel leakage
+/// This is deliberately plain (variable-time) rejection sampling: its timing depends only on
+/// the bytes of `seed = c~ = H(mu, w1)`, a hash output. For an accepted attempt c~ is published
+/// in the signature; for rejected attempts it never leaves the device and cannot be inverted to
+/// recover w1. No secret-key material flows into this function.
 pub fn challenge(c: &mut Poly, seed: &[u8]) {
 	let mut state = fips202::KeccakState::default();
 	fips202::shake256_absorb(&mut state, seed);
@@ -456,41 +459,22 @@ pub fn challenge(c: &mut Poly, seed: &[u8]) {
 		signs |= (byte as u64) << 8 * i;
 	}
 
-	// Create dummy state for timing countermeasures
-	let mut dummy_state = fips202::KeccakState::default();
-	let mut dummy_buf = [0u8; fips202::SHAKE256_RATE];
-
 	let mut pos: usize = 8;
 	c.coeffs.fill(0);
 
-	// For each position from N-TAU to N-1, we need to find a valid index
+	// Fisher-Yates style: for each position, rejection-sample a valid index b <= i.
 	for i in (N - params::TAU)..N {
-		let mut b: usize = 0;
-		let mut found = false;
-
-		// in vast majority of cases this outer loop will run exactly once
-		while !found {
-			// do 8 iterations no matter what to reduce timing variations
-			for _ in 0..8 {
-				if !found {
-					if pos >= fips202::SHAKE256_RATE {
-						fips202::shake256_squeezeblocks(&mut buf, 1, &mut state);
-						pos = 0;
-					} else {
-						// dummy operation
-						fips202::shake256_squeezeblocks(&mut dummy_buf, 1, &mut dummy_state);
-					}
-					b = buf[pos] as usize;
-					pos += 1;
-					// Update found flag without branching
-					let is_valid = ((b <= i) as u8) != 0;
-					found |= is_valid;
-				} else {
-					// Dummy operations when already found to reduce timing variations
-					fips202::shake256_squeezeblocks(&mut dummy_buf, 1, &mut dummy_state);
-				}
+		let b = loop {
+			if pos >= fips202::SHAKE256_RATE {
+				fips202::shake256_squeezeblocks(&mut buf, 1, &mut state);
+				pos = 0;
 			}
-		}
+			let candidate = buf[pos] as usize;
+			pos += 1;
+			if candidate <= i {
+				break candidate;
+			}
+		};
 
 		c.coeffs[i] = c.coeffs[b];
 		c.coeffs[b] = 1 - 2 * ((signs & 1) as i32);

--- a/dilithium/src/rounding.rs
+++ b/dilithium/src/rounding.rs
@@ -35,13 +35,22 @@ pub fn decompose(a: i32) -> (i32, i32) {
 /// Compute hint bit indicating whether the low bits of the input element overflow into the high
 /// bits.
 ///
-/// Returns 1 if overflow.
+/// Branchless via sign-bit arithmetic: the inputs are derived from secret data
+/// (w0 - c*s2 + c*t0) and this runs on rejected signing attempts whose hints are never
+/// published, so a data-dependent branch here could leak.
+///
+/// Returns 1 if overflow, i.e. if a0 > GAMMA2, or a0 < -GAMMA2, or (a0 == -GAMMA2 && a1 != 0).
 pub fn make_hint(a0: i32, a1: i32) -> i32 {
-	if !(-GAMMA2..=GAMMA2).contains(&a0) || (a0 == -GAMMA2 && a1 != 0) {
-		1
-	} else {
-		0
-	}
+	// -1 iff a0 > GAMMA2
+	let gt = (GAMMA2 - a0) >> 31;
+	// -1 iff a0 < -GAMMA2; t == 0 iff a0 == -GAMMA2
+	let t = a0 + GAMMA2;
+	let lt = t >> 31;
+	// -1 iff t == 0 (i.e. a0 == -GAMMA2)
+	let eq = !((t | t.wrapping_neg()) >> 31);
+	// -1 iff a1 != 0
+	let a1_nonzero = (a1 | a1.wrapping_neg()) >> 31;
+	(gt | lt | (eq & a1_nonzero)) & 1
 }
 
 /// Correct high bits according to hint.

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -342,117 +342,89 @@ pub(crate) fn signature(
 	// Step 2: Prepare signing context (message hash, randomness, public seed rho)
 	let signing_ctx = prepare_signing_context(&unpacked_sk, message, hedge);
 
-	// Step 3: Make the rejection sampling lumpy to smear out timing signals
-	// Set this to 1 to revert to standard rejection sampling
-	const MIN_SIGNING_ATTEMPTS: u16 = 16; // covers most cases, |max tau| < 0.1, while keeping runtime short (~1ms)
-
+	// Step 3: Fiat-Shamir with aborts. The *number* of rejection-sampling attempts is
+	// independent of the long-term secret key and is treated as public information, as in
+	// FIPS 204 and the reference implementation. What must not leak through timing is the
+	// arithmetic *within* each attempt; those operations are constant-time.
 	let mut masking_vector_y = Polyvecl::default();
 	let mut commitment_w1 = Polyveck::default();
 	let mut commitment_w0 = Polyveck::default();
-	let mut challenge_poly_c: Poly;
 	let mut hint_vector_h = Polyveck::default();
-	let mut signature_found = false;
-	let mut dummy_output = [0u8; params::SIGNBYTES]; // Dummy buffer for timing countermeasures
-	let mut valid_challenge = [0u8; params::C_DASH_BYTES];
-	let mut valid_signature_z = Polyvecl::default();
-	let mut valid_hint_h = Polyveck::default();
-	let mut attempt_nonce = 0;
+	let mut attempt_nonce: u16 = 0;
 
 	// Largest attempt_nonce for which the per-polynomial mask nonce (L*attempt_nonce + i,
 	// i < L) still fits in u16. Reaching this requires an astronomically improbable run of
 	// rejection-sampling failures, which would signal a broken RNG/entropy source.
 	const MAX_SAFE_ATTEMPT_NONCE: u16 = (u16::MAX - (L as u16 - 1)) / L as u16;
 
-	// this outer loop should run exactly once in the vast majority of cases
 	loop {
-		for _ in 0..MIN_SIGNING_ATTEMPTS {
-			// Fail loudly rather than silently wrap the nonce and reuse a mask y.
-			assert!(
-				attempt_nonce <= MAX_SAFE_ATTEMPT_NONCE,
-				"ML-DSA signing nonce overflow: rejection sampling failed implausibly many times"
-			);
+		// Fail loudly rather than silently wrap the nonce and reuse a mask y.
+		assert!(
+			attempt_nonce <= MAX_SAFE_ATTEMPT_NONCE,
+			"ML-DSA signing nonce overflow: rejection sampling failed implausibly many times"
+		);
 
-			// Generate masking vector and compute commitment
-			let mut signature_z = Polyvecl::default();
-			generate_masking_vector_and_commitment(
-				&mut masking_vector_y,
-				&mut commitment_w1,
-				&mut commitment_w0,
-				&mut signature_z,
-				&signing_ctx.public_seed_rho,
-				&signing_ctx.signing_entropy_rho_prime,
-				attempt_nonce,
-			);
+		// Generate masking vector and compute commitment
+		let mut signature_z = Polyvecl::default();
+		generate_masking_vector_and_commitment(
+			&mut masking_vector_y,
+			&mut commitment_w1,
+			&mut commitment_w0,
+			&mut signature_z,
+			&signing_ctx.public_seed_rho,
+			&signing_ctx.signing_entropy_rho_prime,
+			attempt_nonce,
+		);
 
-			// Generate challenge c = H(μ, w1) - use dummy buffer to avoid overwriting output
-			challenge_poly_c = generate_challenge_polynomial(
-				&mut dummy_output,
-				&commitment_w1,
-				&signing_ctx.message_hash_mu,
-			);
+		// Generate challenge c = H(μ, w1); the challenge bytes land in
+		// signature_output[..C_DASH_BYTES] and are kept there if this attempt is accepted.
+		let challenge_poly_c = generate_challenge_polynomial(
+			signature_output,
+			&commitment_w1,
+			&signing_ctx.message_hash_mu,
+		);
 
-			// Check first rejection condition: compute z = y + cs1 and check ||z||∞ < γ₁ - β
-			let condition1 = compute_and_check_signature_z(
-				&mut signature_z,
-				&masking_vector_y,
-				&challenge_poly_c,
-				&unpacked_sk.secret_poly_s1_ntt,
-			);
+		// All four rejection checks are always evaluated (no short-circuit between them),
+		// so a rejected attempt reveals only that it was rejected, not which bound failed.
 
-			// Check second rejection condition: compute w0 - cs2 and check ||w0 - cs2||∞ < γ₂ - β
-			let condition2 = compute_and_check_commitment_w0(
-				&mut commitment_w0,
-				&challenge_poly_c,
-				&unpacked_sk.secret_poly_s2_ntt,
-			);
+		// First rejection condition: compute z = y + cs1 and check ||z||∞ < γ₁ - β
+		let condition1 = compute_and_check_signature_z(
+			&mut signature_z,
+			&masking_vector_y,
+			&challenge_poly_c,
+			&unpacked_sk.secret_poly_s1_ntt,
+		);
 
-			// Compute challenge_t0 for third norm check and hint generation
-			let mut challenge_t0 = Polyveck::default();
-			let condition3 = compute_and_check_challenge_t0(
-				&mut challenge_t0,
-				&challenge_poly_c,
-				&unpacked_sk.secret_poly_t0_ntt,
-			);
+		// Second rejection condition: compute w0 - cs2 and check ||w0 - cs2||∞ < γ₂ - β
+		let condition2 = compute_and_check_commitment_w0(
+			&mut commitment_w0,
+			&challenge_poly_c,
+			&unpacked_sk.secret_poly_s2_ntt,
+		);
 
-			// Check fourth rejection condition: compute hint vector and check weight ≤ ω
-			let condition4 = compute_and_check_hint_vector(
-				&mut hint_vector_h,
-				&commitment_w0,
-				&challenge_t0,
-				&commitment_w1,
-			);
+		// Compute challenge_t0 for third norm check and hint generation
+		let mut challenge_t0 = Polyveck::default();
+		let condition3 = compute_and_check_challenge_t0(
+			&mut challenge_t0,
+			&challenge_poly_c,
+			&unpacked_sk.secret_poly_t0_ntt,
+		);
 
-			let all_conditions_met = condition1 && condition2 && condition3 && condition4;
+		// Fourth rejection condition: compute hint vector and check weight ≤ ω
+		let condition4 = compute_and_check_hint_vector(
+			&mut hint_vector_h,
+			&commitment_w0,
+			&challenge_t0,
+			&commitment_w1,
+		);
 
-			// Always call pack_sig to dummy buffer for constant timing
-			// Use empty hint vector when conditions aren't met to prevent out-of-bounds access
-			let safe_hint = if all_conditions_met { &hint_vector_h } else { &Polyveck::default() };
-			packing::pack_sig(&mut dummy_output, None, &signature_z, safe_hint);
-
-			// Store valid signature components if this is the first valid one
-			// This branch is data-dependent but the alternative complex branchless operations
-			// may actually introduce more timing variations due to memory access patterns
-			if all_conditions_met && !signature_found {
-				valid_challenge.copy_from_slice(&dummy_output[..params::C_DASH_BYTES]);
-				valid_signature_z = signature_z;
-				valid_hint_h = hint_vector_h.clone();
-				signature_found = true;
-			}
-
-			attempt_nonce += 1;
-			// Continue loop regardless to maintain constant timing
-		}
-
-		// After fixed iterations, pack the final signature and return if found
-		if signature_found {
-			packing::pack_sig(
-				signature_output,
-				Some(&valid_challenge),
-				&valid_signature_z,
-				&valid_hint_h,
-			);
+		if condition1 & condition2 & condition3 & condition4 {
+			// Challenge bytes are already in place; pack z and h around them.
+			packing::pack_sig(signature_output, None, &signature_z, &hint_vector_h);
 			return;
 		}
+
+		attempt_nonce += 1;
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR reworks the constant-time posture of the `dilithium` crate based on a review of
what actually needs protection under the FIPS 204 security analysis. It removes expensive
countermeasures that only disguised **public** information, closes the remaining
secret-dependent timing gaps, and replaces the lost dudect harness with one that measures
the right thing.

Net effect: **signing is ~22x faster** (2.82 ms → 128 µs on Apple Silicon, criterion
`Dilithium signing` bench), signatures are **byte-identical** (all ACVP KATs pass
unchanged), and every secret-consuming component now passes dudect with |max t| well
under the 5.0 leakage threshold.

## Motivation

The previous implementation tried to make *end-to-end* signing time look constant to a
dudect test that compared fixed vs. random keys. But ML-DSA is Fiat–Shamir with aborts:
the number of rejection-sampling attempts is independent of the long-term secret key and
is treated as public in the FIPS 204 analysis (reference C, PQClean, and AWS-LC all use
plain early-exit loops). Chasing that non-leak led to three expensive countermeasures —
while several places that touch actual secrets still had data-dependent branches, and one
fix had introduced a secret-dependent division (the KyberSlash bug class). Meanwhile the
documented dudect harness (`--features ct-testing --bin ct_bench`) no longer existed, so
none of the claims were reproducible.

## Changes

### Commit 1 — drop countermeasures that only masked the public abort count

- `sign.rs`: replace the 16-attempt batched rejection loop (`MIN_SIGNING_ATTEMPTS`) with
  a standard early-exit loop. Removes the per-attempt dummy `pack_sig` call, the dummy
  output buffer, and the data-dependent `Polyveck::default()` in the `safe_hint` branch.
  All four rejection checks are still evaluated unconditionally, so a rejected attempt
  reveals only *that* it was rejected, not which bound failed. The nonce-overflow assert
  is kept.
- `poly.rs::challenge()`: restore plain rejection sampling (was: one dummy Keccak
  permutation per candidate byte, ≥480 permutations per challenge vs. ~2). Its input
  `c~ = H(μ, w1)` is a hash output — published in the signature for accepted attempts,
  and unexploitable (preimage of an unpublished hash) for rejected ones.

### Commit 2 — close the real secret-dependent gaps

- `poly.rs::rej_eta`: `ctr % alen` → `ctr.min(alen - 1)`. The modulo was a hardware
  division with a secret-derived operand (KyberSlash class); `min` compiles to a
  conditional move. Semantics identical: `ctr` can only reach `alen` when the store mask
  is already zero, making the clamped access a self-assignment either way.
- `poly.rs::check_norm`: data-dependent branch → `result |= t >= b` (the code now matches
  its own comment).
- `rounding.rs::make_hint`: if/else on secret-derived `w0 − c·s2 + c·t0` values →
  sign-bit arithmetic. Hints of *rejected* attempts are never published, so this path is
  secret. Verified branchless/vectorized in the emitted assembly.
- `packing.rs::pack_sig`: the branchless masked store was undermined by
  `if is_nonzero { k += 1 }` and an if/else write-index select on the same hint data →
  arithmetic increment and `min` clamp.

### Commit 3 — new dudect harness + docs

- New `dilithium/examples/ct_bench.rs` (same target layout as qp-poseidon). Instead of
  timing whole `sign()`/`keygen()` calls — which mostly measures the public abort count
  and ExpandA's rejection sampling on the public ρ — it isolates each secret-consuming
  component, fixed secret vs. random secret:

  | Test | Component | max t (pass < 5) |
  |---|---|---|
  | `keygen_s1s2_sampling` | s1/s2 eta sampling from ρ′ | ~2.1 |
  | `rej_eta_one_block` | raw eta sampler, one SHAKE block | ~2.7 |
  | `sign_sk_expansion` | sk unpack + NTT of s1/s2/t0 | ~1.8 |
  | `sign_mask_expansion` | ExpandMask for y | ~1.5 |
  | `sign_norm_check` | norm check on z = y + c·s1 | ~1.6 |
  | `sign_make_hint` | hint computation | ~1.7 |
  | `ntt_pointwise` | NTT + pointwise multiply | ~2.6 |

  Harness design: both classes do identical per-sample prep (RNG fill + memcpy into one
  shared working buffer) so RNG cost and cache state cannot differ between classes;
  sub-microsecond ops are batched above the ~41 ns timer tick; no 8 MB cache flush per
  sample, so sample counts are 10–40x higher than the old harness for the same wall time.

- `CONSTANT_TIME_TESTING.md` rewritten around "what to measure and why": documents the
  abort-count argument, what is deliberately excluded (`challenge`, whole-call timing,
  `pack_sig` — only called for the accepted attempt with published data, `verify`), and
  replaces the stale run instructions with the working command:

  ```bash
  cargo run --release -p qp-rusty-crystals-dilithium --example ct_bench
  ```

## Test plan

- [x] `cargo test -p qp-rusty-crystals-dilithium` — 90 unit tests + ACVP keygen/siggen/sigver KATs pass (signatures byte-identical, so the loop restructure and branchless rewrites are behavior-preserving)
- [x] `cargo test -p rusty-crystals-integration-tests` — NIST KAT integration tests pass
- [x] `cargo run --release -p qp-rusty-crystals-dilithium --example ct_bench` — all components |max t| < 5 across repeated runs
- [x] `cargo clippy --release -p qp-rusty-crystals-dilithium --all-targets` — clean
- [x] Emitted assembly inspected for `rej_eta` and `make_hint` (branchless: `csel`/`cset`/SIMD compares only)
- [x] Each commit compiles independently (checked for bisectability)
- [ ] Optional follow-up: run `ct_bench --continuous` on a quiet pinned-frequency machine for higher-confidence numbers; consider a scheduled CI job on a dedicated runner

## Notes for reviewers

- The known residual, inherent to the construction and shared with the reference
  implementation: `rej_eta`'s store address follows the acceptance counter (cache-line
  granularity, within a 4 KB buffer). dudect shows no signal; documented in the md.
- qp-poseidon's `CONSTANT_TIME_TESTING.md` has the same stale `--features ct-testing
  --bin ct_bench` instruction this PR fixes here; worth a small follow-up PR there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches signing control flow and secret-handling primitives in a post-quantum signature crate; behavior is intended to stay KAT-identical but timing and side-channel posture change materially.
> 
> **Overview**
> Reworks ML-DSA-87 **constant-time** behavior: drops costly countermeasures that only hid the **public** Fiat–Shamir abort count, fixes remaining **secret-dependent** timing paths, and adds a **dudect** harness that measures isolated components instead of whole `sign()` / keygen.
> 
> **Signing (`sign.rs`)** uses a normal early-exit rejection loop again (no 16-attempt batching, dummy `pack_sig`, or deferred packing). All four rejection checks still run every attempt; acceptance uses bitwise `&` so a failure does not reveal which bound broke. Challenge bytes are written directly into the output buffer on accept.
> 
> **Crypto primitives:** `poly::challenge()` returns to plain variable-time rejection sampling (input is public hash material). `rej_eta` replaces `ctr % alen` with `ctr.min(alen - 1)` to avoid KyberSlash-style division timing. `check_norm` accumulates with `|=` instead of branching. `make_hint` and `pack_sig` hint packing are fully branchless (`min` clamp, arithmetic `k` increment).
> 
> **Tooling:** New `examples/ct_bench.rs` plus `CONSTANT_TIME_TESTING.md` updates document what to time (per-component fixed vs random secrets) and what to exclude (whole-call timing, `challenge`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d23326f6385141516208d87db576d3b646a77f74. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->