### PR TITLE
bump poseidon version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78172860cd960773c72e97fba07ead9e5a1c13086c5746283744933e2e4a577b"
+checksum = "d3fd767cf8aaecf9369fab79255ff9e0ea439cdfef941976edbfb8ba70435b63"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ hex = { version = "=0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = { version = "=0.4.1", default-features = false }
 libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
-qp-poseidon-core = { version = "=2.1.0", default-features = false }
+qp-poseidon-core = { version = "=3.0.0", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "=2.5.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "=2.4.0", default-features = false }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=1.0.0", default-features = false }

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -28,7 +28,7 @@
 
 use qp_poseidon_core::{
 	hash_bytes, hash_to_bytes, hash_twice,
-	serialization::{bytes_to_digest, string_to_felts},
+	serialization::{bytes_to_digest_lossy, string_to_felts},
 };
 extern crate alloc;
 use alloc::vec::Vec;
@@ -90,13 +90,13 @@ impl WormholePair {
 		let mut secret_bytes = secret.into_bytes();
 		let mut preimage_felts = Vec::new();
 		let salt_felt = string_to_felts(ADDRESS_SALT);
-		// Encode the 32-byte secret as 4 felts via the 8-bytes/felt `bytes_to_digest`.
+		// Encode the 32-byte secret as 4 felts via the 8-bytes/felt `bytes_to_digest_lossy`.
 		// This encoding is non-injective (limbs ≥ the Goldilocks prime are reduced),
 		// which is harmless here: a secret deterministically maps to one canonical
 		// felt-tuple, and a collision would only alias the holder's own secret —
 		// it cannot forge another user's address without their secret. The same
 		// encoding is used when proving, so derivation stays consistent.
-		let mut secret_felt = bytes_to_digest(&secret_bytes);
+		let mut secret_felt = bytes_to_digest_lossy(&secret_bytes);
 		preimage_felts.extend_from_slice(&salt_felt);
 		preimage_felts.extend_from_slice(&secret_felt);
 		let inner_hash = hash_to_bytes(&preimage_felts);
@@ -123,7 +123,7 @@ impl WormholePair {
 mod tests {
 	use super::*;
 	use hex_literal::hex;
-	use qp_poseidon_core::serialization::{bytes_to_digest, bytes_to_felts};
+	use qp_poseidon_core::serialization::{bytes_to_digest_lossy, bytes_to_felts};
 
 	#[test]
 	fn test_generate_pair_from_secret() {
@@ -180,7 +180,7 @@ mod tests {
 	fn test_address_derivation_properties() {
 		// Arrange
 		let secret = hex!("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
-		let secret_felts = bytes_to_digest(&secret);
+		let secret_felts = bytes_to_digest_lossy(&secret);
 
 		// Act - Generate the pair
 		let mut secret_copy = secret;
@@ -254,7 +254,7 @@ mod tests {
 		// Arrange
 		let secret = [7u8; 32];
 
-		let secret_felts = bytes_to_digest(&secret);
+		let secret_felts = bytes_to_digest_lossy(&secret);
 
 		// Generate a pair normally (with salt)
 		let mut secret_copy = secret;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches wormhole identity/address derivation on a major Poseidon release; risk is low if `bytes_to_digest_lossy` is behaviorally equivalent to the old `bytes_to_digest`, but any encoding change would break existing wormhole addresses and ZK proof consistency.
> 
> **Overview**
> **Bumps `qp-poseidon-core` from 2.1.0 to 3.0.0** in workspace dependencies and `Cargo.lock`.
> 
> Wormhole address derivation in `hdwallet` is updated for the new API: all uses of `bytes_to_digest` become **`bytes_to_digest_lossy`** (imports, `generate_pair_from_secret`, and tests), with comments adjusted to match. The derivation flow (salt + secret felts → Poseidon hashes) is otherwise unchanged—this is an adapter change for the renamed serialization helper in Poseidon 3.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78b5eab4706c901505f00f549688344fc55bb444. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->