### PR TITLE
V12 issues again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
+ "unicode-normalization",
  "zeroize",
 ]
 
@@ -1117,6 +1118,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1173,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ rusty-crystals-integration-tests = { path = "./tests" }
 serde = { version = "=1.0.228", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "=1.0.149", default-features = false, features = ["alloc"] }
 thiserror = { version = "=2.0.18", default-features = false }
+unicode-normalization = { version = "=0.1.25", default-features = false }
 zeroize = { version = "=1.8.2", default-features = false, features = ["derive"] }

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -27,6 +27,9 @@ path = "examples/stack_probe.rs"
 [[example]]
 name = "ct_bench"
 path = "examples/ct_bench.rs"
+# The harness times the crate-internal secret samplers, which are only exposed
+# via the `ct-internals` feature. Skip building this example without it.
+required-features = ["ct-internals"]
 
 [dependencies]
 zeroize = { workspace = true }
@@ -46,3 +49,6 @@ harness = false
 
 [features]
 default = []
+# Exposes the crate-internal secret samplers (`polyvec::ct_internals`) so the
+# `ct_bench` constant-time harness can time them directly. Not for production use.
+ct-internals = []

--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -3,8 +3,12 @@
 //! Run with:
 //!
 //! ```bash
-//! cargo run --release -p qp-rusty-crystals-dilithium --example ct_bench
+//! cargo run --release -p qp-rusty-crystals-dilithium --features ct-internals --example ct_bench
 //! ```
+//!
+//! The `ct-internals` feature is required: it exposes the crate-internal secret
+//! samplers (`polyvec::ct_internals`) that this harness times. They are not part
+//! of the public API, so the example is skipped for normal builds.
 //!
 //! # What we measure — and what we deliberately do not
 //!
@@ -67,6 +71,7 @@ use qp_rusty_crystals_dilithium::{
 	packing, params, poly,
 	poly::Poly,
 	polyvec,
+	polyvec::ct_internals::{k_uniform_eta, l_uniform_eta, l_uniform_gamma1},
 	polyvec::{Polyveck, Polyvecl},
 };
 
@@ -133,8 +138,8 @@ fn keygen_s1s2_sampling(runner: &mut CtRunner, rng: &mut BenchRng) {
 		runner.run_one(class, || {
 			let mut s1 = Polyvecl::default();
 			let mut s2 = Polyveck::default();
-			polyvec::l_uniform_eta(&mut s1, black_box(&seed), 0);
-			polyvec::k_uniform_eta(&mut s2, black_box(&seed), L as u16);
+			l_uniform_eta(&mut s1, black_box(&seed), 0);
+			k_uniform_eta(&mut s2, black_box(&seed), L as u16);
 			black_box((&s1, &s2));
 		});
 	}
@@ -235,7 +240,7 @@ fn sign_mask_expansion(runner: &mut CtRunner, rng: &mut BenchRng) {
 		seed.copy_from_slice(if is_left { &fixed } else { &scratch });
 		runner.run_one(class, || {
 			let mut y = Polyvecl::default();
-			polyvec::l_uniform_gamma1(&mut y, black_box(&seed), 0);
+			l_uniform_gamma1(&mut y, black_box(&seed), 0);
 			black_box(&y);
 		});
 	}

--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -71,8 +71,10 @@ use qp_rusty_crystals_dilithium::{
 	packing, params, poly,
 	poly::Poly,
 	polyvec,
-	polyvec::ct_internals::{k_uniform_eta, l_uniform_eta, l_uniform_gamma1},
-	polyvec::{Polyveck, Polyvecl},
+	polyvec::{
+		ct_internals::{k_uniform_eta, l_uniform_eta, l_uniform_gamma1},
+		Polyveck, Polyvecl,
+	},
 };
 
 const L: usize = params::L;

--- a/dilithium/src/acvp.rs
+++ b/dilithium/src/acvp.rs
@@ -106,7 +106,9 @@ fn acvp_siggen_ml_dsa_87() {
 				if deterministic { None } else { Some(fixed::<32>(&hexs(test, "rnd"), "rnd")) };
 
 			let mut sig = [0u8; SIGNBYTES];
-			crate::sign::signature(&mut sig, &message, &sk, hedge);
+			// The internal (Sign_internal) API hashes the message directly, with no
+			// domain prefix; pass an empty prefix.
+			crate::sign::signature(&mut sig, &[], &message, &sk, hedge);
 
 			assert_eq!(
 				sig.as_slice(),
@@ -136,7 +138,7 @@ fn acvp_sigver_ml_dsa_87() {
 			// A length-mutated signature cannot verify; treat as rejection.
 			let sig_bytes = hexs(test, "signature");
 			let got = match <[u8; SIGNBYTES]>::try_from(sig_bytes.as_slice()) {
-				Ok(sig) => crate::sign::verify(&sig, &message, &pk),
+				Ok(sig) => crate::sign::verify(&sig, &[], &message, &pk),
 				Err(_) => false,
 			};
 

--- a/dilithium/src/fips202.rs
+++ b/dilithium/src/fips202.rs
@@ -13,10 +13,18 @@ const NROUNDS: usize = 24;
 /// state is cleared from memory when no longer needed. The `Copy` trait is
 /// intentionally NOT implemented to prevent accidental copies that could
 /// leave sensitive data in memory (HQ8).
+///
+/// The `s` (sponge lanes) and `pos` (offset within the current block) fields
+/// are private. This is deliberate: `pos` must satisfy the invariant
+/// `pos <= rate`, and the squeeze/absorb routines rely on it to make forward
+/// progress. Exposing the fields would let a caller (for example one that
+/// restores a state from untrusted bytes) construct a state with `pos > rate`,
+/// which previously caused `keccak_squeeze` to loop forever. Keeping the
+/// fields private makes that state unrepresentable from outside this module.
 #[derive(Clone, Default, Zeroize, ZeroizeOnDrop)]
 pub struct KeccakState {
-	pub s: [u64; 25],
-	pub pos: usize,
+	s: [u64; 25],
+	pos: usize,
 }
 
 impl KeccakState {
@@ -353,7 +361,11 @@ fn keccak_squeeze(out: &mut [u8], s: &mut [u64; 25], mut pos: usize, r: usize) -
 	let mut outlen = out.len();
 	let mut out_idx = 0;
 	while outlen != 0 {
-		if pos == r {
+		// `>=` (rather than `==`) is a defensive guard: a well-formed state always
+		// has `pos <= r`, but if an out-of-range `pos` ever reaches here we must
+		// still permute and reset so the loop makes progress. Without this, a
+		// `pos > r` would emit zero bytes per iteration and spin forever.
+		if pos >= r {
 			keccakf1600_statepermute(s);
 			pos = 0;
 		}
@@ -583,6 +595,37 @@ mod tests {
 			shake256_squeeze(&mut output, &mut state);
 			assert_eq!(output, test.output, "Input failed with {:?}", test.input);
 		}
+	}
+
+	#[test]
+	fn keccak_squeeze_terminates_with_out_of_range_pos() {
+		// Regression (availability): a `pos` greater than the rate must not make
+		// keccak_squeeze loop forever. Before hardening, `pos > r` meant the inner
+		// `while i < r` loop emitted zero bytes, so `outlen` was never decremented
+		// and the outer `while outlen != 0` spun indefinitely. This test wedges an
+		// out-of-range position (as an untrusted/corrupted state could) and requires
+		// the call to return with a valid in-range position.
+		let mut s = [0u64; 25];
+		let mut out = [0u8; 32];
+		let bad_pos = SHAKE256_RATE + 1;
+		let new_pos = keccak_squeeze(&mut out, &mut s, bad_pos, SHAKE256_RATE);
+		assert!(new_pos <= SHAKE256_RATE, "squeeze must return an in-range position");
+	}
+
+	#[test]
+	fn shake256_squeeze_terminates_with_corrupted_state_pos() {
+		// End-to-end version through the public squeeze entry point. We reach into
+		// the (module-private) `pos` field to simulate a state whose invariant was
+		// violated - e.g. restored from untrusted bytes - and require that squeezing
+		// still terminates and yields a full block of output.
+		let mut state = KeccakState::default();
+		shake256_absorb(&mut state, b"availability");
+		shake256_finalize(&mut state);
+		state.pos = usize::MAX;
+
+		let mut out = [0u8; 64];
+		shake256_squeeze(&mut out, &mut state);
+		assert!(state.pos <= SHAKE256_RATE, "state position must be back in range");
 	}
 
 	#[test]

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -158,7 +158,10 @@ impl fmt::Debug for Keypair {
 /// `Clone` is intentionally not derived because the underlying bytes are sensitive.
 /// To explicitly copy a secret key, use `SecretKey::from_bytes(&sk.to_bytes())?`,
 /// which makes the duplication of secret material visible at every call site.
-#[derive(ZeroizeOnDrop)]
+///
+/// `Zeroize` is derived (in addition to `ZeroizeOnDrop`) so wrapper types that
+/// embed a `SecretKey` can themselves `#[derive(Zeroize, ZeroizeOnDrop)]`.
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct SecretKey {
 	bytes: [u8; SECRETKEYBYTES],
 }

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -222,11 +222,21 @@ impl PublicKey {
 	///
 	/// Returns a PublicKey
 	pub fn from_bytes(bytes: &[u8]) -> Result<PublicKey, KeyParsingError> {
-		let result = bytes.try_into();
-		match result {
-			Ok(bytes) => Ok(PublicKey { bytes }),
-			Err(_) => Err(KeyParsingError::BadPublicKey),
+		let bytes: [u8; PUBLICKEYBYTES] =
+			bytes.try_into().map_err(|_| KeyParsingError::BadPublicKey)?;
+
+		// Reject the degenerate all-zero t1 public key. With t1 = 0 the challenge term in the
+		// verification relation vanishes, letting an attacker forge signatures without any
+		// secret key (see `sign::verify`). Honest key generation never produces t1 = 0, so
+		// this only rejects malformed/malicious keys and never a legitimate one.
+		let mut rho = [0u8; params::SEEDBYTES];
+		let mut t1 = crate::polyvec::Polyveck::default();
+		crate::packing::unpack_pk(&mut rho, &mut t1, &bytes);
+		if t1.vec.iter().all(|p| p.coeffs.iter().all(|&c| c == 0)) {
+			return Err(KeyParsingError::BadPublicKey);
 		}
+
+		Ok(PublicKey { bytes })
 	}
 
 	/// Verify a signature for a given message with a public key.
@@ -343,5 +353,24 @@ mod tests {
 		let keys = Keypair::generate(get_random_bytes());
 		let big_msg = vec![0u8; MAX_MESSAGE_SIZE + 1];
 		assert!(!keys.verify(&big_msg, &[0u8; SIGNBYTES], None));
+	}
+
+	// Malicious-key forgery defense: a public key with an all-zero t1 makes verification
+	// independent of the challenge, enabling signature forgery without a secret key.
+	// `from_bytes` must reject such a key so it can never be constructed or stored.
+	#[test]
+	fn from_bytes_rejects_zero_t1_public_key() {
+		use super::{KeyParsingError, PublicKey, PUBLICKEYBYTES};
+
+		// Arbitrary rho, all-zero t1 region.
+		let mut pk = [0u8; PUBLICKEYBYTES];
+		pk[..crate::params::SEEDBYTES].copy_from_slice(&[0x42u8; crate::params::SEEDBYTES]);
+
+		assert!(matches!(PublicKey::from_bytes(&pk), Err(KeyParsingError::BadPublicKey)));
+
+		// A genuine public key must still round-trip through from_bytes.
+		let keys = Keypair::generate(get_random_bytes());
+		let good = keys.public.to_bytes();
+		assert!(PublicKey::from_bytes(&good).is_ok());
 	}
 }

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -68,6 +68,19 @@ impl Keypair {
 	/// * 'bytes' - private and public keys bytes
 	///
 	/// Returns a Keypair
+	///
+	/// # Consistency check
+	///
+	/// The public half is re-derived from the secret half and must match the
+	/// supplied public-key bytes exactly; otherwise this returns
+	/// [`KeyParsingError::BadKeypair`]. This prevents importing a keypair whose
+	/// public key does not correspond to its secret key — which would otherwise
+	/// let an object sign with one key while advertising an unrelated public key
+	/// (e.g. a receive address the victim cannot spend from).
+	///
+	/// Note: the `secret` and `public` fields are public, so callers can still
+	/// construct or mutate a `Keypair` with mismatched halves directly. This
+	/// check only guards the deserialization/import path.
 	pub fn from_bytes(bytes: &[u8]) -> Result<Keypair, KeyParsingError> {
 		if bytes.len() != SECRETKEYBYTES + PUBLICKEYBYTES {
 			return Err(KeyParsingError::BadKeypair);
@@ -77,6 +90,15 @@ impl Keypair {
 			SecretKey::from_bytes(secret_bytes).map_err(|_| KeyParsingError::BadKeypair)?;
 		let public =
 			PublicKey::from_bytes(public_bytes).map_err(|_| KeyParsingError::BadKeypair)?;
+
+		// Enforce the cross-field invariant: the public key must be the one that
+		// corresponds to the secret key. The derived pk is public data, so a
+		// non-constant-time comparison is fine.
+		let derived_public = crate::sign::public_key_from_secret(&secret.bytes);
+		if derived_public != public.bytes {
+			return Err(KeyParsingError::BadKeypair);
+		}
+
 		Ok(Keypair { secret, public })
 	}
 
@@ -347,6 +369,31 @@ mod tests {
 		let keys = Keypair::generate(get_random_bytes());
 		let big_msg = vec![0u8; MAX_MESSAGE_SIZE + 1];
 		assert!(!keys.verify(&big_msg, &[0u8; SIGNBYTES], None));
+	}
+
+	// A keypair blob whose public half does not correspond to its secret half must
+	// be rejected. Otherwise an imported keypair could sign with one key while
+	// advertising an unrelated public key (e.g. an unspendable receive address).
+	#[test]
+	fn from_bytes_rejects_mismatched_public_key() {
+		use super::{Keypair, KeyParsingError, KEYPAIRBYTES, SECRETKEYBYTES};
+
+		let keys_a = Keypair::generate(get_random_bytes());
+		let keys_b = Keypair::generate(get_random_bytes());
+
+		// Genuine keypair bytes must round-trip.
+		let good = keys_a.to_bytes();
+		assert!(Keypair::from_bytes(&good).is_ok(), "honest keypair must be accepted");
+
+		// Splice A's secret key with B's (unrelated) public key.
+		let mut forged = [0u8; KEYPAIRBYTES];
+		forged[..SECRETKEYBYTES].copy_from_slice(&keys_a.secret.to_bytes());
+		forged[SECRETKEYBYTES..].copy_from_slice(&keys_b.public.to_bytes());
+
+		assert!(
+			matches!(Keypair::from_bytes(&forged), Err(KeyParsingError::BadKeypair)),
+			"public key not derived from the secret key must be rejected"
+		);
 	}
 
 	// Malicious-key forgery defense: a public key with an all-zero t1 makes verification

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -387,7 +387,7 @@ mod tests {
 	// advertising an unrelated public key (e.g. an unspendable receive address).
 	#[test]
 	fn from_bytes_rejects_mismatched_public_key() {
-		use super::{Keypair, KeyParsingError, KEYPAIRBYTES, SECRETKEYBYTES};
+		use super::{KeyParsingError, Keypair, KEYPAIRBYTES, SECRETKEYBYTES};
 
 		let keys_a = Keypair::generate(get_random_bytes());
 		let keys_b = Keypair::generate(get_random_bytes());
@@ -414,7 +414,7 @@ mod tests {
 	// public key. `from_bytes` must reject such blobs at import.
 	#[test]
 	fn from_bytes_rejects_corrupted_tr_or_t0() {
-		use super::{Keypair, KeyParsingError, SECRETKEYBYTES};
+		use super::{KeyParsingError, Keypair, SECRETKEYBYTES};
 		use crate::params::{POLYT0_PACKEDBYTES, SEEDBYTES, TR_BYTES};
 
 		let keys = Keypair::generate(get_random_bytes());

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -78,6 +78,12 @@ impl Keypair {
 	/// let an object sign with one key while advertising an unrelated public key
 	/// (e.g. a receive address the victim cannot spend from).
 	///
+	/// The secret key's internal invariants are checked as well: the stored
+	/// `t0` must match the low bits re-derived from `(rho, s1, s2)`, and the
+	/// stored `tr` must equal `SHAKE256(pk)`. Signing uses both fields, so a
+	/// blob corrupted in those regions would otherwise import cleanly and then
+	/// produce signatures that fail under the advertised public key.
+	///
 	/// Note: the `secret` and `public` fields are public, so callers can still
 	/// construct or mutate a `Keypair` with mismatched halves directly. This
 	/// check only guards the deserialization/import path.
@@ -91,10 +97,12 @@ impl Keypair {
 		let public =
 			PublicKey::from_bytes(public_bytes).map_err(|_| KeyParsingError::BadKeypair)?;
 
-		// Enforce the cross-field invariant: the public key must be the one that
-		// corresponds to the secret key. The derived pk is public data, so a
-		// non-constant-time comparison is fine.
-		let derived_public = crate::sign::public_key_from_secret(&secret.bytes);
+		// Enforce the cross-field invariants: the secret key must be internally
+		// consistent (tr, t0) and the public key must be the one that corresponds
+		// to it. The derived pk is public data, so a non-constant-time comparison
+		// is fine.
+		let derived_public = crate::sign::public_key_from_secret(&secret.bytes)
+			.ok_or(KeyParsingError::BadKeypair)?;
 		if derived_public != public.bytes {
 			return Err(KeyParsingError::BadKeypair);
 		}
@@ -393,6 +401,41 @@ mod tests {
 		assert!(
 			matches!(Keypair::from_bytes(&forged), Err(KeyParsingError::BadKeypair)),
 			"public key not derived from the secret key must be rejected"
+		);
+	}
+
+	// The packed secret key stores tr = SHAKE256(pk) and t0 (low bits of
+	// A·s1 + s2) alongside (rho, s1, s2). Signing uses the stored tr and t0, so
+	// a blob with honest rho/s1/s2/pk but a corrupted tr or t0 region would
+	// import cleanly and then produce signatures that fail under the advertised
+	// public key. `from_bytes` must reject such blobs at import.
+	#[test]
+	fn from_bytes_rejects_corrupted_tr_or_t0() {
+		use super::{Keypair, KeyParsingError, SECRETKEYBYTES};
+		use crate::params::{POLYT0_PACKEDBYTES, SEEDBYTES, TR_BYTES};
+
+		let keys = Keypair::generate(get_random_bytes());
+		let good = keys.to_bytes();
+		assert!(Keypair::from_bytes(&good).is_ok(), "honest keypair must be accepted");
+
+		// SK layout: rho (32) || key (32) || tr (64) || s1 || s2 || t0.
+		let tr_offset = 2 * SEEDBYTES;
+		let t0_offset = SECRETKEYBYTES - crate::params::K * POLYT0_PACKEDBYTES;
+
+		// Corrupt one byte inside the stored tr region only.
+		let mut bad_tr = good;
+		bad_tr[tr_offset + TR_BYTES / 2] ^= 0x01;
+		assert!(
+			matches!(Keypair::from_bytes(&bad_tr), Err(KeyParsingError::BadKeypair)),
+			"secret key with corrupted tr must be rejected"
+		);
+
+		// Corrupt one byte inside the stored t0 region only.
+		let mut bad_t0 = good;
+		bad_t0[t0_offset] ^= 0x01;
+		assert!(
+			matches!(Keypair::from_bytes(&bad_t0), Err(KeyParsingError::BadKeypair)),
+			"secret key with corrupted t0 must be rejected"
 		);
 	}
 

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -4,7 +4,6 @@ use crate::{
 	errors::{KeyParsingError, KeyParsingError::BadSecretKey, SignatureError},
 	params, SensitiveBytes32,
 };
-use alloc::vec;
 use core::fmt;
 
 pub const SECRETKEYBYTES: usize = crate::params::SECRETKEYBYTES;
@@ -176,27 +175,26 @@ impl SecretKey {
 		if msg.len() > MAX_MESSAGE_SIZE {
 			return Err(SignatureError::MessageTooLong);
 		}
+		// The message is hashed as `domain_prefix || msg`. Only the small (<= 257
+		// byte) domain prefix is materialized; `msg` is passed by reference and
+		// absorbed directly, so an attacker-sized message is never copied.
 		match ctx {
 			Some(x) => {
 				if x.len() > 255 {
 					return Err(SignatureError::ContextTooLong);
 				}
 				let x_len = x.len();
-				let msg_len = msg.len();
-				let mut m = vec![0; msg_len + 2 + x_len];
-				m[1] = x_len as u8;
-				m[2..2 + x_len].copy_from_slice(x);
-				m[2 + x_len..].copy_from_slice(msg);
+				let mut prefix = [0u8; 2 + 255];
+				prefix[1] = x_len as u8;
+				prefix[2..2 + x_len].copy_from_slice(x);
 				let mut sig: Signature = [0u8; SIGNBYTES];
-				crate::sign::signature(&mut sig, m.as_slice(), &self.bytes, hedge);
+				crate::sign::signature(&mut sig, &prefix[..2 + x_len], msg, &self.bytes, hedge);
 				Ok(sig)
 			},
 			None => {
 				let mut sig: Signature = [0u8; SIGNBYTES];
 				// Prefix 2 zero bytes (domain_sep=0, context_len=0) for pure signatures
-				let mut m = vec![0u8; msg.len() + 2];
-				m[2..2 + msg.len()].copy_from_slice(msg);
-				crate::sign::signature(&mut sig, m.as_slice(), &self.bytes, hedge);
+				crate::sign::signature(&mut sig, &[0u8, 0u8], msg, &self.bytes, hedge);
 				Ok(sig)
 			},
 		}
@@ -258,24 +256,20 @@ impl PublicKey {
 		if msg.len() > MAX_MESSAGE_SIZE {
 			return false;
 		}
+		// As in `sign`, only the small domain prefix is materialized; the message
+		// is absorbed by reference rather than copied into a full-size buffer.
 		match ctx {
 			Some(x) => {
 				if x.len() > 255 {
 					return false;
 				}
 				let x_len = x.len();
-				let msg_len = msg.len();
-				let mut m = vec![0; msg_len + 2 + x_len];
-				m[1] = x_len as u8;
-				m[2..2 + x_len].copy_from_slice(x);
-				m[2 + x_len..].copy_from_slice(msg);
-				crate::sign::verify(sig, m.as_slice(), &self.bytes)
+				let mut prefix = [0u8; 2 + 255];
+				prefix[1] = x_len as u8;
+				prefix[2..2 + x_len].copy_from_slice(x);
+				crate::sign::verify(sig, &prefix[..2 + x_len], msg, &self.bytes)
 			},
-			None => {
-				let mut m = vec![0; msg.len() + 2];
-				m[2..2 + msg.len()].copy_from_slice(msg);
-				crate::sign::verify(sig, m.as_slice(), &self.bytes)
-			},
+			None => crate::sign::verify(sig, &[0u8, 0u8], msg, &self.bytes),
 		}
 	}
 }

--- a/dilithium/src/packing.rs
+++ b/dilithium/src/packing.rs
@@ -122,8 +122,11 @@ pub fn pack_sig(
 	}
 
 	let mut idx = params::C_DASH_BYTES;
-	for i in 0..L {
-		poly::z_pack(&mut sig[idx + i * params::POLYZ_PACKEDBYTES..], &z.vec[i]);
+	// `as_chunks_mut` splits the buffer into exact-size `&mut [u8; POLYZ_PACKEDBYTES]`
+	// arrays, so no per-polynomial length check or fallible conversion is needed.
+	let (z_chunks, _) = sig[idx..].as_chunks_mut::<{ params::POLYZ_PACKEDBYTES }>();
+	for (chunk, zi) in z_chunks.iter_mut().zip(z.vec.iter()).take(L) {
+		poly::z_pack(chunk, zi);
 	}
 
 	idx += L * params::POLYZ_PACKEDBYTES;
@@ -172,8 +175,11 @@ pub fn unpack_sig(
 	c.copy_from_slice(&sig[..params::C_DASH_BYTES]);
 
 	let mut idx = params::C_DASH_BYTES;
-	for i in 0..L {
-		poly::z_unpack(&mut z.vec[i], &sig[idx + i * params::POLYZ_PACKEDBYTES..]);
+	// Exact-size chunks: each `&[u8; POLYZ_PACKEDBYTES]` is produced by the split,
+	// so a truncated per-polynomial slice can't reach `z_unpack`.
+	let (z_chunks, _) = sig[idx..].as_chunks::<{ params::POLYZ_PACKEDBYTES }>();
+	for (chunk, zi) in z_chunks.iter().zip(z.vec.iter_mut()).take(L) {
+		poly::z_unpack(zi, chunk);
 	}
 	idx += L * params::POLYZ_PACKEDBYTES;
 

--- a/dilithium/src/packing.rs
+++ b/dilithium/src/packing.rs
@@ -154,12 +154,21 @@ pub fn pack_sig(
 }
 
 /// Unpack signature sig = (z, h, c).
+///
+/// The hint vector is sparse: only the coefficients listed in the encoded hint
+/// section are set to 1. `h` is therefore zeroed on entry so the output represents
+/// only the current signature — otherwise a reused (or attacker-poisoned) `h`
+/// buffer would retain stale hint bits from a previous parse, letting a signature
+/// that encodes fewer/zero hints verify or canonicalize against hidden data.
 pub fn unpack_sig(
 	c: &mut [u8; params::C_DASH_BYTES],
 	z: &mut Polyvecl,
 	h: &mut Polyveck,
 	sig: &[u8; params::SIGNBYTES],
 ) -> bool {
+	// Overwrite, don't merge: clear any prior hint bits before decoding this signature.
+	*h = Polyveck::default();
+
 	c.copy_from_slice(&sig[..params::C_DASH_BYTES]);
 
 	let mut idx = params::C_DASH_BYTES;
@@ -420,6 +429,42 @@ mod tests {
 		for i in 0..K {
 			for j in 0..N {
 				assert_eq!(0, unpacked_h.vec[i].coeffs[j], "Expected zero hint at [{},{}]", i, j);
+			}
+		}
+	}
+
+	// unpack_sig must overwrite the destination hint vector, not merge into it. A
+	// reused (or attacker-poisoned) `h` buffer must not leak stale hint bits from a
+	// previous parse into a later signature that encodes fewer/zero hints. Otherwise
+	// direct users of the public packing API could verify or canonicalize bytes
+	// against hidden hint data that is not present in the supplied signature.
+	#[test]
+	fn unpack_sig_clears_stale_hints_from_reused_buffer() {
+		// A syntactically valid signature with an empty hint vector.
+		let c = [0x99u8; params::C_DASH_BYTES];
+		let z = Polyvecl::default();
+		let h = Polyveck::default();
+		let mut packed_sig = [0u8; params::SIGNBYTES];
+		pack_sig(&mut packed_sig, Some(&c), &z, &h);
+
+		// Reuse output buffers that already hold hint bits from a "previous" parse.
+		let mut unpacked_c = [0u8; params::C_DASH_BYTES];
+		let mut unpacked_z = Polyvecl::default();
+		let mut unpacked_h = Polyveck::default();
+		unpacked_h.vec[0].coeffs[5] = 1;
+		unpacked_h.vec[K - 1].coeffs[N - 1] = 1;
+
+		assert!(unpack_sig(&mut unpacked_c, &mut unpacked_z, &mut unpacked_h, &packed_sig));
+
+		// The empty-hint signature must yield an all-zero hint vector: the stale bits
+		// must have been cleared, not preserved.
+		for i in 0..K {
+			for j in 0..N {
+				assert_eq!(
+					0, unpacked_h.vec[i].coeffs[j],
+					"stale hint survived unpack_sig at [{},{}]",
+					i, j
+				);
 			}
 		}
 	}

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -194,7 +194,7 @@ pub fn uniform(a: &mut Poly, seed: &[u8; params::SEEDBYTES], nonce: u16) {
 
 /// Bit-pack polynomial t1 with coefficients fitting in 10 bits.
 /// Input coefficients are assumed to be standard representatives.
-pub fn t1_pack(r: &mut [u8], a: &Poly) {
+pub(crate) fn t1_pack(r: &mut [u8], a: &Poly) {
 	for i in 0..N / 4 {
 		r[5 * i + 0] = (a.coeffs[4 * i + 0] >> 0) as u8;
 		r[5 * i + 1] = ((a.coeffs[4 * i + 0] >> 8) | (a.coeffs[4 * i + 1] << 2)) as u8;
@@ -206,7 +206,7 @@ pub fn t1_pack(r: &mut [u8], a: &Poly) {
 
 /// Unpack polynomial t1 with 9-bit coefficients.
 /// Output coefficients are standard representatives.
-pub fn t1_unpack(r: &mut Poly, a: &[u8]) {
+pub(crate) fn t1_unpack(r: &mut Poly, a: &[u8]) {
 	for i in 0..N / 4 {
 		r.coeffs[4 * i + 0] =
 			(((a[5 * i + 0] >> 0) as u32 | (a[5 * i + 1] as u32) << 8) & 0x3FF) as i32;
@@ -220,7 +220,7 @@ pub fn t1_unpack(r: &mut Poly, a: &[u8]) {
 }
 
 /// Bit-pack polynomial t0 with coefficients in [-2^{D-1}, 2^{D-1}].
-pub fn t0_pack(r: &mut [u8], a: &Poly) {
+pub(crate) fn t0_pack(r: &mut [u8], a: &Poly) {
 	let mut t = [0i32; 8];
 
 	for i in 0..N / 8 {
@@ -258,7 +258,7 @@ pub fn t0_pack(r: &mut [u8], a: &Poly) {
 
 /// Unpack polynomial t0 with coefficients in ]-2^{D-1}, 2^{D-1}].
 /// Output coefficients lie in ]Q-2^{D-1},Q+2^{D-1}].
-pub fn t0_unpack(r: &mut Poly, a: &[u8]) {
+pub(crate) fn t0_unpack(r: &mut Poly, a: &[u8]) {
 	for i in 0..N / 8 {
 		r.coeffs[8 * i + 0] = a[13 * i + 0] as i32;
 		r.coeffs[8 * i + 0] |= (a[13 * i + 1] as i32) << 8;
@@ -440,7 +440,12 @@ pub fn uniform_gamma1(a: &mut Poly, seed: &[u8; params::CRHBYTES], nonce: u16) {
 
 	let mut buf = [0u8; UNIFORM_GAMMA1_NBLOCKS * fips202::SHAKE256_RATE];
 	fips202::shake256_squeezeblocks(&mut buf, UNIFORM_GAMMA1_NBLOCKS, &mut state);
-	z_unpack(a, &buf);
+	// The squeeze buffer is a multiple of the rate and always >= POLYZ_PACKEDBYTES,
+	// so `first_chunk` yields the exact prefix the codec consumes.
+	let z_bytes = buf
+		.first_chunk::<{ params::POLYZ_PACKEDBYTES }>()
+		.expect("gamma1 buffer covers POLYZ_PACKEDBYTES");
+	z_unpack(a, z_bytes);
 }
 
 /// Implementation of H. Samples polynomial with TAU nonzero coefficients in {-1,1} using the output
@@ -488,7 +493,7 @@ pub fn challenge(c: &mut Poly, seed: &[u8]) {
 
 /// Bit-pack polynomial with coefficients in [-ETA,ETA]. Input coefficients are assumed to lie in
 /// [Q-ETA,Q+ETA].
-pub fn eta_pack(r: &mut [u8], a: &Poly) {
+pub(crate) fn eta_pack(r: &mut [u8], a: &Poly) {
 	let mut t = [0u8; 8];
 	for i in 0..N / 8 {
 		t[0] = (params::ETA as i32 - a.coeffs[8 * i + 0]) as u8;
@@ -507,7 +512,7 @@ pub fn eta_pack(r: &mut [u8], a: &Poly) {
 }
 
 /// Unpack polynomial with coefficients in [-ETA,ETA].
-pub fn eta_unpack(r: &mut Poly, a: &[u8]) {
+pub(crate) fn eta_unpack(r: &mut Poly, a: &[u8]) {
 	for i in 0..N / 8 {
 		r.coeffs[8 * i + 0] = (a[3 * i + 0] & 0x07) as i32;
 		r.coeffs[8 * i + 1] = ((a[3 * i + 0] >> 3) & 0x07) as i32;
@@ -531,7 +536,10 @@ pub fn eta_unpack(r: &mut Poly, a: &[u8]) {
 
 /// Bit-pack polynomial z with coefficients in [-(GAMMA1 - 1), GAMMA1 - 1].
 /// Input coefficients are assumed to be standard representatives.
-pub fn z_pack(r: &mut [u8], a: &Poly) {
+///
+/// The output buffer is an exact-size array so a too-short destination is
+/// rejected at compile time rather than panicking on an out-of-bounds write.
+pub fn z_pack(r: &mut [u8; params::POLYZ_PACKEDBYTES], a: &Poly) {
 	let mut t = [0i32; 2];
 
 	for i in 0..N / 2 {
@@ -549,7 +557,10 @@ pub fn z_pack(r: &mut [u8], a: &Poly) {
 
 /// Unpack polynomial z with coefficients in [-(GAMMA1 - 1), GAMMA1 - 1].
 /// Output coefficients are standard representatives.
-pub fn z_unpack(r: &mut Poly, a: &[u8]) {
+///
+/// The input is an exact-size array so a truncated slice is rejected at compile
+/// time rather than panicking on an out-of-bounds read.
+pub fn z_unpack(r: &mut Poly, a: &[u8; params::POLYZ_PACKEDBYTES]) {
 	for i in 0..N / 2 {
 		r.coeffs[2 * i + 0] = a[5 * i + 0] as i32;
 		r.coeffs[2 * i + 0] |= (a[5 * i + 1] as i32) << 8;
@@ -568,7 +579,7 @@ pub fn z_unpack(r: &mut Poly, a: &[u8]) {
 
 /// Bit-pack polynomial w1 with coefficients in [0, 15].
 /// Input coefficients are assumed to be standard representatives.
-pub fn w1_pack(r: &mut [u8], a: &Poly) {
+pub(crate) fn w1_pack(r: &mut [u8], a: &Poly) {
 	for i in 0..N / 2 {
 		r[i] = (a.coeffs[2 * i + 0] | (a.coeffs[2 * i + 1] << 4)) as u8;
 	}

--- a/dilithium/src/polyvec.rs
+++ b/dilithium/src/polyvec.rs
@@ -5,6 +5,34 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 const K: usize = params::K;
 const L: usize = params::L;
 
+/// Unstable accessors for the crate-internal secret samplers, used only by the
+/// in-crate constant-time harness (`examples/ct_bench.rs`).
+///
+/// The samplers themselves stay `pub(crate)`; these are thin pass-through
+/// wrappers gated behind the off-by-default `ct-internals` feature, so they do
+/// not appear in the public API of a normal build. Not covered by semver; do not
+/// depend on this module outside the crate's own timing tests.
+#[cfg(feature = "ct-internals")]
+pub mod ct_internals {
+	use super::{Polyveck, Polyvecl};
+	use crate::params;
+
+	/// See [`super::l_uniform_eta`].
+	pub fn l_uniform_eta(v: &mut Polyvecl, seed: &[u8; params::CRHBYTES], base_nonce: u16) {
+		super::l_uniform_eta(v, seed, base_nonce);
+	}
+
+	/// See [`super::k_uniform_eta`].
+	pub fn k_uniform_eta(v: &mut Polyveck, seed: &[u8; params::CRHBYTES], base_nonce: u16) {
+		super::k_uniform_eta(v, seed, base_nonce);
+	}
+
+	/// See [`super::l_uniform_gamma1`].
+	pub fn l_uniform_gamma1(v: &mut Polyvecl, seed: &[u8; params::CRHBYTES], nonce: u16) {
+		super::l_uniform_gamma1(v, seed, nonce);
+	}
+}
+
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct Polyveck {
 	pub vec: [Poly; K],
@@ -80,14 +108,32 @@ pub fn matrix_pointwise_montgomery_streamed(
 	}
 }
 
-pub fn l_uniform_eta(v: &mut Polyvecl, seed: &[u8; params::CRHBYTES], mut nonce: u16) {
+/// Sample an L-vector of eta-bounded polynomials, one per SHAKE stream nonce
+/// `base_nonce + i` for `i in 0..L`.
+///
+/// Crate-internal: only the low two nonce bytes are absorbed into the SHAKE
+/// stream, so callers must keep `base_nonce + (L - 1) <= u16::MAX` to avoid
+/// aliasing distinct sampler invocations onto the same stream. The in-crate
+/// callers (keygen, using constant nonces) satisfy this by construction; the
+/// helper is deliberately not part of the public API so external callers cannot
+/// supply an out-of-range nonce.
+pub(crate) fn l_uniform_eta(v: &mut Polyvecl, seed: &[u8; params::CRHBYTES], base_nonce: u16) {
 	for i in 0..L {
-		poly::uniform_eta(&mut v.vec[i], seed, nonce);
-		nonce += 1;
+		poly::uniform_eta(&mut v.vec[i], seed, base_nonce + i as u16);
 	}
 }
 
-pub fn l_uniform_gamma1(v: &mut Polyvecl, seed: &[u8; params::CRHBYTES], nonce: u16) {
+/// Sample an L-vector of gamma1 mask polynomials, one per SHAKE stream nonce
+/// `L * nonce + i` for `i in 0..L`.
+///
+/// Crate-internal: only the low two nonce bytes are absorbed into the SHAKE
+/// stream, so `nonce` must satisfy `L * nonce + (L - 1) <= u16::MAX` — otherwise
+/// distinct mask samples alias onto the same stream, reusing a mask `y` across
+/// signing attempts (which leaks the secret via `z = y + c*s1`). The sole
+/// in-crate caller (the signer) enforces this with its `MAX_SAFE_ATTEMPT_NONCE`
+/// check before calling, and the helper is not exported, so an external caller
+/// cannot reach it with an unchecked nonce.
+pub(crate) fn l_uniform_gamma1(v: &mut Polyvecl, seed: &[u8; params::CRHBYTES], nonce: u16) {
 	for i in 0..L {
 		poly::uniform_gamma1(&mut v.vec[i], seed, L as u16 * nonce + i as u16);
 	}
@@ -146,10 +192,15 @@ pub fn polyvecl_is_norm_within_bound(v: &Polyvecl, bound: i32) -> bool {
 
 //---------------------------------
 
-pub fn k_uniform_eta(v: &mut Polyveck, seed: &[u8; params::CRHBYTES], mut nonce: u16) {
+/// Sample a K-vector of eta-bounded polynomials, one per SHAKE stream nonce
+/// `base_nonce + i` for `i in 0..K`.
+///
+/// As in [`l_uniform_eta`], this is crate-internal and only the low two nonce
+/// bytes are absorbed, so `base_nonce` must be `<= u16::MAX - (K - 1)`. Keygen,
+/// the only in-crate caller, passes a constant in-range nonce.
+pub(crate) fn k_uniform_eta(v: &mut Polyveck, seed: &[u8; params::CRHBYTES], base_nonce: u16) {
 	for i in 0..K {
-		poly::uniform_eta(&mut v.vec[i], seed, nonce);
-		nonce += 1
+		poly::uniform_eta(&mut v.vec[i], seed, base_nonce + i as u16);
 	}
 }
 
@@ -350,6 +401,27 @@ mod tests {
 				);
 			}
 		}
+	}
+
+	// The samplers are `pub(crate)`: external callers cannot reach them, so the
+	// only nonces they ever see come from in-crate callers that keep them in the
+	// valid u16 range (keygen uses constants; the signer checks
+	// `MAX_SAFE_ATTEMPT_NONCE` before expanding the mask). This test confirms the
+	// largest in-range nonces still sample correctly.
+	#[test]
+	fn samplers_accept_maximum_in_range_nonce() {
+		let seed = [0x13u8; params::CRHBYTES];
+
+		let mut vl = Polyvecl::default();
+		l_uniform_eta(&mut vl, &seed, u16::MAX - (L as u16 - 1));
+
+		let mut vk = Polyveck::default();
+		k_uniform_eta(&mut vk, &seed, u16::MAX - (K as u16 - 1));
+
+		// Largest `nonce` with L * nonce + (L - 1) <= u16::MAX.
+		let max_gamma1_nonce = (u16::MAX - (L as u16 - 1)) / L as u16;
+		let mut vg = Polyvecl::default();
+		l_uniform_gamma1(&mut vg, &seed, max_gamma1_nonce);
 	}
 
 	#[test]

--- a/dilithium/src/polyvec.rs
+++ b/dilithium/src/polyvec.rs
@@ -313,9 +313,12 @@ pub fn k_use_hint(a: &mut Polyveck, hint: &Polyveck) {
 	}
 }
 
-/// Pack polynomial vector w1 into byte array. Output buffer must be at least K * POLYW1_PACKEDBYTES
-/// bytes.
-pub fn k_pack_w1(r: &mut [u8], a: &Polyveck) {
+/// Pack polynomial vector w1 into byte array.
+///
+/// The output is an exact-size array (`K * POLYW1_PACKEDBYTES`) so a too-short
+/// destination buffer is rejected at compile time rather than panicking on an
+/// out-of-bounds write.
+pub fn k_pack_w1(r: &mut [u8; K * params::POLYW1_PACKEDBYTES], a: &Polyveck) {
 	for i in 0..K {
 		poly::w1_pack(&mut r[i * params::POLYW1_PACKEDBYTES..], &a.vec[i]);
 	}

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -103,16 +103,31 @@ pub fn keypair(
 	t0.zeroize();
 }
 
-/// Re-derive the public key that corresponds to a secret key.
+/// Re-derive the public key that corresponds to a secret key, verifying the
+/// secret key's internal invariants along the way.
 ///
-/// Recomputes `t1` from the secret key's `(rho, s1, s2)` exactly as
-/// [`keypair`] does, and packs `pk = (rho, t1)`. Callers use this to enforce
-/// the cross-field invariant that a supplied public key actually belongs to a
-/// secret key (rather than trusting a concatenated blob). The secret
-/// polynomials are zeroized before returning.
+/// Recomputes `t1` and `t0` from the secret key's `(rho, s1, s2)` exactly as
+/// [`keypair`] does, and packs `pk = (rho, t1)`. In addition to re-deriving
+/// the public key, this checks the two remaining packed-SK invariants:
+///
+/// - the stored `t0` must equal the re-derived low bits of `A·s1 + s2`, and
+/// - the stored `tr` must equal `SHAKE256(pk)`.
+///
+/// Signing uses the stored `tr` (bound into the message digest) and `t0`
+/// (hint computation), so a blob with a corrupted `tr`/`t0` region would
+/// import "successfully" and then produce signatures that fail under the
+/// advertised public key. Rejecting such blobs here fails fast at import and
+/// avoids ever signing with an inconsistent key (corrupted-key signing is the
+/// setup for fault-style analyses on Dilithium).
+///
+/// Returns `None` if either invariant is violated. The comparisons are not
+/// constant-time; timing can only differ for an already-corrupted blob, and
+/// the honest path compares all-equal data.
+///
+/// The secret polynomials are zeroized before returning.
 pub(crate) fn public_key_from_secret(
 	sk: &[u8; params::SECRETKEYBYTES],
-) -> [u8; params::PUBLICKEYBYTES] {
+) -> Option<[u8; params::PUBLICKEYBYTES]> {
 	let mut rho = [0u8; params::SEEDBYTES];
 	let mut tr = [0u8; params::TR_BYTES];
 	let mut key = [0u8; params::SEEDBYTES];
@@ -121,19 +136,36 @@ pub(crate) fn public_key_from_secret(
 	let mut s2 = Polyveck::default();
 	packing::unpack_sk(&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, sk);
 
-	// Same derivation as key generation; the stored `t0` is recomputed and discarded.
+	// Same derivation as key generation.
 	let (t1, mut t0_derived) = derive_public_components(&rho, &s1, &s2);
 
 	let mut pk = [0u8; params::PUBLICKEYBYTES];
 	packing::pack_pk(&mut pk, &rho, &t1);
 
-	// Only rho/s1/s2 are needed to derive the public key; wipe the secret copies.
+	// Invariant: stored t0 must be the low bits actually derived from (rho, s1, s2).
+	let t0_consistent = t0
+		.vec
+		.iter()
+		.zip(t0_derived.vec.iter())
+		.all(|(stored, derived)| stored.coeffs == derived.coeffs);
+
+	// Invariant: stored tr must be the hash of the (re-derived) public key.
+	let mut tr_derived = [0u8; params::TR_BYTES];
+	fips202::shake256(&mut tr_derived, &pk);
+	let tr_consistent = tr == tr_derived;
+
+	// Only rho/t1 are public; wipe the secret copies.
 	key.zeroize();
 	s1.zeroize();
 	s2.zeroize();
 	t0.zeroize();
 	t0_derived.zeroize();
-	pk
+
+	if t0_consistent && tr_consistent {
+		Some(pk)
+	} else {
+		None
+	}
 }
 
 /// Compute a signature for a given message from a private (secret) key.

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -650,7 +650,6 @@ mod tests {
 		bytes
 	}
 
-
 	#[test]
 	fn self_verify_hedged() {
 		let mut pk = [0u8; crate::params::PUBLICKEYBYTES];

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -456,6 +456,16 @@ pub(crate) fn verify(
 	let mut state = fips202::KeccakState::default(); // shake256_init()
 
 	packing::unpack_pk(&mut rho, &mut t1, pk);
+
+	// Reject the degenerate all-zero t1 public key. With t1 = 0 the term c*2^d*t1 in the
+	// verification relation vanishes for every challenge c, so w1 = UseHint(h, Az) no longer
+	// binds the challenge to the key. An attacker can then forge a signature (z = 0, empty
+	// hint, c = H(mu || w1Encode(0))) with no secret key. Honest key generation never yields
+	// t1 = 0, so rejecting it costs nothing and closes the malicious-key forgery.
+	if t1.vec.iter().all(|p| p.coeffs.iter().all(|&c| c == 0)) {
+		return false;
+	}
+
 	if !packing::unpack_sig(&mut c, &mut z, &mut h, sig) {
 		return false;
 	}
@@ -817,6 +827,55 @@ mod tests {
 		assert!(
 			!polyvecl_eq(&y1, &y2),
 			"mask y was reused across two different messages (Bug Class 3)"
+		);
+	}
+
+	// Malicious-key forgery (degenerate all-zero t1): a public key whose t1 is entirely zero
+	// makes the verification relation w1 = UseHint(h, Az - c*2^d*t1) independent of the
+	// challenge c, because the c*2^d*t1 term vanishes for every c. An attacker can then pick
+	// z = 0 and an empty hint, so the verifier reconstructs w1 = 0, precompute
+	// c = H(mu || w1Encode(0)), and place that c in the signature. Verification then finds
+	// c == c2 and accepts, even though the attacker possesses no secret key. A successful
+	// verify must imply possession of a real secret key, so this key must be rejected.
+	#[test]
+	fn test_forged_signature_with_zero_t1_is_rejected() {
+		// Public key with arbitrary rho and an all-zero t1 (the t1 byte region stays zero).
+		let mut pk = [0u8; params::PUBLICKEYBYTES];
+		pk[..params::SEEDBYTES].copy_from_slice(&[0x42u8; params::SEEDBYTES]);
+
+		let m = b"forge me without a secret key";
+
+		// Recompute mu exactly as verify() does: mu = CRH(H(pk) || m).
+		let mut mu = [0u8; params::CRHBYTES];
+		fips202::shake256(&mut mu, &pk);
+		let mut state = fips202::KeccakState::default();
+		fips202::shake256_absorb(&mut state, &mu);
+		fips202::shake256_absorb(&mut state, m);
+		fips202::shake256_finalize(&mut state);
+		fips202::shake256_squeeze(&mut mu, &mut state);
+
+		// With z = 0, h = 0 and t1 = 0 the verifier reconstructs w1 = 0.
+		let w1 = Polyveck::default();
+		let mut buf = [0u8; K * params::POLYW1_PACKEDBYTES];
+		polyvec::k_pack_w1(&mut buf, &w1);
+
+		// Pick the challenge to equal the verifier's own recomputation: c = H(mu || w1Encode(0)).
+		let mut c = [0u8; params::C_DASH_BYTES];
+		let mut cstate = fips202::KeccakState::default();
+		fips202::shake256_absorb(&mut cstate, &mu);
+		fips202::shake256_absorb(&mut cstate, &buf);
+		fips202::shake256_finalize(&mut cstate);
+		fips202::shake256_squeeze(&mut c, &mut cstate);
+
+		// Assemble the forged signature (c, z = 0, empty hint).
+		let z = Polyvecl::default();
+		let h = Polyveck::default();
+		let mut sig = [0u8; params::SIGNBYTES];
+		packing::pack_sig(&mut sig, Some(&c), &z, &h);
+
+		assert!(
+			!super::verify(&sig, m, &pk),
+			"signature forged under an all-zero-t1 public key must be rejected"
 		);
 	}
 

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -10,6 +10,37 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 const K: usize = params::K;
 const L: usize = params::L;
 
+/// Derive the public high bits `t1` and secret low bits `t0` from the public
+/// seed `rho` and secret vectors `s1`, `s2`.
+///
+/// Computes `t = A(rho)·s1 + s2` (streaming `A` from `rho` so the full matrix
+/// is never materialized) and splits it via `power2round` into `t1` (public)
+/// and `t0` (secret). Both key generation and the `Keypair` consistency check
+/// go through this single routine, so the public key derived at import can
+/// never disagree with the one produced at generation. The transient NTT copy
+/// of `s1` is zeroized before returning.
+fn derive_public_components(
+	rho: &[u8; params::SEEDBYTES],
+	s1: &Polyvecl,
+	s2: &Polyveck,
+) -> (Polyveck, Polyveck) {
+	let mut s1hat = s1.clone();
+	polyvec::l_ntt(&mut s1hat);
+
+	let mut t1 = Polyveck::default();
+	polyvec::matrix_pointwise_montgomery_streamed(&mut t1, rho, &s1hat);
+	polyvec::k_reduce(&mut t1);
+	polyvec::k_invntt_tomont(&mut t1);
+	polyvec::k_add(&mut t1, s2);
+	polyvec::k_caddq(&mut t1);
+
+	let mut t0 = Polyveck::default();
+	polyvec::k_power2round(&mut t1, &mut t0);
+
+	s1hat.zeroize();
+	(t1, t0)
+}
+
 /// Generate public and private key.
 ///
 /// # Arguments
@@ -49,19 +80,8 @@ pub fn keypair(
 	let mut s2 = Polyveck::default();
 	polyvec::k_uniform_eta(&mut s2, &rhoprime, L as u16);
 
-	let mut s1hat = s1.clone();
-	polyvec::l_ntt(&mut s1hat);
-
-	// Compute t1 = A * s1hat, streaming A from rho so the full matrix is never materialized.
-	let mut t1 = Polyveck::default();
-	polyvec::matrix_pointwise_montgomery_streamed(&mut t1, &rho, &s1hat);
-	polyvec::k_reduce(&mut t1);
-	polyvec::k_invntt_tomont(&mut t1);
-	polyvec::k_add(&mut t1, &s2);
-	polyvec::k_caddq(&mut t1);
-
-	let mut t0 = Polyveck::default();
-	polyvec::k_power2round(&mut t1, &mut t0);
+	// t1 = high bits of A*s1 + s2 (public); t0 = low bits (kept in the secret key).
+	let (t1, t0) = derive_public_components(&rho, &s1, &s2);
 
 	packing::pack_pk(pk, &rho, &t1);
 
@@ -96,19 +116,8 @@ pub(crate) fn public_key_from_secret(
 	let mut s2 = Polyveck::default();
 	packing::unpack_sk(&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, sk);
 
-	let mut s1hat = s1.clone();
-	polyvec::l_ntt(&mut s1hat);
-
-	// t1 = A*s1 + s2, then keep only the high bits (power2round), matching keygen.
-	let mut t1 = Polyveck::default();
-	polyvec::matrix_pointwise_montgomery_streamed(&mut t1, &rho, &s1hat);
-	polyvec::k_reduce(&mut t1);
-	polyvec::k_invntt_tomont(&mut t1);
-	polyvec::k_add(&mut t1, &s2);
-	polyvec::k_caddq(&mut t1);
-
-	let mut t0_derived = Polyveck::default();
-	polyvec::k_power2round(&mut t1, &mut t0_derived);
+	// Same derivation as key generation; the stored `t0` is recomputed and discarded.
+	let (t1, mut t0_derived) = derive_public_components(&rho, &s1, &s2);
 
 	let mut pk = [0u8; params::PUBLICKEYBYTES];
 	packing::pack_pk(&mut pk, &rho, &t1);
@@ -116,7 +125,6 @@ pub(crate) fn public_key_from_secret(
 	// Only rho/s1/s2 are needed to derive the public key; wipe the secret copies.
 	key.zeroize();
 	s1.zeroize();
-	s1hat.zeroize();
 	s2.zeroize();
 	t0.zeroize();
 	t0_derived.zeroize();

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -321,8 +321,12 @@ fn generate_challenge_polynomial(
 	commitment_w1: &Polyveck,
 	message_hash_mu: &[u8; params::CRHBYTES],
 ) -> Poly {
-	// Pack w1 into signature buffer temporarily
-	polyvec::k_pack_w1(signature_buffer, commitment_w1);
+	// Pack w1 into signature buffer temporarily. The buffer is the full
+	// signature buffer, comfortably larger than K * POLYW1_PACKEDBYTES.
+	let w1_region = signature_buffer
+		.first_chunk_mut::<{ K * params::POLYW1_PACKEDBYTES }>()
+		.expect("signature buffer covers the packed w1 region");
+	polyvec::k_pack_w1(w1_region, commitment_w1);
 
 	let mut keccak_state = fips202::KeccakState::default();
 	fips202::shake256_absorb(&mut keccak_state, message_hash_mu);

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -153,13 +153,21 @@ fn unpack_secret_key_for_signing(
 	}
 }
 
-/// Compute the message representative μ = H(tr || M').
+/// Compute the message representative μ = H(tr || pre || M).
+///
+/// The domain prefix `pre` (FIPS 204 domain separator + context) and the caller's
+/// message `M` are absorbed as separate slices rather than a single concatenated
+/// buffer. SHAKE256 absorption is incremental, so this is bit-identical to hashing
+/// `pre || M` while avoiding a heap copy of the (attacker-controlled, up to 64 MiB)
+/// message — closing an allocation-amplification DoS on the signing path.
 fn derive_message_hash(
 	public_key_hash_tr: &[u8; params::TR_BYTES],
+	domain_prefix: &[u8],
 	message: &[u8],
 ) -> [u8; params::CRHBYTES] {
 	let mut keccak_state = fips202::KeccakState::default();
 	fips202::shake256_absorb(&mut keccak_state, public_key_hash_tr);
+	fips202::shake256_absorb(&mut keccak_state, domain_prefix);
 	fips202::shake256_absorb(&mut keccak_state, message);
 	fips202::shake256_finalize(&mut keccak_state);
 	let mut message_hash_mu = [0u8; params::CRHBYTES];
@@ -190,11 +198,13 @@ fn derive_mask_seed(
 /// Compute message hash and signing randomness
 fn prepare_signing_context(
 	unpacked_sk: &UnpackedSecretKey,
+	domain_prefix: &[u8],
 	message: &[u8],
 	hedge_randomness: Option<[u8; params::SEEDBYTES]>,
 ) -> SigningContext {
-	// Compute message hash μ = H(tr || pre || msg) where pre = (0, 0) for pure signatures
-	let message_hash_mu = derive_message_hash(&unpacked_sk.public_key_hash_tr, message);
+	// Compute message hash μ = H(tr || pre || msg) where pre is the domain prefix.
+	let message_hash_mu =
+		derive_message_hash(&unpacked_sk.public_key_hash_tr, domain_prefix, message);
 
 	// Generate signing randomness ρ' = H(K || rnd || μ)
 	let mut hedge_bytes = hedge_randomness.unwrap_or([0u8; params::SEEDBYTES]);
@@ -329,9 +339,14 @@ fn generate_challenge_polynomial(
 	challenge_poly_c
 }
 
-/// Main signature generation function
+/// Main signature generation function.
+///
+/// The message to be hashed is `domain_prefix || message`; the two are absorbed
+/// as separate slices (never concatenated) so the caller-controlled `message` is
+/// not copied into a fresh heap buffer.
 pub(crate) fn signature(
 	signature_output: &mut [u8; params::SIGNBYTES],
+	domain_prefix: &[u8],
 	message: &[u8],
 	secret_key_bytes: &[u8; params::SECRETKEYBYTES],
 	hedge: Option<[u8; params::SEEDBYTES]>,
@@ -340,7 +355,7 @@ pub(crate) fn signature(
 	let unpacked_sk = unpack_secret_key_for_signing(secret_key_bytes);
 
 	// Step 2: Prepare signing context (message hash, randomness, public seed rho)
-	let signing_ctx = prepare_signing_context(&unpacked_sk, message, hedge);
+	let signing_ctx = prepare_signing_context(&unpacked_sk, domain_prefix, message, hedge);
 
 	// Step 3: Fiat-Shamir with aborts. The *number* of rejection-sampling attempts is
 	// independent of the long-term secret key and is treated as public information, as in
@@ -433,12 +448,18 @@ pub(crate) fn signature(
 /// # Arguments
 ///
 /// * 'sig' - signature to verify (must be SIGNBYTES)
+/// * 'domain_prefix' - FIPS 204 domain separator + context (hashed before the message)
 /// * 'm' - message that is claimed to be signed
 /// * 'pk' - public key (must be PUBLICKEYBYTES)
+///
+/// The message representative is hashed over `domain_prefix || m`, with the two
+/// absorbed as separate slices so the caller-controlled `m` is never copied into a
+/// fresh heap buffer (avoids allocation-amplification DoS on the verify path).
 ///
 /// Returns 'true' if the verification process was successful, 'false' otherwise
 pub(crate) fn verify(
 	sig: &[u8; params::SIGNBYTES],
+	domain_prefix: &[u8],
 	m: &[u8],
 	pk: &[u8; params::PUBLICKEYBYTES],
 ) -> bool {
@@ -476,9 +497,11 @@ pub(crate) fn verify(
 		return false;
 	}
 
-	// Compute CRH(H(rho, t1), pre, msg) with pre=(0,0)
+	// Compute CRH(H(rho, t1) || pre || msg). The domain prefix and message are
+	// absorbed as separate slices (SHAKE256 is incremental), matching the signer.
 	fips202::shake256(&mut mu, pk);
 	fips202::shake256_absorb(&mut state, &mu);
+	fips202::shake256_absorb(&mut state, domain_prefix);
 	fips202::shake256_absorb(&mut state, m);
 	fips202::shake256_finalize(&mut state);
 	fips202::shake256_squeeze(&mut mu, &mut state);
@@ -533,6 +556,7 @@ mod tests {
 		bytes
 	}
 
+
 	#[test]
 	fn self_verify_hedged() {
 		let mut pk = [0u8; crate::params::PUBLICKEYBYTES];
@@ -541,8 +565,8 @@ mod tests {
 		let msg = get_random_msg();
 		let mut sig = [0u8; crate::params::SIGNBYTES];
 		let hedge = get_random_bytes();
-		super::signature(&mut sig, &msg, &sk, Some(hedge.0));
-		assert!(super::verify(&sig, &msg, &pk));
+		super::signature(&mut sig, &[], &msg, &sk, Some(hedge.0));
+		assert!(super::verify(&sig, &[], &msg, &pk));
 	}
 
 	#[test]
@@ -552,8 +576,8 @@ mod tests {
 		super::keypair(&mut pk, &mut sk, get_random_bytes());
 		let msg = get_random_msg();
 		let mut sig = [0u8; crate::params::SIGNBYTES];
-		super::signature(&mut sig, &msg, &sk, None);
-		assert!(super::verify(&sig, &msg, &pk));
+		super::signature(&mut sig, &[], &msg, &sk, None);
+		assert!(super::verify(&sig, &[], &msg, &pk));
 	}
 
 	#[test]
@@ -564,8 +588,8 @@ mod tests {
 
 		let empty_msg: &[u8] = &[];
 		let mut sig = [0u8; crate::params::SIGNBYTES];
-		super::signature(&mut sig, empty_msg, &sk, None);
-		assert!(super::verify(&sig, empty_msg, &pk));
+		super::signature(&mut sig, &[], empty_msg, &sk, None);
+		assert!(super::verify(&sig, &[], empty_msg, &pk));
 	}
 
 	#[test]
@@ -576,8 +600,8 @@ mod tests {
 
 		let msg = [0x42u8];
 		let mut sig = [0u8; crate::params::SIGNBYTES];
-		super::signature(&mut sig, &msg, &sk, None);
-		assert!(super::verify(&sig, &msg, &pk));
+		super::signature(&mut sig, &[], &msg, &sk, None);
+		assert!(super::verify(&sig, &[], &msg, &pk));
 	}
 
 	#[test]
@@ -588,8 +612,8 @@ mod tests {
 
 		let large_msg = vec![0xABu8; 10000];
 		let mut sig = [0u8; crate::params::SIGNBYTES];
-		super::signature(&mut sig, &large_msg, &sk, None);
-		assert!(super::verify(&sig, &large_msg, &pk));
+		super::signature(&mut sig, &[], &large_msg, &sk, None);
+		assert!(super::verify(&sig, &[], &large_msg, &pk));
 	}
 
 	#[test]
@@ -604,13 +628,13 @@ mod tests {
 
 		let hedge = get_random_bytes();
 
-		super::signature(&mut sig1, msg, &sk, Some(hedge.0));
-		super::signature(&mut sig2, msg, &sk, Some(hedge.0));
+		super::signature(&mut sig1, &[], msg, &sk, Some(hedge.0));
+		super::signature(&mut sig2, &[], msg, &sk, Some(hedge.0));
 
 		// Deterministic signing should produce identical signatures
 		assert_eq!(sig1, sig2);
-		assert!(super::verify(&sig1, msg, &pk));
-		assert!(super::verify(&sig2, msg, &pk));
+		assert!(super::verify(&sig1, &[], msg, &pk));
+		assert!(super::verify(&sig2, &[], msg, &pk));
 	}
 
 	#[test]
@@ -626,13 +650,13 @@ mod tests {
 		let hedge1 = get_random_bytes();
 		let hedge2 = get_random_bytes();
 
-		super::signature(&mut sig1, msg, &sk, Some(hedge1.0));
-		super::signature(&mut sig2, msg, &sk, Some(hedge2.0));
+		super::signature(&mut sig1, &[], msg, &sk, Some(hedge1.0));
+		super::signature(&mut sig2, &[], msg, &sk, Some(hedge2.0));
 
 		// Hedged signing should produce different signatures (with high probability)
 		assert_ne!(sig1, sig2);
-		assert!(super::verify(&sig1, msg, &pk));
-		assert!(super::verify(&sig2, msg, &pk));
+		assert!(super::verify(&sig1, &[], msg, &pk));
+		assert!(super::verify(&sig2, &[], msg, &pk));
 	}
 
 	#[test]
@@ -645,12 +669,12 @@ mod tests {
 		let msg2 = b"different message";
 		let mut sig = [0u8; crate::params::SIGNBYTES];
 
-		super::signature(&mut sig, msg1, &sk, None);
+		super::signature(&mut sig, &[], msg1, &sk, None);
 
 		// Should verify with correct message
-		assert!(super::verify(&sig, msg1, &pk));
+		assert!(super::verify(&sig, &[], msg1, &pk));
 		// Should fail with wrong message
-		assert!(!super::verify(&sig, msg2, &pk));
+		assert!(!super::verify(&sig, &[], msg2, &pk));
 	}
 
 	#[test]
@@ -666,12 +690,12 @@ mod tests {
 		let msg = b"test message";
 		let mut sig = [0u8; crate::params::SIGNBYTES];
 
-		super::signature(&mut sig, msg, &sk1, None);
+		super::signature(&mut sig, &[], msg, &sk1, None);
 
 		// Should verify with correct key
-		assert!(super::verify(&sig, msg, &pk1));
+		assert!(super::verify(&sig, &[], msg, &pk1));
 		// Should fail with wrong key
-		assert!(!super::verify(&sig, msg, &pk2));
+		assert!(!super::verify(&sig, &[], msg, &pk2));
 	}
 
 	#[test]
@@ -682,26 +706,26 @@ mod tests {
 
 		let msg = b"test message";
 		let mut sig = [0u8; crate::params::SIGNBYTES];
-		super::signature(&mut sig, msg, &sk, None);
+		super::signature(&mut sig, &[], msg, &sk, None);
 
 		// Original signature should verify
-		assert!(super::verify(&sig, msg, &pk));
+		assert!(super::verify(&sig, &[], msg, &pk));
 
 		// Corrupt first byte
 		let original_byte = sig[0];
 		sig[0] = sig[0].wrapping_add(1);
-		assert!(!super::verify(&sig, msg, &pk));
+		assert!(!super::verify(&sig, &[], msg, &pk));
 
 		// Restore and corrupt last byte
 		sig[0] = original_byte;
 		let last_idx = sig.len() - 1;
 		let original_last = sig[last_idx];
 		sig[last_idx] = sig[last_idx].wrapping_add(1);
-		assert!(!super::verify(&sig, msg, &pk));
+		assert!(!super::verify(&sig, &[], msg, &pk));
 
 		// Restore and verify it works again
 		sig[last_idx] = original_last;
-		assert!(super::verify(&sig, msg, &pk));
+		assert!(super::verify(&sig, &[], msg, &pk));
 	}
 
 	// Note: Invalid signature length tests are in ml_dsa_87.rs since the internal
@@ -758,9 +782,9 @@ mod tests {
 
 		for msg in &messages {
 			let mut sig = [0u8; crate::params::SIGNBYTES];
-			super::signature(&mut sig, msg, &sk, None);
+			super::signature(&mut sig, &[], msg, &sk, None);
 			assert!(
-				super::verify(&sig, msg, &pk),
+				super::verify(&sig, &[], msg, &pk),
 				"Failed to verify message: {:?}",
 				String::from_utf8_lossy(msg)
 			);
@@ -817,8 +841,8 @@ mod tests {
 
 		let mut sig1 = [0u8; params::SIGNBYTES];
 		let mut sig2 = [0u8; params::SIGNBYTES];
-		super::signature(&mut sig1, b"message one", &sk, None);
-		super::signature(&mut sig2, b"message two", &sk, None);
+		super::signature(&mut sig1, &[], b"message one", &sk, None);
+		super::signature(&mut sig2, &[], b"message two", &sk, None);
 
 		assert_ne!(sig1, sig2, "deterministic signatures of different messages must differ");
 
@@ -874,7 +898,7 @@ mod tests {
 		packing::pack_sig(&mut sig, Some(&c), &z, &h);
 
 		assert!(
-			!super::verify(&sig, m, &pk),
+			!super::verify(&sig, &[], m, &pk),
 			"signature forged under an all-zero-t1 public key must be rejected"
 		);
 	}
@@ -889,7 +913,7 @@ mod tests {
 
 		let msg = b"K must influence the mask";
 		let mut sig_original = [0u8; params::SIGNBYTES];
-		super::signature(&mut sig_original, msg, &sk, None);
+		super::signature(&mut sig_original, &[], msg, &sk, None);
 
 		// K is stored at offset [SEEDBYTES, 2*SEEDBYTES) in the packed secret key.
 		let mut sk_flipped = sk;
@@ -897,14 +921,14 @@ mod tests {
 		assert_ne!(sk, sk_flipped, "test setup should change the stored K");
 
 		let mut sig_flipped = [0u8; params::SIGNBYTES];
-		super::signature(&mut sig_flipped, msg, &sk_flipped, None);
+		super::signature(&mut sig_flipped, &[], msg, &sk_flipped, None);
 
 		assert_ne!(
 			sig_original, sig_flipped,
 			"flipping a byte of K did not change the signature (Bug Class 2)"
 		);
 		// K only seeds the mask; the signature stays valid under the unchanged public key.
-		assert!(super::verify(&sig_flipped, msg, &pk));
+		assert!(super::verify(&sig_flipped, &[], msg, &pk));
 	}
 
 	// Bug Class 3 (truncated/incorrect hash-input assembly): pin ρ' = H(K || rnd || μ) for

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -78,6 +78,51 @@ pub fn keypair(
 	key.zeroize();
 }
 
+/// Re-derive the public key that corresponds to a secret key.
+///
+/// Recomputes `t1` from the secret key's `(rho, s1, s2)` exactly as
+/// [`keypair`] does, and packs `pk = (rho, t1)`. Callers use this to enforce
+/// the cross-field invariant that a supplied public key actually belongs to a
+/// secret key (rather than trusting a concatenated blob). The secret
+/// polynomials are zeroized before returning.
+pub(crate) fn public_key_from_secret(
+	sk: &[u8; params::SECRETKEYBYTES],
+) -> [u8; params::PUBLICKEYBYTES] {
+	let mut rho = [0u8; params::SEEDBYTES];
+	let mut tr = [0u8; params::TR_BYTES];
+	let mut key = [0u8; params::SEEDBYTES];
+	let mut t0 = Polyveck::default();
+	let mut s1 = Polyvecl::default();
+	let mut s2 = Polyveck::default();
+	packing::unpack_sk(&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, sk);
+
+	let mut s1hat = s1.clone();
+	polyvec::l_ntt(&mut s1hat);
+
+	// t1 = A*s1 + s2, then keep only the high bits (power2round), matching keygen.
+	let mut t1 = Polyveck::default();
+	polyvec::matrix_pointwise_montgomery_streamed(&mut t1, &rho, &s1hat);
+	polyvec::k_reduce(&mut t1);
+	polyvec::k_invntt_tomont(&mut t1);
+	polyvec::k_add(&mut t1, &s2);
+	polyvec::k_caddq(&mut t1);
+
+	let mut t0_derived = Polyveck::default();
+	polyvec::k_power2round(&mut t1, &mut t0_derived);
+
+	let mut pk = [0u8; params::PUBLICKEYBYTES];
+	packing::pack_pk(&mut pk, &rho, &t1);
+
+	// Only rho/s1/s2 are needed to derive the public key; wipe the secret copies.
+	key.zeroize();
+	s1.zeroize();
+	s1hat.zeroize();
+	s2.zeroize();
+	t0.zeroize();
+	t0_derived.zeroize();
+	pk
+}
+
 /// Compute a signature for a given message from a private (secret) key.
 ///
 /// # Arguments

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -81,7 +81,7 @@ pub fn keypair(
 	polyvec::k_uniform_eta(&mut s2, &rhoprime, L as u16);
 
 	// t1 = high bits of A*s1 + s2 (public); t0 = low bits (kept in the secret key).
-	let (t1, t0) = derive_public_components(&rho, &s1, &s2);
+	let (t1, mut t0) = derive_public_components(&rho, &s1, &s2);
 
 	packing::pack_pk(pk, &rho, &t1);
 
@@ -90,12 +90,17 @@ pub fn keypair(
 
 	packing::pack_sk(sk, &rho, &tr, &key, &t0, &s1, &s2);
 
-	// Zeroize sensitive intermediate seed material
+	// Zeroize sensitive intermediate material. `s1`, `s2`, and `t0` are the
+	// secret polynomials; now that they're packed into `sk` the working copies
+	// must not linger on the stack. (`rho`/`tr`/`t1` are public.)
 	seedbuf.zeroize();
 	seed_bytes.zeroize();
 	preimage.zeroize();
 	rhoprime.zeroize();
 	key.zeroize();
+	s1.zeroize();
+	s2.zeroize();
+	t0.zeroize();
 }
 
 /// Re-derive the public key that corresponds to a secret key.

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -20,6 +20,7 @@ categories = ["cryptography"]
 qp-rusty-crystals-dilithium.workspace = true
 bip39.workspace = true
 thiserror.workspace = true
+unicode-normalization.workspace = true
 qp-poseidon-core.workspace = true
 hex-literal.workspace = true
 serde_json.workspace = true

--- a/hdwallet/src/hderive.rs
+++ b/hdwallet/src/hderive.rs
@@ -48,6 +48,21 @@ impl FromStr for ChildNumber {
 
 	fn from_str(child: &str) -> Result<ChildNumber, Error> {
 		let child = child.strip_suffix('\'').ok_or(Error::NotHardened)?;
+
+		// Enforce a canonical decimal encoding before parsing. `u32::from_str`
+		// tolerates a leading '+' and any number of leading zeros, so "44'",
+		// "+44'", "0044'" and "000000044'" would all decode to the same child
+		// index. Since the child index (not the string) feeds the HMAC step,
+		// those distinct path strings would derive byte-identical keys and
+		// addresses — collapsing textually distinct paths onto one identity.
+		// Require: non-empty, ASCII digits only, and no redundant leading zero.
+		if child.is_empty() || !child.bytes().all(|b| b.is_ascii_digit()) {
+			return Err(Error::InvalidChildNumber);
+		}
+		if child.len() > 1 && child.starts_with('0') {
+			return Err(Error::InvalidChildNumber);
+		}
+
 		let index: u32 = child.parse().map_err(|_| Error::InvalidChildNumber)?;
 		if index & HARDENED_BIT != 0 {
 			return Err(Error::InvalidChildNumber);
@@ -218,5 +233,31 @@ mod tests {
 	fn non_hardened_path_rejected() {
 		assert_eq!("m/44'/60'/0".parse::<DerivationPath>().unwrap_err(), Error::NotHardened);
 		assert_eq!("0".parse::<ChildNumber>().unwrap_err(), Error::NotHardened);
+	}
+
+	// Non-canonical decimal spellings must be rejected. Otherwise "+44'",
+	// "0044'", etc. would alias to the same child index as "44'" and derive
+	// byte-identical keys/addresses, collapsing distinct path strings onto one
+	// on-chain identity.
+	#[test]
+	fn non_canonical_child_numbers_rejected() {
+		// The canonical form still works.
+		assert_eq!("44'".parse::<ChildNumber>().unwrap(), ChildNumber(44 | HARDENED_BIT));
+		assert_eq!("0'".parse::<ChildNumber>().unwrap(), ChildNumber(HARDENED_BIT));
+
+		for bad in ["+44'", "0044'", "000000044'", "+0'", "00'", " 44'", "44 '", "4_4'"] {
+			assert_eq!(
+				bad.parse::<ChildNumber>().unwrap_err(),
+				Error::InvalidChildNumber,
+				"non-canonical child number {:?} must be rejected",
+				bad
+			);
+		}
+
+		// And the same via a full path so the aliasing can't slip in mid-path.
+		assert_eq!(
+			"m/44'/189189189'/+0'".parse::<DerivationPath>().unwrap_err(),
+			Error::InvalidChildNumber
+		);
 	}
 }

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -13,6 +13,7 @@ use alloc::{
 use bip39::{Language, Mnemonic};
 use core::str::FromStr;
 use qp_rusty_crystals_dilithium::ml_dsa_87::Keypair;
+use unicode_normalization::{is_nfkd_quick, IsNormalized, UnicodeNormalization};
 
 use zeroize::Zeroizing;
 
@@ -98,17 +99,41 @@ pub fn mnemonic_to_seed(
 	parse_mnemonic_to_seed(mnemonic.as_str(), passphrase)
 }
 
+/// NFKD-normalize a potentially secret string. Returns `None` when the input is already
+/// normalized (the common all-ASCII case), so no extra heap copy of the secret is made.
+/// When a normalized copy is required it is wrapped in `Zeroizing` so it is wiped on drop.
+fn nfkd_owned(s: &str) -> Option<Zeroizing<String>> {
+	match is_nfkd_quick(s.chars()) {
+		IsNormalized::Yes => None,
+		// `Maybe` is treated as not-normalized; NFKD is idempotent, so re-normalizing is safe.
+		_ => Some(Zeroizing::new(s.nfkd().collect())),
+	}
+}
+
 /// Shared parser that does not take ownership of the mnemonic.
 /// Used by both `mnemonic_to_seed` (which owns and zeroizes the String) and the
 /// `derive_*_from_mnemonic` helpers (which borrow the caller's `&str` and avoid
 /// the redundant heap copy a `to_string()` would create).
+///
+/// BIP39 requires NFKD Unicode normalization of both the mnemonic and the passphrase
+/// before PBKDF2. The bip39 crate's `parse_in_normalized`/`to_seed_normalized` APIs
+/// assume the *caller* already normalized their inputs, so we normalize here. Without
+/// this, canonically equivalent inputs (e.g. a composed "é" vs a decomposed "e"+combining
+/// accent in a passphrase) would silently derive different seeds and thus different keys.
 fn parse_mnemonic_to_seed(
 	mnemonic: &str,
 	passphrase: Option<&str>,
 ) -> Result<[u8; 64], HDLatticeError> {
+	let normalized_mnemonic = nfkd_owned(mnemonic);
+	let mnemonic = normalized_mnemonic.as_ref().map_or(mnemonic, |m| m.as_str());
+
+	let passphrase = passphrase.unwrap_or("");
+	let normalized_passphrase = nfkd_owned(passphrase);
+	let passphrase = normalized_passphrase.as_ref().map_or(passphrase, |p| p.as_str());
+
 	let parsed_mnemonic = Mnemonic::parse_in_normalized(Language::English, mnemonic)
 		.map_err(|e| HDLatticeError::Bip39Error(e.to_string()))?;
-	Ok(parsed_mnemonic.to_seed_normalized(passphrase.unwrap_or("")))
+	Ok(parsed_mnemonic.to_seed_normalized(passphrase))
 }
 
 /// Derive a Dilithium keypair from a seed at the given BIP44 path

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -322,8 +322,8 @@ mod hdwallet_tests {
 			"wormhole first_hash derivation changed"
 		);
 		assert_eq!(
-			w.secret,
-			hex!("30051cfa3abd462d3bc26da2d660e90ba8af6080b7fe95d9fd3f3b37c7d9ce4b"),
+			w.secret.as_bytes(),
+			&hex!("30051cfa3abd462d3bc26da2d660e90ba8af6080b7fe95d9fd3f3b37c7d9ce4b"),
 			"wormhole secret derivation changed"
 		);
 	}
@@ -337,7 +337,7 @@ mod hdwallet_tests {
 		let hex = |b: &[u8]| b.iter().map(|x| format!("{x:02x}")).collect::<String>();
 		println!("address    = {}", hex(&w.address));
 		println!("first_hash = {}", hex(&w.first_hash));
-		println!("secret     = {}", hex(&w.secret));
+		println!("secret     = {}", hex(w.secret.as_bytes()));
 	}
 
 	#[test]
@@ -501,10 +501,10 @@ mod hdwallet_tests {
 			generate_wormhole_from_seed((&mut seed).into(), "m/44'/189189189'/0'").unwrap();
 
 		// Verify wormhole pair has expected structure
-		assert_eq!(wormhole.secret.len(), 32);
+		assert_eq!(wormhole.secret.as_bytes().len(), 32);
 		assert_eq!(wormhole.address.len(), 32);
 		assert_eq!(wormhole.first_hash.len(), 32);
-		assert_ne!(wormhole.secret, [0u8; 32]);
+		assert_ne!(wormhole.secret.as_bytes(), &[0u8; 32]);
 		assert_ne!(wormhole.address, [0u8; 32]);
 	}
 

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -402,6 +402,55 @@ mod hdwallet_tests {
 	}
 
 	#[test]
+	fn test_passphrase_unicode_normalization() {
+		// BIP39 mandates NFKD normalization before PBKDF2: canonically equivalent
+		// passphrases must derive the same seed. "café" spelled with a precomposed
+		// U+00E9 vs a decomposed "e" + U+0301 combining acute accent.
+		let mnemonic = "rocket primary way job input cactus submit menu zoo burger rent impose";
+		let composed = "caf\u{00e9}";
+		let decomposed = "cafe\u{0301}";
+		assert_ne!(composed.as_bytes(), decomposed.as_bytes());
+
+		let seed_composed = mnemonic_to_seed(mnemonic.to_string(), Some(composed)).unwrap();
+		let seed_decomposed = mnemonic_to_seed(mnemonic.to_string(), Some(decomposed)).unwrap();
+		assert_eq!(
+			seed_composed, seed_decomposed,
+			"canonically equivalent passphrases must derive the same seed"
+		);
+
+		// The normalized form must feed PBKDF2 (NFKD of both spellings is the
+		// decomposed byte string), matching what standard BIP39 tooling computes.
+		let reference = bip39::Mnemonic::parse_in_normalized(bip39::Language::English, mnemonic)
+			.unwrap()
+			.to_seed_normalized(decomposed);
+		assert_eq!(seed_composed, reference);
+
+		// Same guarantee through the borrowing derivation helpers.
+		let key_composed =
+			crate::derive_key_from_mnemonic(mnemonic, Some(composed), "m/44'/189189'/0'/0'/0'")
+				.unwrap();
+		let key_decomposed =
+			crate::derive_key_from_mnemonic(mnemonic, Some(decomposed), "m/44'/189189'/0'/0'/0'")
+				.unwrap();
+		assert_eq!(key_composed.secret.to_bytes(), key_decomposed.secret.to_bytes());
+	}
+
+	#[test]
+	fn test_mnemonic_unicode_normalization() {
+		// NFKD also applies to the mnemonic itself: U+00A0 (no-break space) has a
+		// compatibility decomposition to a plain space, so a mnemonic pasted with
+		// non-breaking separators must parse and derive identically.
+		let ascii = "rocket primary way job input cactus submit menu zoo burger rent impose";
+		let nbsp = ascii.replace(' ', "\u{00a0}");
+		assert_ne!(ascii.as_bytes(), nbsp.as_bytes());
+
+		let seed_ascii = mnemonic_to_seed(ascii.to_string(), None).unwrap();
+		let seed_nbsp = mnemonic_to_seed(nbsp, None)
+			.expect("NFKD-equivalent mnemonic must parse after normalization");
+		assert_eq!(seed_ascii, seed_nbsp);
+	}
+
+	#[test]
 	fn test_derive_key_from_seed_different_paths() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -33,26 +33,44 @@ use qp_poseidon_core::{
 extern crate alloc;
 use alloc::vec::Vec;
 use qp_rusty_crystals_dilithium::SensitiveBytes32;
-use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Salt used when deriving wormhole addresses.
 pub const ADDRESS_SALT: &str = "wormhole";
 
 /// A struct representing a wormhole identity pair: address + secret.
 ///
-/// `Clone` is intentionally not derived because `secret` is sensitive. Callers
-/// who genuinely need a second instance must construct one explicitly from the
-/// public fields, making the duplication of secret material visible at the call
-/// site. Prefer passing `&WormholePair` instead.
-#[derive(Eq, PartialEq, ZeroizeOnDrop)]
+/// `Clone` is intentionally not derived because `secret` is sensitive. The
+/// secret is stored as a [`SensitiveBytes32`] wrapper rather than a bare
+/// `[u8; 32]`: a plain array is `Copy`, so `pair.secret` could silently
+/// duplicate the secret (leaving copies in stack frames, logs, or crash dumps)
+/// that the pair's own drop-time zeroization can never scrub. The wrapper is
+/// move-only and zeroizes on drop, so any duplication must be explicit
+/// (`pair.secret.as_bytes()`), making it visible at the call site. Prefer
+/// passing `&WormholePair` instead.
 pub struct WormholePair {
 	/// Deterministic Poseidon-derived address.
 	pub address: [u8; 32],
 	/// First hash of secret
 	pub first_hash: [u8; 32],
-	/// The hashed secret used to generate this address.
-	pub secret: [u8; 32],
+	/// The hashed secret used to generate this address. Move-only and zeroized
+	/// on drop; read the raw bytes via `secret.as_bytes()`.
+	pub secret: SensitiveBytes32,
 }
+
+// `secret` is a `SensitiveBytes32` (which is not `PartialEq`), so equality is
+// implemented by hand over the raw bytes to preserve the previous derived
+// semantics. The address alone determines identity; the secret is compared for
+// completeness. `SensitiveBytes32` already zeroizes itself on drop, so no
+// `ZeroizeOnDrop` derive is needed on `WormholePair`.
+impl PartialEq for WormholePair {
+	fn eq(&self, other: &Self) -> bool {
+		self.address == other.address &&
+			self.first_hash == other.first_hash &&
+			self.secret.as_bytes() == other.secret.as_bytes()
+	}
+}
+
+impl Eq for WormholePair {}
 
 impl WormholePair {
 	/// Generates a new `WormholePair` from user-supplied entropy.
@@ -102,18 +120,20 @@ impl WormholePair {
 		let inner_hash = hash_to_bytes(&preimage_felts);
 		let second_hash = hash_twice(&preimage_felts);
 
-		// Create result with copy of secret before zeroizing
-		let result =
-			WormholePair { address: second_hash, first_hash: inner_hash, secret: secret_bytes };
+		// Move the secret into the move-only, self-zeroizing wrapper.
+		// `SensitiveBytes32::new` copies the bytes into the wrapper and zeroizes
+		// `secret_bytes` in place, so no separate scrub of it is needed.
+		let result = WormholePair {
+			address: second_hash,
+			first_hash: inner_hash,
+			secret: SensitiveBytes32::new(&mut secret_bytes),
+		};
 
 		// Manually clear intermediate sensitive data
 		for elem in secret_felt.iter_mut() {
 			*elem = Default::default();
 		}
 		preimage_felts.clear();
-
-		// Zeroize the input secret parameter
-		secret_bytes.zeroize();
 
 		result
 	}
@@ -135,7 +155,7 @@ mod tests {
 
 		// Assert secret was zeroized and pair.secret was not zeroized
 		assert_eq!(secret, [0u8; 32]);
-		assert_eq!(pair.secret, [42u8; 32]);
+		assert_eq!(pair.secret.as_bytes(), &[42u8; 32]);
 
 		// We can't easily predict the exact hash output without mocking Poseidon2Core,
 		// but we can verify that it's not zero and that it's deterministic
@@ -188,7 +208,7 @@ mod tests {
 
 		// Assert
 		// 1. Verify that the secret is stored correctly
-		assert_eq!(pair.secret, secret);
+		assert_eq!(pair.secret.as_bytes(), &secret);
 
 		// 2. Verify that the derived address is consistent with our verification method
 		let mut secret_for_verify = secret;
@@ -236,13 +256,13 @@ mod tests {
 		let pair = WormholePair::generate_new((&mut seed).into());
 
 		// The secret should not be all zeros
-		assert_ne!(pair.secret, [0u8; 32]);
+		assert_ne!(pair.secret.as_bytes(), &[0u8; 32]);
 
 		// Address should not be zero
 		assert_ne!(pair.address, [0u8; 32]);
 
 		// Verification should work with the generated secret
-		let mut secret_for_verify = pair.secret;
+		let mut secret_for_verify = *pair.secret.as_bytes();
 		let verification = WormholePair::verify(pair.address, (&mut secret_for_verify).into());
 		assert!(verification);
 	}

--- a/threshold/benches/threshold_benchmarks.rs
+++ b/threshold/benches/threshold_benchmarks.rs
@@ -16,7 +16,7 @@ use qp_rusty_crystals_threshold::{
 
 /// Simple test signer for DKG benchmarks.
 /// Uses a trivial signature scheme (just ID + hash) for benchmarking purposes.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 struct BenchSigner {
 	id: u32,
 }

--- a/threshold/src/broadcast.rs
+++ b/threshold/src/broadcast.rs
@@ -52,6 +52,33 @@ pub const MAX_COMMITMENT_DATA_SIZE: usize = 10_500_000;
 /// 640 = 4480) = 7_168_000 bytes. We round up to 8 MB for margin.
 pub const MAX_RESPONSE_SIZE: usize = 8_000_000;
 
+/// Read exactly `len` bytes from `reader` without trusting `len` for the up-front
+/// allocation size.
+///
+/// The caller has already rejected `len` values above the per-field maximum, but
+/// that maximum can be several megabytes (see [`MAX_COMMITMENT_DATA_SIZE`]). A
+/// malicious peer can advertise a large `len` and then truncate the payload;
+/// `vec![0u8; len]` would eagerly allocate (and zero) the full claimed size
+/// *before* `read_exact` discovers the truncation, letting a few-byte message
+/// force a multi-megabyte allocation. Growing the buffer in bounded chunks caps
+/// the transient allocation to what the peer actually delivered (plus one chunk)
+/// and fails fast on a short payload.
+pub(crate) fn read_length_prefixed<R: borsh::io::Read>(
+	reader: &mut R,
+	len: usize,
+) -> borsh::io::Result<Vec<u8>> {
+	// Cap per-step growth so `len` alone cannot drive the allocation size.
+	const CHUNK: usize = 64 * 1024;
+	let mut buf = Vec::new();
+	while buf.len() < len {
+		let step = (len - buf.len()).min(CHUNK);
+		let filled = buf.len();
+		buf.resize(filled + step, 0);
+		reader.read_exact(&mut buf[filled..])?;
+	}
+	Ok(buf)
+}
+
 /// Round 1 broadcast message: commitment hash.
 ///
 /// In Round 1, each party generates random values and computes a commitment.
@@ -130,9 +157,9 @@ impl BorshDeserialize for Round2Broadcast {
 			));
 		}
 
-		// Now safe to allocate and read
-		let mut commitment_data = vec![0u8; len];
-		reader.read_exact(&mut commitment_data)?;
+		// Read incrementally so a truncated payload cannot force an up-front
+		// allocation of the full (attacker-chosen) `len`.
+		let commitment_data = read_length_prefixed(reader, len)?;
 
 		Ok(Self { ssid, party_id, commitment_data })
 	}
@@ -194,9 +221,9 @@ impl BorshDeserialize for Round3Broadcast {
 			));
 		}
 
-		// Now safe to allocate and read
-		let mut response = vec![0u8; len];
-		reader.read_exact(&mut response)?;
+		// Read incrementally so a truncated payload cannot force an up-front
+		// allocation of the full (attacker-chosen) `len`.
+		let response = read_length_prefixed(reader, len)?;
 
 		Ok(Self { ssid, party_id, response })
 	}
@@ -404,6 +431,35 @@ mod tests {
 		let serialized = borsh::to_vec(&broadcast).unwrap();
 		let recovered: Round3Broadcast = borsh::from_slice(&serialized).unwrap();
 		assert_eq!(recovered, broadcast);
+	}
+
+	/// A within-bounds length prefix whose body is truncated must fail without
+	/// pre-allocating the claimed length. We can only observe the error here (the
+	/// bounded-allocation behavior is exercised by `read_length_prefixed`), but
+	/// this locks in that a lying-then-truncated payload is rejected.
+	#[test]
+	fn test_round2_deserialize_rejects_truncated_body() {
+		let mut payload = Vec::new();
+		payload.extend_from_slice(&TEST_SSID);
+		payload.extend_from_slice(&1u32.to_le_bytes()); // party_id
+		payload.extend_from_slice(&1000u32.to_le_bytes()); // claims 1000 bytes...
+		payload.extend_from_slice(&[0u8; 10]); // ...but only 10 are present
+
+		let result: Result<Round2Broadcast, _> = borsh::from_slice(&payload);
+		assert!(result.is_err(), "truncated commitment_data must be rejected");
+	}
+
+	#[test]
+	fn test_read_length_prefixed_matches_requested_len() {
+		let data = [7u8; 200];
+		let mut reader = &data[..];
+		let out = read_length_prefixed(&mut reader, 200).unwrap();
+		assert_eq!(out, data);
+
+		// Short input for the requested length must error, not hang or over-read.
+		let short = [1u8; 5];
+		let mut reader = &short[..];
+		assert!(read_length_prefixed(&mut reader, 1000).is_err());
 	}
 
 	#[test]

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -39,7 +39,7 @@ const DKG_CONTRIBUTION_DOMAIN: &[u8] = b"near-mpc-dilithium-dkg-contribution-v2"
 /// Derive a DKG contribution from a master share and tweak.
 ///
 /// This function produces a deterministic 32-byte value that a party uses
-/// as their randomness contribution in the DKG protocol. The contribution
+/// as their per-party seed input in the DKG protocol. The contribution
 /// incorporates secret material from the master share, ensuring that:
 ///
 /// 1. Only parties with valid master shares can compute their contribution
@@ -52,7 +52,17 @@ const DKG_CONTRIBUTION_DOMAIN: &[u8] = b"near-mpc-dilithium-dkg-contribution-v2"
 /// * `tweak` - The derivation tweak (computed from account_id + path by the caller)
 ///
 /// # Returns
-/// A 32-byte contribution for DKG randomness
+/// A 32-byte contribution passed as the `seed` argument to [`crate::keygen::dkg::Dkg::new`].
+///
+/// # Session freshness
+///
+/// The contribution alone does **not** include a DKG session nonce. Callers
+/// **must** supply a fresh, unique `session_nonce` to [`crate::keygen::dkg::Dkg::new`]
+/// for every DKG attempt (including retries of the same derived key). Round 1
+/// randomness and leader subset secrets are derived from both this seed and the
+/// session SSID (which incorporates `session_nonce`), so a retry with a new
+/// nonce produces fresh honest randomness even though the contribution is
+/// unchanged.
 ///
 /// # Security
 ///

--- a/threshold/src/error.rs
+++ b/threshold/src/error.rs
@@ -27,12 +27,24 @@ pub enum ThresholdError {
 		/// Maximum valid party ID.
 		max_id: u32,
 	},
-	/// Wrong number of parties (requires exactly threshold).
+	/// Wrong number of parties for Round 2 setup (requires exactly threshold).
 	WrongPartyCount {
 		/// Number of parties provided.
 		provided: usize,
-		/// Required threshold (exact).
+		/// Required signing-set size (equal to threshold under the protocol).
 		required: u32,
+	},
+	/// Round 3 reveal set does not match the signing session recorded at Round 2.
+	///
+	/// Distinct from [`ThresholdError::WrongPartyCount`]: this fires when the
+	/// caller supplies too few or too many Round 2 reveals relative to
+	/// `active_participants`, not when Round 2 is started with the wrong number
+	/// of parties.
+	RevealSetMismatch {
+		/// Total parties implied by the supplied reveals (others + self).
+		provided: usize,
+		/// Expected signing-session size from Round 2.
+		expected: u32,
 	},
 	/// Invalid signature share.
 	InvalidSignatureShare {
@@ -200,8 +212,15 @@ impl fmt::Display for ThresholdError {
 			ThresholdError::WrongPartyCount { provided, required } => {
 				write!(
 					f,
-					"Wrong party count: provided {}, requires exactly {} (threshold)",
+					"Wrong party count: provided {}, requires exactly {} parties in signing set",
 					provided, required
+				)
+			},
+			ThresholdError::RevealSetMismatch { provided, expected } => {
+				write!(
+					f,
+					"Round 3 reveal set mismatch: {} parties in reveal set, expected exactly {} for this signing session",
+					provided, expected
 				)
 			},
 			ThresholdError::InvalidSignatureShare { party_id, reason } => {
@@ -398,5 +417,20 @@ mod tests {
 	#[test]
 	fn test_invalid_context() {
 		assert!(validate_context(&vec![0u8; 256]).is_err());
+	}
+
+	#[test]
+	fn reveal_set_mismatch_display_distinguishes_from_wrong_party_count() {
+		let reveal_err = ThresholdError::RevealSetMismatch { provided: 1, expected: 2 };
+		let party_err = ThresholdError::WrongPartyCount { provided: 1, required: 2 };
+
+		let reveal_display = reveal_err.to_string();
+		let party_display = party_err.to_string();
+
+		assert!(reveal_display.contains("reveal set"));
+		assert!(reveal_display.contains("signing session"));
+		assert!(!reveal_display.contains("threshold"));
+		assert!(party_display.contains("signing set"));
+		assert!(!party_display.contains("threshold"));
 	}
 }

--- a/threshold/src/error.rs
+++ b/threshold/src/error.rs
@@ -3,6 +3,8 @@
 use alloc::{string::String, vec::Vec};
 use core::fmt;
 
+use qp_rusty_crystals_dilithium::ml_dsa_87::MAX_MESSAGE_SIZE;
+
 /// Result type for threshold operations.
 pub type ThresholdResult<T> = Result<T, ThresholdError>;
 
@@ -76,6 +78,15 @@ pub enum ThresholdError {
 	},
 	/// Context too long (must be ≤ 255 bytes).
 	ContextTooLong {
+		/// Length provided.
+		length: usize,
+	},
+	/// Message too long (must be ≤ [`MAX_MESSAGE_SIZE`]).
+	///
+	/// Messages above this bound are rejected by ML-DSA verification, so signing
+	/// them can never yield a usable signature; rejecting up front denies a
+	/// low-cost denial-of-service vector on the direct signer path.
+	MessageTooLong {
 		/// Length provided.
 		length: usize,
 	},
@@ -218,6 +229,9 @@ impl fmt::Display for ThresholdError {
 			ThresholdError::ContextTooLong { length } => {
 				write!(f, "Context too long: {} bytes (max: 255)", length)
 			},
+			ThresholdError::MessageTooLong { length } => {
+				write!(f, "Message too long: {} bytes (max: {})", length, MAX_MESSAGE_SIZE)
+			},
 			ThresholdError::CombinationFailed => {
 				write!(f, "Signature combination failed")
 			},
@@ -334,6 +348,18 @@ pub fn validate_threshold_params(t: u32, n: u32) -> ThresholdResult<()> {
 pub fn validate_context(ctx: &[u8]) -> ThresholdResult<()> {
 	if ctx.len() > 255 {
 		return Err(ThresholdError::ContextTooLong { length: ctx.len() });
+	}
+	Ok(())
+}
+
+/// Validate message length against the ML-DSA [`MAX_MESSAGE_SIZE`] bound.
+///
+/// The direct `ThresholdSigner` path must enforce this before hashing/cloning
+/// attacker-controlled bytes: a message above the bound cannot produce a
+/// verifiable signature, so accepting it only wastes memory and CPU.
+pub fn validate_message(message: &[u8]) -> ThresholdResult<()> {
+	if message.len() > MAX_MESSAGE_SIZE {
+		return Err(ThresholdError::MessageTooLong { length: message.len() });
 	}
 	Ok(())
 }

--- a/threshold/src/keygen/README.md
+++ b/threshold/src/keygen/README.md
@@ -149,7 +149,7 @@ loop {
 The DKG requires a `TranscriptSigner` implementation for signing transcripts:
 
 ```rust
-pub trait TranscriptSigner {
+pub trait TranscriptSigner: Zeroize + ZeroizeOnDrop {
     type Signature: Clone + AsRef<[u8]>;
     type PublicKey: Clone + PartialEq;
 
@@ -161,6 +161,22 @@ pub trait TranscriptSigner {
 ```
 
 For NEAR MPC, this would typically be Ed25519 or ML-DSA-87 for long-term keys.
+
+Implementors hold the party's long-term signing key, so the trait requires
+`Zeroize + ZeroizeOnDrop`: the DKG state machine erases the signer (and thus
+the key) when the protocol completes or aborts. Prefer deriving both:
+
+```rust
+#[derive(Zeroize, ZeroizeOnDrop)]
+struct MySigner {
+    sk: MySecretKey,      // must implement Zeroize
+    #[zeroize(skip)]
+    pk: MyPublicKey,      // non-secret fields can be skipped
+}
+```
+
+Avoid a bare `impl ZeroizeOnDrop for MySigner {}`: it is only a marker and
+wipes nothing unless every secret field already zeroizes itself on drop.
 
 ### NEAR MPC Compatibility
 

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -12,6 +12,8 @@ use qp_rusty_crystals_dilithium::{
 	poly, polyvec,
 };
 
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
 use crate::{
 	config::ThresholdConfig,
 	error::{ThresholdError, ThresholdResult},
@@ -220,7 +222,7 @@ pub fn generate_with_dealer(
 }
 
 /// Internal secret share structure used during key generation.
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 struct SecretShare {
 	s1_share: polyvec::Polyvecl,
 	s2_share: polyvec::Polyveck,
@@ -278,6 +280,10 @@ fn generate_threshold_shares(
 		for (j, s2_poly) in s2_share.vec.iter_mut().enumerate().take(K) {
 			poly::uniform_eta(s2_poly, &share_seed, (L + j) as u16);
 		}
+
+		// The plaintext seed is no longer needed; wipe it rather than leaving it
+		// on the stack until the next iteration overwrites (or drops) it.
+		share_seed.zeroize();
 
 		// Compute NTT of s1 share and accumulate
 		let mut s1h_share = s1_share.clone();

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -22,6 +22,9 @@ use crate::{
 	protocol::primitives::{mod_q, NttAccumulatorL},
 };
 
+/// Domain separator for per-subset dealer share-seed derivation.
+const DEALER_SUBSHARE_DOMAIN: &[u8] = b"threshold-dealer-subshare-v1";
+
 /// Generate threshold keys using a trusted dealer.
 ///
 /// This function generates a public key and private key shares for all parties
@@ -109,6 +112,18 @@ pub fn generate_with_dealer(
 	// NIST mode: absorb K and L
 	let kl = [K as u8, L as u8];
 	fips202::shake256_absorb(&mut h, &kl);
+
+	// Bind the threshold policy (t, n) into the dealer's randomness. RSS
+	// enumerates `C(n, n-t+1)` subsets, and `C(n, n-t+1) == C(n, t-1)`, so
+	// distinct policies over the same `n` (e.g. 2-of-3 vs 3-of-3, or 3-of-5 vs
+	// 4-of-5) enumerate the *same number* of subsets. Without this binding they
+	// would consume an identical XOF stream (rho, party keys, subset seeds) and
+	// sum to the same secret, producing an identical public key — letting an old
+	// weaker coalition sign under a key that was "strengthened" by re-running
+	// keygen with the same seed. Absorbing (t, n) makes rho and every downstream
+	// value policy-specific, so the public keys can no longer collide.
+	fips202::shake256_absorb(&mut h, &threshold.to_le_bytes());
+	fips202::shake256_absorb(&mut h, &parties.to_le_bytes());
 	fips202::shake256_finalize(&mut h);
 
 	// 1. Squeeze rho (seed for matrix A)
@@ -265,9 +280,26 @@ fn generate_threshold_shares(
 	let max_combinations: u16 = 1u16 << parties;
 
 	while honest_signers < max_combinations {
-		// Generate random seed for this share
+		// Derive this subset's seed with explicit domain separation by subset
+		// mask (and threshold config), rather than assigning raw XOF output to
+		// masks purely by enumeration order. This binds each secret share to the
+		// subset it belongs to, so the derivation cannot be reinterpreted for a
+		// different subset/policy that happens to squeeze the stream in the same
+		// order. `raw` keys the derivation; `honest_signers` is the subset mask.
+		let mut raw = [0u8; 64];
+		fips202::shake256_squeeze(&mut raw, state);
+
+		let mut sh = fips202::KeccakState::default();
+		fips202::shake256_absorb(&mut sh, DEALER_SUBSHARE_DOMAIN);
+		fips202::shake256_absorb(&mut sh, &raw);
+		fips202::shake256_absorb(&mut sh, &threshold.to_le_bytes());
+		fips202::shake256_absorb(&mut sh, &parties.to_le_bytes());
+		fips202::shake256_absorb(&mut sh, &honest_signers.to_le_bytes());
+		fips202::shake256_finalize(&mut sh);
+
 		let mut share_seed = [0u8; 64];
-		fips202::shake256_squeeze(&mut share_seed, state);
+		fips202::shake256_squeeze(&mut share_seed, &mut sh);
+		raw.zeroize();
 
 		// Create η-bounded shares for s1
 		let mut s1_share = polyvec::Polyvecl::default();
@@ -405,6 +437,39 @@ mod tests {
 
 		// Different seeds should produce different keys
 		assert_ne!(pk1.as_bytes(), pk2.as_bytes());
+	}
+
+	/// Distinct threshold policies over the same `n` that enumerate the *same
+	/// number* of RSS subsets must not collide on the public key when generated
+	/// from the same seed. `C(n, n-t+1) == C(n, t-1)`, so 2-of-3 and 3-of-3 both
+	/// enumerate 3 subsets, and 3-of-5 and 4-of-5 both enumerate 10. Before the
+	/// (t, n) binding fix these produced byte-identical public keys, letting an
+	/// old weaker coalition sign under a "strengthened" key.
+	#[test]
+	fn test_distinct_policies_same_subset_count_differ() {
+		let seed = [0x5Au8; 32];
+
+		// Same n=3, equal subset counts (C(3,2)=C(3,1)=3).
+		let (pk_2of3, _) =
+			generate_with_dealer(&seed, ThresholdConfig::new(2, 3).unwrap()).unwrap();
+		let (pk_3of3, _) =
+			generate_with_dealer(&seed, ThresholdConfig::new(3, 3).unwrap()).unwrap();
+		assert_ne!(
+			pk_2of3.as_bytes(),
+			pk_3of3.as_bytes(),
+			"2-of-3 and 3-of-3 must not share a public key for the same seed"
+		);
+
+		// Same n=5, equal subset counts (C(5,3)=C(5,2)=10).
+		let (pk_3of5, _) =
+			generate_with_dealer(&seed, ThresholdConfig::new(3, 5).unwrap()).unwrap();
+		let (pk_4of5, _) =
+			generate_with_dealer(&seed, ThresholdConfig::new(4, 5).unwrap()).unwrap();
+		assert_ne!(
+			pk_3of5.as_bytes(),
+			pk_4of5.as_bytes(),
+			"3-of-5 and 4-of-5 must not share a public key for the same seed"
+		);
 	}
 
 	#[test]

--- a/threshold/src/keygen/dkg/mod.rs
+++ b/threshold/src/keygen/dkg/mod.rs
@@ -85,8 +85,8 @@
 //!
 //! The hyperball sampling parameters are pre-computed to accommodate this wider
 //! distribution with substantial safety margins (>99% headroom in tested
-//! configurations). The `coefficient_stats()` method on `PrivateKeyShare` can
-//! be used to monitor coefficient ranges if desired.
+//! configurations). Coefficient ranges are monitored by the analysis helpers
+//! in the integration test suite (see `threshold/tests/resharing_tests.rs`).
 //!
 //! # Usage
 //!

--- a/threshold/src/keygen/dkg/mod.rs
+++ b/threshold/src/keygen/dkg/mod.rs
@@ -236,7 +236,7 @@ mod tests {
 	/// Test session nonce for DKG tests.
 	const TEST_SESSION_NONCE: [u8; 32] = [0xDF; 32];
 
-	#[derive(Clone, Debug)]
+	#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 	struct TestSigner {
 		id: u32,
 	}

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -203,10 +203,8 @@ impl fmt::Debug for DkgAction {
 			DkgAction::Wait => f.write_str("Wait"),
 			// Broadcast payloads are public, but the serialized bytes are noise in
 			// a log; show only the length for consistency with SendPrivate.
-			DkgAction::SendMany(data) => f
-				.debug_tuple("SendMany")
-				.field(&format_args!("{} bytes", data.len()))
-				.finish(),
+			DkgAction::SendMany(data) =>
+				f.debug_tuple("SendMany").field(&format_args!("{} bytes", data.len())).finish(),
 			// The payload is the serialized Round 1 private message (K_S). Never
 			// render the bytes; keep the recipient and length for diagnostics.
 			DkgAction::SendPrivate(to, data) => f
@@ -1450,8 +1448,8 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 		// Combine partial PKs to get final public key. Reject any partial PK with
 		// non-canonical coefficients rather than overflowing the i32 accumulation.
-		let public_key = pack_combined_pk(&rho, all_partial_pks.values().map(|pk| &pk.t))
-			.map_err(|_| {
+		let public_key =
+			pack_combined_pk(&rho, all_partial_pks.values().map(|pk| &pk.t)).map_err(|_| {
 				DkgError::InvalidMessage(
 					"a partial public key contains out-of-range coefficients".into(),
 				)
@@ -2067,16 +2065,12 @@ mod tests {
 	/// had seen Round 2 reveals could predict it.
 	#[test]
 	fn test_round1_randomness_changes_with_session_nonce() {
-		use crate::derivation::derive_dkg_contribution;
-		use crate::keys::SecretShareData;
+		use crate::{derivation::derive_dkg_contribution, keys::SecretShareData};
 		use alloc::collections::BTreeMap;
 
 		let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
 		let mut shares = BTreeMap::new();
-		shares.insert(
-			0b011,
-			SecretShareData { s1: [[42i32; 256]; L], s2: [[42i32; 256]; K] },
-		);
+		shares.insert(0b011, SecretShareData { s1: [[42i32; 256]; L], s2: [[42i32; 256]; K] });
 		let master_share = PrivateKeyShare::new(
 			0,
 			3,

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -2292,8 +2292,13 @@ mod tests {
 
 		/// Signer that wraps a Dilithium secret key.
 		/// Clone is implemented manually to explicitly copy the secret key bytes.
+		///
+		/// `Zeroize`/`ZeroizeOnDrop` are derived (not marker-implemented) so the
+		/// secret key is provably wiped on drop; the public key is skipped.
+		#[derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 		struct DilithiumSigner {
 			sk: SecretKey,
+			#[zeroize(skip)]
 			pk: PublicKey,
 		}
 
@@ -2313,11 +2318,6 @@ mod tests {
 					.finish()
 			}
 		}
-
-		// `sk` is a dilithium `SecretKey`, which is itself `ZeroizeOnDrop`, so the
-		// secret-key bytes are wiped when this signer is dropped. `pk` is public.
-		// The marker impl satisfies the `TranscriptSigner: ZeroizeOnDrop` bound.
-		impl zeroize::ZeroizeOnDrop for DilithiumSigner {}
 
 		impl TranscriptSigner for DilithiumSigner {
 			type Signature = Vec<u8>;

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -2148,7 +2148,7 @@ mod tests {
 		assert!(rendered.contains("redacted"), "payload should be redacted: {rendered}");
 	}
 
-	#[derive(Clone, Debug)]
+	#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 	struct TestSigner {
 		id: u32,
 	}
@@ -2308,6 +2308,11 @@ mod tests {
 			}
 		}
 
+		// `sk` is a dilithium `SecretKey`, which is itself `ZeroizeOnDrop`, so the
+		// secret-key bytes are wiped when this signer is dropped. `pk` is public.
+		// The marker impl satisfies the `TranscriptSigner: ZeroizeOnDrop` bound.
+		impl zeroize::ZeroizeOnDrop for DilithiumSigner {}
+
 		impl TranscriptSigner for DilithiumSigner {
 			type Signature = Vec<u8>;
 			type PublicKey = PublicKey;
@@ -2389,7 +2394,7 @@ mod tests {
 	#[test]
 	fn test_dkg_rejects_bad_signature() {
 		// A signer that produces bad signatures for party 2
-		#[derive(Clone, Debug)]
+		#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 		struct BadSigner {
 			id: u32,
 			produce_bad_sig: bool,

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -417,16 +417,27 @@ pub struct Dkg<S: TranscriptSigner> {
 	ssid: [u8; DKG_SSID_SIZE],
 	/// Master seed for deriving all randomness (32 bytes, cryptographically random).
 	seed: [u8; 32],
-	pending_privates: Vec<(ParticipantId, Vec<u8>)>,
+	/// Round 1 private messages awaiting delivery, held as zeroizing
+	/// [`Round1Private`] structs (not pre-serialized byte buffers) so the queued
+	/// K_S material is wiped on drop rather than left in a freed `Vec<u8>`.
+	pending_privates: Vec<(ParticipantId, Round1Private)>,
 	/// Buffer for messages that arrive before we're ready to process them.
 	message_buffer: DkgMessageBuffer,
 }
 
 impl<S: TranscriptSigner> Drop for Dkg<S> {
 	fn drop(&mut self) {
-		// Zeroize sensitive data when the DKG is dropped
+		// Zeroize sensitive data when the DKG is dropped. Queued and buffered
+		// Round 1 private messages carry K_S, so wipe them too rather than freeing
+		// heap allocations that still contain secret bytes.
 		self.state.zeroize();
 		self.seed.zeroize();
+		for (_, private) in self.pending_privates.iter_mut() {
+			private.zeroize();
+		}
+		for private in self.message_buffer.round1_privates.values_mut() {
+			private.zeroize();
+		}
 	}
 }
 
@@ -485,7 +496,9 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// * `Ok(DkgAction)` - The action to perform
 	/// * `Err(DkgError)` - If the protocol encounters an error
 	pub fn poke(&mut self) -> Result<DkgAction, DkgError> {
-		if let Some((to, data)) = self.pending_privates.pop() {
+		if let Some((to, private)) = self.pending_privates.pop() {
+			let data = borsh::to_vec(&DkgMessage::Round1Private(private))
+				.map_err(|e| DkgError::InternalError(e.to_string()))?;
 			return Ok(DkgAction::SendPrivate(to, data));
 		}
 
@@ -999,17 +1012,18 @@ impl<S: TranscriptSigner> Dkg<S> {
 							subset_mask: subset,
 							shared_secret: secret,
 						};
-						let msg = DkgMessage::Round1Private(private);
-						let data = borsh::to_vec(&msg)
-							.map_err(|e| DkgError::InternalError(e.to_string()))?;
-						self.pending_privates.push((party, data));
+						// Queue the zeroizing struct; serialize only when popped for
+						// sending, so K_S is never parked in a plain byte buffer.
+						self.pending_privates.push((party, private));
 					}
 				}
 			}
 
 			self.state.privates_sent = true;
 
-			if let Some((to, data)) = self.pending_privates.pop() {
+			if let Some((to, private)) = self.pending_privates.pop() {
+				let data = borsh::to_vec(&DkgMessage::Round1Private(private))
+					.map_err(|e| DkgError::InternalError(e.to_string()))?;
 				return Ok(DkgAction::SendPrivate(to, data));
 			}
 		}

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -170,7 +170,12 @@ impl fmt::Display for DkgError {
 /// `Return` carries a boxed [`DkgOutput`] because the output is ~2.8 KB
 /// (full Dilithium key material) and inlining it would balloon every other
 /// variant. See `clippy::large_enum_variant`.
-#[derive(Debug)]
+///
+/// `Debug` is implemented manually (rather than derived) so that the
+/// [`SendPrivate`](DkgAction::SendPrivate) transport bytes — which carry the
+/// serialized Round 1 secret K_S — are never rendered. A derived formatter would
+/// print the raw `Vec<u8>`, persisting key material into any log or trace that
+/// includes `{:?}` output. Only the recipient and payload length are shown.
 pub enum DkgAction {
 	/// Wait for more messages before proceeding.
 	Wait,
@@ -190,6 +195,29 @@ pub enum DkgAction {
 	SendPrivate(ParticipantId, Vec<u8>),
 	/// DKG is complete, return the output.
 	Return(Box<DkgOutput>),
+}
+
+impl fmt::Debug for DkgAction {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			DkgAction::Wait => f.write_str("Wait"),
+			// Broadcast payloads are public, but the serialized bytes are noise in
+			// a log; show only the length for consistency with SendPrivate.
+			DkgAction::SendMany(data) => f
+				.debug_tuple("SendMany")
+				.field(&format_args!("{} bytes", data.len()))
+				.finish(),
+			// The payload is the serialized Round 1 private message (K_S). Never
+			// render the bytes; keep the recipient and length for diagnostics.
+			DkgAction::SendPrivate(to, data) => f
+				.debug_struct("SendPrivate")
+				.field("to", to)
+				.field("payload", &format_args!("<{} bytes redacted>", data.len()))
+				.finish(),
+			// Delegates to DkgOutput's Debug, which redacts the private share.
+			DkgAction::Return(output) => f.debug_tuple("Return").field(output).finish(),
+		}
+	}
 }
 
 // ============================================================================
@@ -1980,6 +2008,43 @@ mod tests {
 
 	/// Test session nonce for DKG tests.
 	const TEST_SESSION_NONCE: [u8; 32] = [0xDEu8; 32];
+
+	/// The `SendPrivate` payload carries the borsh-serialized Round 1 private
+	/// message (K_S). Its `Debug` output must never expose those secret bytes,
+	/// otherwise any downstream `{:?}` logging persists key material outside the
+	/// encrypted transport path.
+	#[test]
+	fn send_private_debug_does_not_leak_shared_secret() {
+		// A recognizable K_S: every byte 0xAB (== 171 decimal) so we can search
+		// for the exact form a derived `Debug` on `Vec<u8>` would print.
+		let secret_marker = [0xABu8; SHARED_SECRET_SIZE];
+		let private = Round1Private {
+			ssid: [0x11u8; DKG_SSID_SIZE],
+			from_party_id: 7,
+			subset_mask: 0b011,
+			shared_secret: secret_marker,
+		};
+		let data = borsh::to_vec(&DkgMessage::Round1Private(private)).unwrap();
+
+		// Sanity: the secret really is inside the transport payload.
+		assert!(
+			data.windows(SHARED_SECRET_SIZE).any(|w| w == secret_marker),
+			"test setup: secret not present in serialized payload"
+		);
+
+		let action = DkgAction::SendPrivate(3, data);
+		let rendered = format!("{action:?}");
+
+		// A derived `Debug` renders the payload as `[.., 171, 171, ..]`; the
+		// redacting impl must emit no run of the secret bytes.
+		assert!(
+			!rendered.contains("171, 171"),
+			"SendPrivate Debug leaked raw secret bytes: {rendered}"
+		);
+		// Still useful for debugging: recipient visible, payload redacted.
+		assert!(rendered.contains("to: 3"), "recipient should stay visible: {rendered}");
+		assert!(rendered.contains("redacted"), "payload should be redacted: {rendered}");
+	}
 
 	#[derive(Clone, Debug)]
 	struct TestSigner {

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -1448,8 +1448,14 @@ impl<S: TranscriptSigner> Dkg<S> {
 			&transcript_hash,
 		)?;
 
-		// Combine partial PKs to get final public key
-		let public_key = pack_combined_pk(&rho, all_partial_pks.values().map(|pk| &pk.t));
+		// Combine partial PKs to get final public key. Reject any partial PK with
+		// non-canonical coefficients rather than overflowing the i32 accumulation.
+		let public_key = pack_combined_pk(&rho, all_partial_pks.values().map(|pk| &pk.t))
+			.map_err(|_| {
+				DkgError::InvalidMessage(
+					"a partial public key contains out-of-range coefficients".into(),
+				)
+			})?;
 
 		// Build private key share
 		let private_share = build_private_share(config, my_contributions, &rho, &public_key)?;

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -330,17 +330,25 @@ impl DkgMessageBuffer {
 // Seed-based Randomness Derivation
 // ============================================================================
 
-/// Derive randomness for DKG Round 1 from a master seed.
+/// Derive randomness for DKG Round 1 from a master seed and session identifier.
 ///
 /// This uses SHAKE256 to derive all random values needed for Round 1:
 /// - `my_randomness`: The party's commitment randomness
 /// - `shared_secrets`: One secret per subset where this party is leader
 ///
+/// The [`DKG_SSID_SIZE`]-byte `ssid` (which incorporates the session nonce) is
+/// mixed into every derivation so that a retry with a fresh `session_nonce`
+/// produces fresh randomness even when `seed` is a deterministic derived-key
+/// contribution (`derive_dkg_contribution`). Without this binding, an adversary
+/// who observed honest Round 2 reveals from a failed attempt could predict the
+/// same values on retry and grind `global_randomness`.
+///
 /// Formula:
-/// - `my_randomness = SHAKE256("dkg-r1-rand" || seed || party_id)[0..32]`
-/// - `shared_secret[i] = SHAKE256("dkg-r1-ss" || seed || party_id || subset_mask)[0..32]`
+/// - `my_randomness = SHAKE256("dkg-r1-rand" || seed || party_id || ssid)[0..32]`
+/// - `shared_secret[i] = SHAKE256("dkg-r1-ss" || seed || party_id || subset_mask || ssid)[0..32]`
 fn derive_round1_randomness(
 	seed: &[u8; 32],
+	ssid: &[u8; DKG_SSID_SIZE],
 	party_id: ParticipantId,
 	leader_subsets: &[SubsetMask],
 ) -> ([u8; RANDOMNESS_SIZE], BTreeMap<SubsetMask, [u8; SHARED_SECRET_SIZE]>) {
@@ -350,6 +358,7 @@ fn derive_round1_randomness(
 	fips202::shake256_absorb(&mut state, seed);
 	let party_bytes = party_id.to_le_bytes();
 	fips202::shake256_absorb(&mut state, &party_bytes);
+	fips202::shake256_absorb(&mut state, ssid);
 	fips202::shake256_finalize(&mut state);
 
 	let mut my_randomness = [0u8; RANDOMNESS_SIZE];
@@ -364,6 +373,7 @@ fn derive_round1_randomness(
 		fips202::shake256_absorb(&mut state, &party_bytes);
 		let subset_bytes = subset.to_le_bytes();
 		fips202::shake256_absorb(&mut state, &subset_bytes); // SubsetMask is u16 = 2 bytes
+		fips202::shake256_absorb(&mut state, ssid);
 		fips202::shake256_finalize(&mut state);
 
 		let mut secret = [0u8; SHARED_SECRET_SIZE];
@@ -890,7 +900,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 		// Derive all randomness from the master seed
 		let leader_subsets = config.my_leader_subsets();
 		let (my_randomness, my_shared_secrets) =
-			derive_round1_randomness(&self.seed, config.my_party_id, &leader_subsets);
+			derive_round1_randomness(&self.seed, &self.ssid, config.my_party_id, &leader_subsets);
 
 		let my_commitment = h_commit(&self.ssid, config.my_party_id, &my_randomness);
 
@@ -2022,6 +2032,63 @@ mod tests {
 
 	/// Test session nonce for DKG tests.
 	const TEST_SESSION_NONCE: [u8; 32] = [0xDEu8; 32];
+
+	/// A deterministic derived-key contribution (same share + tweak) must not
+	/// pin Round 1 randomness across DKG retries. Before the SSID binding fix,
+	/// `derive_round1_randomness` ignored `session_nonce`, so an honest party
+	/// replayed the same `my_randomness` on every retry and a malicious peer who
+	/// had seen Round 2 reveals could predict it.
+	#[test]
+	fn test_round1_randomness_changes_with_session_nonce() {
+		use crate::derivation::derive_dkg_contribution;
+		use crate::keys::SecretShareData;
+		use alloc::collections::BTreeMap;
+
+		let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
+		let mut shares = BTreeMap::new();
+		shares.insert(
+			0b011,
+			SecretShareData { s1: [[42i32; 256]; L], s2: [[42i32; 256]; K] },
+		);
+		let master_share = PrivateKeyShare::new(
+			0,
+			3,
+			2,
+			[0u8; 32],
+			[0u8; 32],
+			[0u8; 64],
+			shares,
+			dkg_participants,
+		);
+		let tweak = [0x55u8; 32];
+		let contribution = derive_dkg_contribution(&master_share, &tweak);
+
+		let nonce_a = [0xA1u8; 32];
+		let nonce_b = [0xB2u8; 32];
+		let ssid_a = compute_dkg_ssid(2, 3, &[0, 1, 2], &nonce_a);
+		let ssid_b = compute_dkg_ssid(2, 3, &[0, 1, 2], &nonce_b);
+		let leader_subsets = [0b011u16];
+
+		let (rand_a, secrets_a) =
+			derive_round1_randomness(&contribution, &ssid_a, 0, &leader_subsets);
+		let (rand_b, secrets_b) =
+			derive_round1_randomness(&contribution, &ssid_b, 0, &leader_subsets);
+
+		assert_ne!(
+			rand_a, rand_b,
+			"same derived-key contribution must yield different Round 1 randomness per session nonce"
+		);
+		assert_ne!(
+			secrets_a[&0b011], secrets_b[&0b011],
+			"leader subset secrets must also change with session nonce"
+		);
+
+		// Same nonce → reproducible (honest parties in one session agree).
+		let (rand_a2, secrets_a2) =
+			derive_round1_randomness(&contribution, &ssid_a, 0, &leader_subsets);
+		assert_eq!(rand_a, rand_a2);
+		assert_eq!(secrets_a[&0b011], secrets_a2[&0b011]);
+	}
 
 	/// The `SendPrivate` payload carries the borsh-serialized Round 1 private
 	/// message (K_S). Its `Debug` output must never expose those secret bytes,

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -1930,6 +1930,27 @@ where
 	let threshold_config = ThresholdConfig::new(threshold, total_parties)
 		.map_err(|e| DkgError::InternalError(e.to_string()))?;
 
+	// Validate vector lengths up front. Without this, mismatched lengths would
+	// reach `DkgConfig::new(...).unwrap()` (panic on a length/participant error)
+	// or, when too few signers are supplied, the driver loop's `dkgs[party_id]`
+	// indexing — turning a `Result`-returning API into a process abort.
+	if signers.len() != total_parties as usize {
+		return Err(DkgError::InvalidState(format!(
+			"expected {} signers for {} parties, got {}",
+			total_parties,
+			total_parties,
+			signers.len()
+		)));
+	}
+	if public_keys.len() != total_parties as usize {
+		return Err(DkgError::InvalidState(format!(
+			"expected {} public keys for {} parties, got {}",
+			total_parties,
+			total_parties,
+			public_keys.len()
+		)));
+	}
+
 	let participants: Vec<ParticipantId> = (0..total_parties).collect();
 
 	let mut pk_map: BTreeMap<ParticipantId, S::PublicKey> = BTreeMap::new();
@@ -1949,7 +1970,7 @@ where
 				signer,
 				pk_map.clone(),
 			)
-			.unwrap();
+			.map_err(|e| DkgError::InvalidState(e.to_string()))?;
 
 			// Derive party-specific seed: SHAKE256(master_seed || "dkg-party" || party_id)
 			let mut state = fips202::KeccakState::default();
@@ -1962,9 +1983,9 @@ where
 			let mut party_seed = [0u8; 32];
 			fips202::shake256_squeeze(&mut party_seed, &mut state);
 
-			Dkg::new(config, party_seed, session_nonce)
+			Ok(Dkg::new(config, party_seed, session_nonce))
 		})
-		.collect();
+		.collect::<Result<Vec<Dkg<S>>, DkgError>>()?;
 
 	let mut outputs: Vec<Option<DkgOutput>> = vec![None; total_parties as usize];
 	let mut pending_messages: Vec<Vec<(ParticipantId, Vec<u8>)>> =
@@ -2183,6 +2204,32 @@ mod tests {
 				panic!("DKG failed: {:?}", e);
 			},
 		}
+	}
+
+	/// Mismatched input vector lengths must return a `DkgError`, not panic.
+	/// `run_local_dkg` is public, so untrusted setup parameters reaching a
+	/// `.unwrap()` or `dkgs[party_id]` index would be an availability DoS.
+	#[test]
+	fn test_run_local_dkg_rejects_mismatched_lengths() {
+		let seed = [7u8; 32];
+
+		// Too few signers (and the driver loop would otherwise index out of bounds).
+		let signers: Vec<TestSigner> = (0..2).map(|id| TestSigner { id }).collect();
+		let public_keys: Vec<u32> = (0..3).collect();
+		let result = run_local_dkg(2, 3, signers, public_keys, seed, &TEST_SESSION_NONCE);
+		assert!(matches!(result, Err(DkgError::InvalidState(_))), "too few signers must error");
+
+		// Too many signers (index would fall outside all_participants).
+		let signers: Vec<TestSigner> = (0..4).map(|id| TestSigner { id }).collect();
+		let public_keys: Vec<u32> = (0..3).collect();
+		let result = run_local_dkg(2, 3, signers, public_keys, seed, &TEST_SESSION_NONCE);
+		assert!(matches!(result, Err(DkgError::InvalidState(_))), "too many signers must error");
+
+		// Mismatched public key count (would fail DkgConfig::new before the fix).
+		let signers: Vec<TestSigner> = (0..3).map(|id| TestSigner { id }).collect();
+		let public_keys: Vec<u32> = (0..2).collect();
+		let result = run_local_dkg(2, 3, signers, public_keys, seed, &TEST_SESSION_NONCE);
+		assert!(matches!(result, Err(DkgError::InvalidState(_))), "wrong pk count must error");
 	}
 
 	#[test]

--- a/threshold/src/keygen/dkg/state.rs
+++ b/threshold/src/keygen/dkg/state.rs
@@ -281,6 +281,13 @@ impl<S: TranscriptSigner> Zeroize for DkgState<S> {
 		}
 		self.my_contributions = None;
 
+		// Drop the config, which owns the transcript signer (this party's
+		// long-term authentication key). The `TranscriptSigner: ZeroizeOnDrop`
+		// bound guarantees that dropping the signer erases any secret-key bytes
+		// it holds, so the authentication key does not survive past this
+		// zeroization boundary in freed memory.
+		self.config = None;
+
 		// Clear non-sensitive data
 		self.my_commitment = None;
 		self.round1_broadcasts = None;
@@ -290,7 +297,6 @@ impl<S: TranscriptSigner> Zeroize for DkgState<S> {
 		self.my_pk_commitments = None;
 		self.round3_broadcasts = None;
 		self.round4_broadcasts = None;
-		self.config = None;
 		self.output = None;
 		self.error_message = None;
 		self.broadcast_sent = false;
@@ -459,4 +465,103 @@ pub fn all_private_messages_received(
 		}
 	}
 	true
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::config::ThresholdConfig;
+	use alloc::rc::Rc;
+	use core::cell::Cell;
+
+	/// A transcript signer that holds "secret" key bytes and records, via a
+	/// shared flag, whether its key material was zeroized. Because
+	/// `TranscriptSigner: ZeroizeOnDrop`, dropping the signer must scrub the key.
+	struct SpySigner {
+		id: u32,
+		secret: Vec<u8>,
+		zeroized: Rc<Cell<bool>>,
+	}
+
+	impl Zeroize for SpySigner {
+		fn zeroize(&mut self) {
+			self.secret.zeroize();
+			self.zeroized.set(true);
+		}
+	}
+
+	impl Drop for SpySigner {
+		fn drop(&mut self) {
+			self.zeroize();
+		}
+	}
+
+	impl ZeroizeOnDrop for SpySigner {}
+
+	impl TranscriptSigner for SpySigner {
+		type Signature = Vec<u8>;
+		type PublicKey = u32;
+
+		fn sign(&self, hash: &[u8; 32]) -> Self::Signature {
+			let mut sig = Vec::with_capacity(36);
+			sig.extend_from_slice(&self.id.to_le_bytes());
+			sig.extend_from_slice(hash);
+			sig
+		}
+
+		fn verify(pk: &Self::PublicKey, hash: &[u8; 32], sig: &Self::Signature) -> bool {
+			Self::verify_bytes(pk, hash, sig)
+		}
+
+		fn verify_bytes(pk: &Self::PublicKey, hash: &[u8; 32], sig: &[u8]) -> bool {
+			if sig.len() < 36 {
+				return false;
+			}
+			let sig_id = u32::from_le_bytes(sig[..4].try_into().unwrap());
+			sig_id == *pk && &sig[4..36] == hash
+		}
+
+		fn public_key(&self) -> Self::PublicKey {
+			self.id
+		}
+	}
+
+	/// Regression test: `DkgState::zeroize()` must erase the transcript signer's
+	/// long-term key, not merely drop the config without a zeroization guarantee.
+	#[test]
+	fn zeroize_erases_transcript_signer_key() {
+		let zeroized = Rc::new(Cell::new(false));
+
+		let mut public_keys = BTreeMap::new();
+		public_keys.insert(0u32, 0u32);
+		public_keys.insert(1u32, 1u32);
+		public_keys.insert(2u32, 2u32);
+
+		let signer = SpySigner {
+			id: 0,
+			secret: [0xABu8; 64].to_vec(),
+			zeroized: zeroized.clone(),
+		};
+
+		let config = DkgConfig::new(
+			ThresholdConfig::new(2, 3).unwrap(),
+			0,
+			Vec::from([0u32, 1, 2]),
+			signer,
+			public_keys,
+		)
+		.unwrap();
+
+		let mut state = DkgState::new(config);
+		assert!(!zeroized.get(), "signer should not be zeroized before teardown");
+
+		// The documented zeroization boundary: dropping the config must scrub the
+		// signer's key material, which the `TranscriptSigner: ZeroizeOnDrop` bound
+		// now guarantees.
+		state.zeroize();
+		assert!(
+			zeroized.get(),
+			"transcript signer key was not zeroized within DkgState::zeroize()"
+		);
+	}
 }

--- a/threshold/src/keygen/dkg/state.rs
+++ b/threshold/src/keygen/dkg/state.rs
@@ -538,11 +538,7 @@ mod tests {
 		public_keys.insert(1u32, 1u32);
 		public_keys.insert(2u32, 2u32);
 
-		let signer = SpySigner {
-			id: 0,
-			secret: [0xABu8; 64].to_vec(),
-			zeroized: zeroized.clone(),
-		};
+		let signer = SpySigner { id: 0, secret: [0xABu8; 64].to_vec(), zeroized: zeroized.clone() };
 
 		let config = DkgConfig::new(
 			ThresholdConfig::new(2, 3).unwrap(),

--- a/threshold/src/keygen/dkg/state.rs
+++ b/threshold/src/keygen/dkg/state.rs
@@ -282,10 +282,10 @@ impl<S: TranscriptSigner> Zeroize for DkgState<S> {
 		self.my_contributions = None;
 
 		// Drop the config, which owns the transcript signer (this party's
-		// long-term authentication key). The `TranscriptSigner: ZeroizeOnDrop`
-		// bound guarantees that dropping the signer erases any secret-key bytes
-		// it holds, so the authentication key does not survive past this
-		// zeroization boundary in freed memory.
+		// long-term authentication key). The `TranscriptSigner: Zeroize +
+		// ZeroizeOnDrop` bound guarantees that dropping the signer erases any
+		// secret-key bytes it holds, so the authentication key does not survive
+		// past this zeroization boundary in freed memory.
 		self.config = None;
 
 		// Clear non-sensitive data
@@ -476,7 +476,8 @@ mod tests {
 
 	/// A transcript signer that holds "secret" key bytes and records, via a
 	/// shared flag, whether its key material was zeroized. Because
-	/// `TranscriptSigner: ZeroizeOnDrop`, dropping the signer must scrub the key.
+	/// `TranscriptSigner: Zeroize + ZeroizeOnDrop`, dropping the signer must
+	/// scrub the key.
 	struct SpySigner {
 		id: u32,
 		secret: Vec<u8>,
@@ -556,8 +557,8 @@ mod tests {
 		assert!(!zeroized.get(), "signer should not be zeroized before teardown");
 
 		// The documented zeroization boundary: dropping the config must scrub the
-		// signer's key material, which the `TranscriptSigner: ZeroizeOnDrop` bound
-		// now guarantees.
+		// signer's key material, which the `TranscriptSigner: Zeroize +
+		// ZeroizeOnDrop` bound now guarantees.
 		state.zeroize();
 		assert!(
 			zeroized.get(),

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -47,7 +47,19 @@ use qp_rusty_crystals_dilithium::fips202;
 ///
 /// This allows the DKG protocol to be agnostic to the signature scheme used.
 /// Implementors can use Ed25519, ML-DSA, or any other scheme.
-pub trait TranscriptSigner {
+///
+/// # Zeroization
+///
+/// `TranscriptSigner` requires [`ZeroizeOnDrop`] because implementors hold a
+/// long-term signing key (`my_signer` in [`DkgConfig`]). The DKG/resharing
+/// state machines own the signer for the whole protocol lifetime and rely on
+/// dropping the configuration to erase that key at their zeroization boundary.
+/// Making the guarantee part of the trait — rather than an unenforced integrator
+/// convention — ensures a signer holding raw secret-key bytes cannot leave them
+/// in freed process memory after the protocol completes or aborts. Implementors
+/// that wrap already-zeroizing key types (e.g. dilithium's `SecretKey`) can
+/// satisfy this with `#[derive(Zeroize, ZeroizeOnDrop)]` or a marker impl.
+pub trait TranscriptSigner: ZeroizeOnDrop {
 	/// The signature type produced by this signer.
 	type Signature: Clone + AsRef<[u8]>;
 
@@ -791,7 +803,7 @@ mod tests {
 	/// Test SSID for DKG type tests.
 	const TEST_SSID: [u8; DKG_SSID_SIZE] = [0xDD; DKG_SSID_SIZE];
 
-	#[derive(Clone, Debug)]
+	#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 	struct TestSigner {
 		id: u32,
 	}

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -50,16 +50,25 @@ use qp_rusty_crystals_dilithium::fips202;
 ///
 /// # Zeroization
 ///
-/// `TranscriptSigner` requires [`ZeroizeOnDrop`] because implementors hold a
-/// long-term signing key (`my_signer` in [`DkgConfig`]). The DKG/resharing
-/// state machines own the signer for the whole protocol lifetime and rely on
-/// dropping the configuration to erase that key at their zeroization boundary.
-/// Making the guarantee part of the trait — rather than an unenforced integrator
-/// convention — ensures a signer holding raw secret-key bytes cannot leave them
-/// in freed process memory after the protocol completes or aborts. Implementors
-/// that wrap already-zeroizing key types (e.g. dilithium's `SecretKey`) can
-/// satisfy this with `#[derive(Zeroize, ZeroizeOnDrop)]` or a marker impl.
-pub trait TranscriptSigner: ZeroizeOnDrop {
+/// `TranscriptSigner` requires [`Zeroize`] + [`ZeroizeOnDrop`] because
+/// implementors hold a long-term signing key (`my_signer` in [`DkgConfig`]).
+/// The DKG/resharing state machines own the signer for the whole protocol
+/// lifetime and rely on dropping the configuration to erase that key at their
+/// zeroization boundary.
+///
+/// **Implement this with `#[derive(Zeroize, ZeroizeOnDrop)]`** (using
+/// `#[zeroize(skip)]` on non-secret fields such as public keys). The derive
+/// requires every non-skipped field to implement `Zeroize` and generates a
+/// real wipe on drop.
+///
+/// Note that `ZeroizeOnDrop` alone is only a marker trait: an empty
+/// `impl ZeroizeOnDrop for MySigner {}` compiles without wiping anything.
+/// Requiring `Zeroize` as well means a hand-written impl must spell out a
+/// `zeroize()` body, making a no-op erasure visible at review time rather than
+/// implied by a bare marker. If you write the impls by hand, `zeroize()` must
+/// overwrite every field that holds secret key material, and your `Drop` must
+/// call it (or each secret field must itself be `ZeroizeOnDrop`).
+pub trait TranscriptSigner: Zeroize + ZeroizeOnDrop {
 	/// The signature type produced by this signer.
 	type Signature: Clone + AsRef<[u8]>;
 

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -385,7 +385,10 @@ pub struct Round1Broadcast {
 }
 
 /// Round 1 private: Shared secret K_S (leader to subset members).
-#[derive(Clone, BorshSerialize, BorshDeserialize)]
+///
+/// Carries the secret `shared_secret` (K_S), so it is zeroized on drop. Queued
+/// copies awaiting delivery therefore never leave K_S in freed heap memory.
+#[derive(Clone, BorshSerialize, BorshDeserialize, Zeroize, ZeroizeOnDrop)]
 pub struct Round1Private {
 	/// Session identifier binding this message to a specific DKG session.
 	pub ssid: [u8; DKG_SSID_SIZE],

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -245,7 +245,6 @@ impl PrivateKeyShare {
 	pub(crate) fn shares(&self) -> &BTreeMap<u16, SecretShareData> {
 		&self.shares
 	}
-
 }
 
 impl Zeroize for PrivateKeyShare {

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -111,8 +111,11 @@ impl PublicKey {
 /// **This contains secret material and MUST be kept confidential.**
 ///
 /// Each party in the threshold scheme holds one private key share.
-/// The share is intentionally opaque - you cannot access the internal
-/// secret values directly. This prevents accidental leakage.
+/// The share is intentionally opaque - the API exposes no way to read the
+/// internal secret values. This prevents accidental leakage. (Note that
+/// the share must remain serializable so it can be stored and restored;
+/// the serialized bytes contain the secret material and must be protected
+/// accordingly.)
 ///
 /// # Security
 ///
@@ -243,95 +246,6 @@ impl PrivateKeyShare {
 		&self.shares
 	}
 
-	/// Collect all coefficients from all shares, centered in (-Q/2, Q/2].
-	///
-	/// Returns a vector of all centered coefficient values from all subset shares.
-	/// Useful for statistical analysis of coefficient distributions after resharing.
-	///
-	/// Note: This is primarily intended for testing and analysis, not for normal
-	/// protocol operation.
-	pub fn collect_all_coefficients(&self) -> Vec<i32> {
-		const Q: i64 = 8380417;
-		const HALF_Q: i64 = Q / 2;
-
-		let mut coeffs = Vec::new();
-		for share_data in self.shares.values() {
-			// Collect s1 coefficients
-			for poly in &share_data.s1 {
-				for &coeff in poly {
-					let c = coeff as i64;
-					let centered = if c > HALF_Q { c - Q } else { c };
-					coeffs.push(centered as i32);
-				}
-			}
-			// Collect s2 coefficients
-			for poly in &share_data.s2 {
-				for &coeff in poly {
-					let c = coeff as i64;
-					let centered = if c > HALF_Q { c - Q } else { c };
-					coeffs.push(centered as i32);
-				}
-			}
-		}
-		coeffs
-	}
-
-	/// Compute coefficient statistics across all shares.
-	///
-	/// Returns `(max_abs_coeff, min_coeff, max_coeff)` where coefficients are
-	/// interpreted as centered values in `[-(Q-1)/2, (Q-1)/2]`.
-	///
-	/// This is useful for monitoring coefficient growth after resharing.
-	pub fn coefficient_stats(&self) -> (i32, i32, i32) {
-		const Q: i64 = 8380417;
-		const HALF_Q: i64 = Q / 2;
-
-		let mut max_abs: i32 = 0;
-		let mut min_coeff: i32 = 0;
-		let mut max_coeff: i32 = 0;
-
-		for share_data in self.shares.values() {
-			// Check s1 coefficients
-			for poly in &share_data.s1 {
-				for &coeff in poly {
-					// Center the coefficient
-					let c = coeff as i64;
-					let centered = if c > HALF_Q { c - Q } else { c };
-					let centered_i32 = centered as i32;
-
-					if centered_i32.abs() > max_abs {
-						max_abs = centered_i32.abs();
-					}
-					if centered_i32 < min_coeff {
-						min_coeff = centered_i32;
-					}
-					if centered_i32 > max_coeff {
-						max_coeff = centered_i32;
-					}
-				}
-			}
-			// Check s2 coefficients
-			for poly in &share_data.s2 {
-				for &coeff in poly {
-					let c = coeff as i64;
-					let centered = if c > HALF_Q { c - Q } else { c };
-					let centered_i32 = centered as i32;
-
-					if centered_i32.abs() > max_abs {
-						max_abs = centered_i32.abs();
-					}
-					if centered_i32 < min_coeff {
-						min_coeff = centered_i32;
-					}
-					if centered_i32 > max_coeff {
-						max_coeff = centered_i32;
-					}
-				}
-			}
-		}
-
-		(max_abs, min_coeff, max_coeff)
-	}
 }
 
 impl Zeroize for PrivateKeyShare {

--- a/threshold/src/lib.rs
+++ b/threshold/src/lib.rs
@@ -178,7 +178,7 @@ pub use derivation::{derive_dkg_contribution, DerivedKeyId};
 pub use verification::verify_signature;
 
 // SSID computation (for tests and advanced use cases)
-pub use protocol::signing::{compute_ssid, convert_shares};
+pub use protocol::signing::compute_ssid;
 
 // Hyperball parameters (for analysis and testing)
 pub use protocol::signing::get_hyperball_params;

--- a/threshold/src/lib.rs
+++ b/threshold/src/lib.rs
@@ -183,9 +183,6 @@ pub use protocol::signing::compute_ssid;
 // Hyperball parameters (for analysis and testing)
 pub use protocol::signing::get_hyperball_params;
 
-// Secret sharing utilities (for analysis and testing)
-pub use protocol::secret_sharing::generate_subsets_of_size;
-
 /// Signature verification.
 mod verification {
 	use crate::{broadcast::Signature, keys::PublicKey};

--- a/threshold/src/protocol/partial_pk.rs
+++ b/threshold/src/protocol/partial_pk.rs
@@ -81,7 +81,10 @@ pub enum PackCombinedPkError {
 /// crafted coefficient near `i32::MAX` would panic in debug builds and wrap
 /// silently in release builds. Rejecting out-of-range coefficients up front keeps
 /// the running sum bounded below `2Q` and makes the accumulation overflow-free.
-pub fn pack_combined_pk<'a, I>(rho: &[u8; 32], partial_ts: I) -> Result<PublicKey, PackCombinedPkError>
+pub fn pack_combined_pk<'a, I>(
+	rho: &[u8; 32],
+	partial_ts: I,
+) -> Result<PublicKey, PackCombinedPkError>
 where
 	I: IntoIterator<Item = &'a [[i32; N as usize]; K]>,
 {

--- a/threshold/src/protocol/partial_pk.rs
+++ b/threshold/src/protocol/partial_pk.rs
@@ -55,12 +55,33 @@ pub fn compute_partial_pk_t(
 	t_coeffs
 }
 
+/// Error returned when combining partial public keys fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackCombinedPkError {
+	/// A partial-PK coefficient was outside the canonical range `[0, Q)`.
+	///
+	/// Legitimate partial PKs come from [`compute_partial_pk_t`], whose output
+	/// is always reduced into `[0, Q)`. A value outside that range indicates a
+	/// malformed or attacker-supplied contribution.
+	CoefficientOutOfRange,
+}
+
 /// Sum a collection of partial-PK polynomial vectors and pack into the canonical
 /// ML-DSA-87 public-key encoding (`rho || t1`).
 ///
 /// Each partial PK is a fixed-size `[[i32; N]; K]` array, guaranteeing the correct
 /// shape at compile time.
-pub fn pack_combined_pk<'a, I>(rho: &[u8; 32], partial_ts: I) -> PublicKey
+///
+/// # Coefficient validation
+///
+/// Every coefficient must already be reduced into `[0, Q)` (as produced by
+/// [`compute_partial_pk_t`]). Peer-supplied partial PKs (e.g. from resharing
+/// Round 5 or DKG Round 4 broadcasts) are attacker-controlled, so an unvalidated
+/// `i32 + i32` accumulation could overflow before the mod-`Q` reduction — a
+/// crafted coefficient near `i32::MAX` would panic in debug builds and wrap
+/// silently in release builds. Rejecting out-of-range coefficients up front keeps
+/// the running sum bounded below `2Q` and makes the accumulation overflow-free.
+pub fn pack_combined_pk<'a, I>(rho: &[u8; 32], partial_ts: I) -> Result<PublicKey, PackCombinedPkError>
 where
 	I: IntoIterator<Item = &'a [[i32; N as usize]; K]>,
 {
@@ -68,6 +89,13 @@ where
 	for partial in partial_ts {
 		for (i, poly_coeffs) in partial.iter().enumerate() {
 			for (j, &coeff) in poly_coeffs.iter().enumerate() {
+				// Reject non-canonical coefficients. This bounds the running sum
+				// (each accumulator stays in `[0, Q)`, so `acc + coeff < 2Q`) and
+				// prevents the i32 overflow that an attacker-supplied coefficient
+				// near `i32::MAX` would otherwise trigger.
+				if !(0..Q).contains(&coeff) {
+					return Err(PackCombinedPkError::CoefficientOutOfRange);
+				}
 				t.vec[i].coeffs[j] = (t.vec[i].coeffs[j] + coeff) % Q;
 			}
 		}
@@ -82,7 +110,7 @@ where
 	let mut pk_packed = [0u8; PUBLIC_KEY_SIZE];
 	packing::pack_pk(&mut pk_packed, rho, &t1);
 
-	PublicKey::new(pk_packed)
+	Ok(PublicKey::new(pk_packed))
 }
 
 #[cfg(test)]
@@ -117,8 +145,8 @@ mod tests {
 		let t_b = compute_partial_pk_t(&rho, &s1_b, &s2_b);
 		let t_sum = compute_partial_pk_t(&rho, &s1_sum, &s2_sum);
 
-		let combined = pack_combined_pk(&rho, [&t_a, &t_b]);
-		let expected = pack_combined_pk(&rho, [&t_sum]);
+		let combined = pack_combined_pk(&rho, [&t_a, &t_b]).unwrap();
+		let expected = pack_combined_pk(&rho, [&t_sum]).unwrap();
 
 		assert_eq!(
 			combined.as_bytes(),
@@ -136,13 +164,51 @@ mod tests {
 		let s1: Vec<[i32; N as usize]> = vec![[1i32; N as usize]; L];
 		let s2: Vec<[i32; N as usize]> = vec![[2i32; N as usize]; K];
 		let mut t = compute_partial_pk_t(&rho, &s1, &s2);
-		let honest = pack_combined_pk(&rho, [&t]);
+		let honest = pack_combined_pk(&rho, [&t]).unwrap();
 		t[0][0] = (t[0][0] + (1 << 13)) % Q;
-		let tampered = pack_combined_pk(&rho, [&t]);
+		let tampered = pack_combined_pk(&rho, [&t]).unwrap();
 		assert_ne!(
 			honest.as_bytes(),
 			tampered.as_bytes(),
 			"high-bit tamper must change the packed PK"
+		);
+	}
+
+	/// Regression test (security review): a peer-supplied partial PK coefficient
+	/// near `i32::MAX` must be rejected rather than overflowing the i32
+	/// accumulation. Before the fix this addition panicked in debug builds and
+	/// wrapped silently in release builds.
+	#[test]
+	fn pack_combined_pk_rejects_overflowing_coefficient() {
+		let rho = [1u8; 32];
+
+		// A first, canonical contribution makes the accumulator non-zero so that
+		// the malicious second addition would overflow `i32` (Q-1 + i32::MAX).
+		let honest = [[1i32; N as usize]; K];
+		let mut malicious = [[0i32; N as usize]; K];
+		malicious[0][0] = i32::MAX;
+
+		let result = pack_combined_pk(&rho, [&honest, &malicious]);
+		assert_eq!(
+			result,
+			Err(PackCombinedPkError::CoefficientOutOfRange),
+			"out-of-range coefficient must be rejected, not summed"
+		);
+
+		// A negative out-of-range coefficient is likewise rejected.
+		let mut negative = [[0i32; N as usize]; K];
+		negative[0][0] = -1;
+		assert_eq!(
+			pack_combined_pk(&rho, [&negative]),
+			Err(PackCombinedPkError::CoefficientOutOfRange),
+		);
+
+		// Q itself is out of range (canonical is [0, Q)).
+		let mut at_q = [[0i32; N as usize]; K];
+		at_q[0][0] = Q;
+		assert_eq!(
+			pack_combined_pk(&rho, [&at_q]),
+			Err(PackCombinedPkError::CoefficientOutOfRange),
 		);
 	}
 }

--- a/threshold/src/protocol/primitives.rs
+++ b/threshold/src/protocol/primitives.rs
@@ -108,6 +108,7 @@ const N_COEFFS: usize = N as usize;
 /// }
 /// let result: Polyvecl = acc.finalize();
 /// ```
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct NttAccumulator<const VECS: usize> {
 	coeffs: [[u64; N_COEFFS]; VECS],
 }

--- a/threshold/src/protocol/secret_sharing.rs
+++ b/threshold/src/protocol/secret_sharing.rs
@@ -99,25 +99,43 @@ pub(crate) fn compute_sharing_patterns(
 	Ok(patterns)
 }
 
-/// Generate all subsets of exactly `size` elements from `n` elements.
-/// Uses Gosper's hack to efficiently enumerate subsets.
-pub fn generate_subsets_of_size(n: usize, size: usize) -> Vec<u16> {
-	if size > n || size == 0 {
+/// Generate all subsets of exactly `size` elements from `n` elements, encoded as
+/// `u16` bitmasks. Uses Gosper's hack to efficiently enumerate subsets.
+///
+/// # Domain
+///
+/// Subset masks are `u16`, so at most 16 elements (`n <= 16`) are representable.
+/// Out-of-domain inputs (`n > 16`, `size == 0`, or `size > n`) return an empty
+/// vector rather than overflowing the mask arithmetic. This matters because, done
+/// naively in `u16`, `n == 16` makes the loop sentinel `1 << 16` and `size == 16`
+/// makes the initial mask `(1 << 16) - 1` — both overflow `u16` (a panic under
+/// overflow checks, or a silent wrap that also corrupts the Gosper iteration and
+/// yields truncated/empty enumeration). Iteration is therefore performed in `u32`
+/// and narrowed to the `u16` mask domain, which the bounds above make lossless.
+pub(crate) fn generate_subsets_of_size(n: usize, size: usize) -> Vec<u16> {
+	// A u16 mask cannot represent more than 16 elements.
+	if size == 0 || size > n || n > 16 {
 		return Vec::new();
 	}
 
 	let mut subsets = Vec::new();
-	let max_val: u16 = 1 << n;
+	// Sentinel one past the largest n-bit mask; computed in u32 so that n == 16
+	// (sentinel == 65536) does not overflow.
+	let max_val: u32 = 1u32 << n;
 
-	// Start with the smallest subset of the given size
-	let mut subset: u16 = (1 << size) - 1;
+	// Start with the smallest subset of the given size (low `size` bits set).
+	let mut subset: u32 = (1u32 << size) - 1;
 
 	while subset < max_val {
-		subsets.push(subset);
+		// `subset < max_val <= 1 << 16` and `subset` is a valid n-bit mask, so it
+		// always fits in u16 here.
+		subsets.push(subset as u16);
 
-		// Gosper's hack to get next subset of same size
-		let c = subset & (!subset + 1); // lowest set bit
-		let r = subset + c; // next higher number with same bits, except one moved left
+		// Gosper's hack to get the next subset of the same size. Computed in u32
+		// to avoid overflow at the top of the range; `subset >= 1` in the loop, so
+		// the lowest-set-bit divisor `c` is never zero.
+		let c = subset & subset.wrapping_neg(); // lowest set bit
+		let r = subset + c; // next higher number with same popcount
 		subset = (((r ^ subset) >> 2) / c) | r;
 	}
 
@@ -313,6 +331,46 @@ mod tests {
 		// C(5, 3) = 10 subsets of size 3
 		let subsets = generate_subsets_of_size(5, 3);
 		assert_eq!(subsets.len(), 10);
+	}
+
+	/// The full 16-bit mask domain (n == 16, size == 16) must enumerate correctly
+	/// rather than overflow the mask arithmetic. Before the u32-based rewrite,
+	/// `n == 16` computed the sentinel as `1u16 << 16` and `size == 16` the initial
+	/// mask as `(1u16 << 16) - 1`, panicking under overflow checks.
+	#[test]
+	fn test_generate_subsets_of_size_full_u16_domain() {
+		// n = 16 previously panicked on `1u16 << 16`.
+		for size in 1..=16 {
+			let subsets = generate_subsets_of_size(16, size);
+			assert_eq!(
+				subsets.len(),
+				binomial(16, size),
+				"n=16, size={} should yield C(16, {}) masks",
+				size,
+				size
+			);
+			for &mask in &subsets {
+				assert_eq!(
+					mask.count_ones() as usize,
+					size,
+					"each mask must have exactly `size` bits set"
+				);
+			}
+		}
+
+		// size == 16 selects the single full mask.
+		let full = generate_subsets_of_size(16, 16);
+		assert_eq!(full, alloc::vec![0xFFFFu16]);
+	}
+
+	/// Inputs outside the representable 16-bit domain return an empty vector
+	/// instead of panicking or wrapping into corrupt state.
+	#[test]
+	fn test_generate_subsets_of_size_rejects_out_of_domain() {
+		assert!(generate_subsets_of_size(17, 1).is_empty(), "n > 16 is not representable");
+		assert!(generate_subsets_of_size(20, 10).is_empty(), "n > 16 is not representable");
+		assert!(generate_subsets_of_size(4, 0).is_empty(), "size == 0 yields no subsets");
+		assert!(generate_subsets_of_size(3, 5).is_empty(), "size > n yields no subsets");
 	}
 
 	#[test]

--- a/threshold/src/protocol/secret_sharing.rs
+++ b/threshold/src/protocol/secret_sharing.rs
@@ -27,12 +27,16 @@ use crate::{
 };
 
 /// Secret share for a single party.
+///
+/// Contains raw secret `s1`/`s2` share material and must never leave the
+/// crate; `PrivateKeyShare` is the only share-bearing type in the public API
+/// and it is intentionally opaque.
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct SecretShare {
 	/// Share of the s1 polynomial vector.
-	pub s1_share: polyvec::Polyvecl,
+	pub(crate) s1_share: polyvec::Polyvecl,
 	/// Share of the s2 polynomial vector.
-	pub s2_share: polyvec::Polyveck,
+	pub(crate) s2_share: polyvec::Polyveck,
 }
 
 /// Compute sharing patterns for a (threshold, parties) configuration.

--- a/threshold/src/protocol/signing.rs
+++ b/threshold/src/protocol/signing.rs
@@ -208,7 +208,11 @@ pub(crate) fn verify_commitment_hash(
 }
 
 /// Convert PrivateKeyShare to the SecretShare format used by recover_share.
-pub fn convert_shares(share: &PrivateKeyShare) -> BTreeMap<u16, SecretShare> {
+///
+/// This copies the raw secret `s1`/`s2` share material, so it must remain
+/// crate-internal: exposing it publicly would defeat the intentional opacity
+/// of `PrivateKeyShare`.
+pub(crate) fn convert_shares(share: &PrivateKeyShare) -> BTreeMap<u16, SecretShare> {
 	let mut shares: BTreeMap<u16, SecretShare> = BTreeMap::new();
 
 	for (subset_id, share_data) in share.shares() {

--- a/threshold/src/protocol/signing.rs
+++ b/threshold/src/protocol/signing.rs
@@ -619,7 +619,7 @@ pub(crate) fn generate_round3_response(
 		// Note: SSID is NOT included in the challenge to maintain compatibility
 		// with standard ML-DSA verification. Cross-session replay protection is
 		// provided by SSID binding in commitment hashes and message validation.
-		let mut w1_packed = vec![0u8; K * POLYW1_PACKEDBYTES];
+		let mut w1_packed = [0u8; K * POLYW1_PACKEDBYTES];
 		polyvec::k_pack_w1(&mut w1_packed, &w1);
 
 		let mut challenge_bytes = [0u8; C_DASH_BYTES];
@@ -708,13 +708,13 @@ pub(crate) fn pack_responses(responses: &[polyvec::Polyvecl]) -> Vec<u8> {
 				}
 			}
 		}
-		// Pack each polynomial
-		for j in 0..L {
-			let poly_offset = offset + j * POLYZ_PACKEDBYTES;
-			poly::z_pack(
-				&mut buf[poly_offset..poly_offset + POLYZ_PACKEDBYTES],
-				&z_centered.vec[j],
-			);
+		// Pack each polynomial. `as_chunks_mut` yields exact-size
+		// `&mut [u8; POLYZ_PACKEDBYTES]` arrays, matching `z_pack`'s signature
+		// without any fallible slice conversion.
+		let (chunks, _) =
+			buf[offset..offset + single_response_size].as_chunks_mut::<POLYZ_PACKEDBYTES>();
+		for (chunk, zj) in chunks.iter_mut().zip(z_centered.vec.iter()).take(L) {
+			poly::z_pack(chunk, zj);
 		}
 	}
 
@@ -749,11 +749,12 @@ pub(crate) fn unpack_responses(
 	for i in 0..k {
 		let start = i * single_response_size;
 		let mut z = polyvec::Polyvecl::default();
-		for j in 0..L {
-			let poly_start = start + j * 640;
-			let poly_end = poly_start + 640;
-			// Size already validated, so this slice is guaranteed to be valid
-			poly::z_unpack(&mut z.vec[j], &data[poly_start..poly_end]);
+		// Size already validated above; `as_chunks` splits the per-response region
+		// into exact-size `&[u8; POLYZ_PACKEDBYTES]` arrays for `z_unpack`.
+		let (chunks, _) =
+			data[start..start + single_response_size].as_chunks::<POLYZ_PACKEDBYTES>();
+		for (chunk, zj) in chunks.iter().zip(z.vec.iter_mut()).take(L) {
+			poly::z_unpack(zj, chunk);
 		}
 		responses.push(z);
 	}
@@ -910,7 +911,7 @@ pub(crate) fn combine_signature(
 		// Note: SSID is NOT included in the challenge to maintain compatibility
 		// with standard ML-DSA verification. Cross-session replay protection is
 		// provided by SSID binding in commitment hashes and message validation.
-		let mut w1_packed = vec![0u8; K * POLYW1_PACKEDBYTES];
+		let mut w1_packed = [0u8; K * POLYW1_PACKEDBYTES];
 		polyvec::k_pack_w1(&mut w1_packed, &w1);
 
 		let mut challenge_bytes = [0u8; C_DASH_BYTES];

--- a/threshold/src/protocol/signing.rs
+++ b/threshold/src/protocol/signing.rs
@@ -507,6 +507,9 @@ pub(crate) fn process_round2(
 	context: &[u8],
 	other_party_ids: &[ParticipantId],
 ) -> ThresholdResult<Round2Data> {
+	// Enforce the ML-DSA size bounds before hashing/cloning attacker-controlled
+	// input: oversized messages can never yield a verifiable signature.
+	crate::error::validate_message(message)?;
 	crate::error::validate_context(context)?;
 
 	let k = config.k_iterations() as usize;
@@ -804,6 +807,8 @@ pub(crate) fn combine_signature(
 	w_aggregated: &[polyvec::Polyveck],
 	all_responses: &[Vec<polyvec::Polyvecl>],
 ) -> ThresholdResult<Vec<u8>> {
+	// Enforce the ML-DSA size bounds before hashing the message into μ.
+	crate::error::validate_message(message)?;
 	crate::error::validate_context(context)?;
 
 	let k_iterations = config.k_iterations() as usize;

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -35,8 +35,8 @@
 //! - **Round 4**: Private delivery - dealers send `r_{I→J}` to new committee (**secure channel**)
 //! - **Round 5**: Verification - share commitments, partial PKs
 //! - **Round 6**: Signed transcript acceptance - new committee members sign the transcript hash
-//!   (bound together with the `active_set`) using their long-term keys ([`TranscriptSigner`]);
-//!   the collected signatures form a publicly verifiable [`ResharingCertificate`]
+//!   (bound together with the `active_set`) using their long-term keys ([`TranscriptSigner`]); the
+//!   collected signatures form a publicly verifiable [`ResharingCertificate`]
 //!
 //! For each old RSS subset `I` (a `k_old`-subset of the old committee whose members all hold the
 //! η-bounded share `s_I^old`), the lowest-ID *active* member of `I` (the "designated dealer"
@@ -77,8 +77,8 @@
 //!   party against its own transcript hash, so completion implies all parties observed identical
 //!   broadcasts (equivocation causes an abort). The signed hash also binds the certificate's
 //!   `active_set` directly, so a third party holding only the certificate (and the new committee's
-//!   verifying keys) authenticates both the transcript hash *and* the named active old members;
-//!   the `active_set` field cannot be rewritten without invalidating the signatures.
+//!   verifying keys) authenticates both the transcript hash *and* the named active old members; the
+//!   `active_set` field cannot be rewritten without invalidating the signatures.
 //!
 //! # Proactive Security Model
 //!

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -35,8 +35,8 @@
 //! - **Round 4**: Private delivery - dealers send `r_{I→J}` to new committee (**secure channel**)
 //! - **Round 5**: Verification - share commitments, partial PKs
 //! - **Round 6**: Signed transcript acceptance - new committee members sign the transcript hash
-//!   with their long-term keys ([`TranscriptSigner`]); the collected signatures form a publicly
-//!   verifiable [`ResharingCertificate`]
+//!   (bound together with the `active_set`) using their long-term keys ([`TranscriptSigner`]);
+//!   the collected signatures form a publicly verifiable [`ResharingCertificate`]
 //!
 //! For each old RSS subset `I` (a `k_old`-subset of the old committee whose members all hold the
 //! η-bounded share `s_I^old`), the lowest-ID *active* member of `I` (the "designated dealer"
@@ -75,8 +75,10 @@
 //! - **Public key preservation**: `t = A·s1 + s2` is unchanged.
 //! - **Transcript agreement + attestation**: Round 6 acceptance signatures are verified by every
 //!   party against its own transcript hash, so completion implies all parties observed identical
-//!   broadcasts (equivocation causes an abort). The resulting certificate is verifiable by third
-//!   parties holding the new committee's verifying keys.
+//!   broadcasts (equivocation causes an abort). The signed hash also binds the certificate's
+//!   `active_set` directly, so a third party holding only the certificate (and the new committee's
+//!   verifying keys) authenticates both the transcript hash *and* the named active old members;
+//!   the `active_set` field cannot be rewritten without invalidating the signatures.
 //!
 //! # Proactive Security Model
 //!

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -3432,6 +3432,30 @@ mod tests {
 		assert_eq!(share.max_abs_coefficient(), 500);
 	}
 
+	/// A malicious dealer can set a coefficient to `i32::MIN`, whose magnitude
+	/// (2_147_483_648) is not representable as a positive `i32`. `i32::abs()`
+	/// would panic on it in overflow-checking builds and wrap back to
+	/// `i32::MIN` (still negative) in release builds, letting the oversized
+	/// coefficient pass the `> bound` check. The fixed helpers use
+	/// `unsigned_abs()` and must reject it in every build profile.
+	#[test]
+	fn test_coefficients_within_bound_rejects_i32_min() {
+		let mut share = NewShareData::new();
+		share.s1[0][0] = i32::MIN;
+		assert!(
+			!share.coefficients_within_bound(SUBSHARE_COEFF_BOUND),
+			"i32::MIN coefficient must be rejected, not silently accepted"
+		);
+		// The diagnostic must report the true magnitude without overflowing.
+		assert_eq!(share.max_abs_coefficient(), 2_147_483_648u32);
+
+		// The same edge case in s2.
+		let mut share = NewShareData::new();
+		share.s2[K - 1][N as usize - 1] = i32::MIN;
+		assert!(!share.coefficients_within_bound(SUBSHARE_COEFF_BOUND));
+		assert_eq!(share.max_abs_coefficient(), 2_147_483_648u32);
+	}
+
 	#[test]
 	fn test_honest_subshares_within_bound() {
 		// Verify that honestly-derived sub-shares are well within the coefficient bound

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -2845,7 +2845,7 @@ mod tests {
 	const TEST_SSID: [u8; RESHARING_SSID_SIZE] = [0xABu8; RESHARING_SSID_SIZE];
 
 	/// Minimal transcript signer for unit tests: "signature" = party_id || hash.
-	#[derive(Clone)]
+	#[derive(Clone, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 	pub(crate) struct TestSigner {
 		pub id: u32,
 	}

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -39,7 +39,7 @@
 //! do not advance past those states until they know `Act`.
 
 use alloc::{
-	collections::BTreeMap,
+	collections::{BTreeMap, BTreeSet},
 	format,
 	string::{String, ToString},
 	vec::Vec,
@@ -2130,9 +2130,28 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	///
 	/// Only accepts partial PK contributions from parties that are actually in the new subset.
 	fn verify_public_key_preservation(&self) -> Result<(), ResharingProtocolError> {
+		// The public key is the sum of exactly one partial PK per canonical new subset
+		// (`new_subset_order`). Any other `j_mask` is not part of that sum, so we must
+		// reject it outright rather than fold it in: otherwise a new committee member could
+		// inject an extra term keyed by a non-canonical superset mask that still contains
+		// its own index bit (e.g. the full-committee mask) with an attacker-chosen
+		// `t_partial`, and use it to cancel a public-key deviation introduced by corrupted
+		// residuals — making this invariant check pass on a broken reshare.
+		let allowed_masks: BTreeSet<SubsetMask> =
+			self.new_subset_order.iter().copied().collect();
+
 		let mut canonical: BTreeMap<SubsetMask, [[i32; N as usize]; K]> = BTreeMap::new();
 		for (party, broadcast) in &self.round5_broadcasts {
 			for (j_mask, t_partial) in &broadcast.partial_pks {
+				// Reject partial PKs keyed by any mask that is not a canonical new subset.
+				// An honest party never broadcasts one; a malicious party could use it to
+				// smuggle a compensating term into the public-key sum.
+				if !allowed_masks.contains(j_mask) {
+					return Err(ResharingProtocolError::ShareVerificationFailed(format!(
+						"party {} broadcast a partial PK for non-canonical subset {:b}",
+						party, j_mask
+					)));
+				}
 				// Only accept partial PKs from parties that are in this new subset
 				if !self.config.new_participants().is_in_mask(*party, *j_mask) {
 					log::warn!(
@@ -3281,6 +3300,71 @@ mod tests {
 			.expect_err("oversized recovered partial must be rejected");
 		assert!(
 			err.to_string().contains("exceeds partial-secret norm bound"),
+			"unexpected error: {}",
+			err
+		);
+	}
+
+	#[test]
+	fn test_public_key_preservation_rejects_non_canonical_mask() {
+		// Regression test (security review): `verify_public_key_preservation` must reject a
+		// Round 5 broadcast that carries a partial PK keyed by a mask outside the canonical
+		// `new_subset_order`. Otherwise a malicious new committee member could inject an
+		// extra term keyed by a superset mask that still contains its own index bit (e.g.
+		// the full-committee mask) with an attacker-chosen `t_partial`, and use it to cancel
+		// a public-key deviation introduced by corrupted residuals — passing the invariant
+		// check on a broken reshare.
+		let config = crate::ThresholdConfig::new(2, 3).expect("valid config");
+		let (public_key, shares) =
+			crate::keygen::generate_with_dealer(&[13u8; 32], config).expect("keygen");
+		let resharing_config = ResharingConfig::new(
+			Some(shares[0].clone()),
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 2],
+			1,
+			public_key,
+		)
+		.expect("valid resharing config");
+		let protocol = ResharingProtocol::new(
+			resharing_config,
+			test_signer_config(0, &[0, 1, 2]),
+			[1u8; 32],
+			&[2u8; 32],
+			0,
+		);
+
+		// With new n = 3, threshold = 2, the canonical subsets are the size-2 masks
+		// {0b011, 0b101, 0b110}. The full-committee mask 0b111 is never canonical, yet it
+		// contains party 0's index bit, so the old `is_in_mask` gate would have accepted it.
+		let full_mask: SubsetMask = 0b111;
+		assert!(
+			!protocol.new_subset_order.contains(&full_mask),
+			"full-committee mask must not be a canonical subset"
+		);
+		assert!(protocol.config.new_participants().is_in_mask(0, full_mask));
+
+		let mut protocol = protocol;
+		let mut partial_pks: BTreeMap<SubsetMask, [[i32; N as usize]; K]> = BTreeMap::new();
+		partial_pks.insert(full_mask, [[7i32; N as usize]; K]);
+		protocol.round5_broadcasts.insert(
+			0,
+			ResharingRound5Broadcast {
+				ssid: protocol.ssid,
+				party_id: 0,
+				share_commitments: BTreeMap::new(),
+				partial_pks,
+				success: true,
+				error_message: None,
+			},
+		);
+
+		let err = protocol
+			.verify_public_key_preservation()
+			.expect_err("non-canonical partial PK mask must be rejected");
+		assert!(
+			err.to_string().contains("non-canonical subset"),
 			"unexpected error: {}",
 			err
 		);

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -2196,7 +2196,15 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			}
 		}
 		let rho = self.derive_rho();
-		let recovered = crate::protocol::partial_pk::pack_combined_pk(&rho, canonical.values());
+		// Reject partial PKs with non-canonical coefficients. An attacker-supplied
+		// coefficient near i32::MAX would otherwise overflow the i32 accumulation
+		// inside `pack_combined_pk` (panic in debug, silent wrap in release).
+		let recovered = crate::protocol::partial_pk::pack_combined_pk(&rho, canonical.values())
+			.map_err(|_| {
+				ResharingProtocolError::ShareVerificationFailed(
+					"a Round 5 partial public key contains out-of-range coefficients".to_string(),
+				)
+			})?;
 		if recovered.as_bytes() != self.config.public_key().as_bytes() {
 			return Err(ResharingProtocolError::ShareVerificationFailed(
 				"recovered public key does not match the original — a dealer corrupted at \

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -1595,7 +1595,12 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			return self.handle_accept_waiting();
 		}
 
-		let accept_hash = compute_accept_hash(&self.ssid, &transcript_hash);
+		let active_set = self.active_set.clone().ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"AcceptGenerate reached without an agreed active set".to_string(),
+			)
+		})?;
+		let accept_hash = compute_accept_hash(&self.ssid, &transcript_hash, &active_set);
 		let signature = self.signer_config.my_signer.sign(&accept_hash);
 		let my_id = self.config.my_party_id();
 		self.accepts.insert(my_id, signature.as_ref().to_vec());
@@ -1623,10 +1628,16 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			return Ok(Action::Wait);
 		}
 
+		let active_set = self.active_set.clone().ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"AcceptWaiting reached without an agreed active set".to_string(),
+			)
+		})?;
+
 		// Verify every signature against *our own* transcript hash. A signer
 		// that observed a different transcript (dealer equivocation, tampered
 		// broadcast) produces a signature that fails here, and we abort.
-		let accept_hash = compute_accept_hash(&self.ssid, &transcript_hash);
+		let accept_hash = compute_accept_hash(&self.ssid, &transcript_hash, &active_set);
 		for p in &new_participants {
 			let pk = self.signer_config.verifying_keys.get(p).ok_or_else(|| {
 				ResharingProtocolError::InternalError(format!(
@@ -1648,7 +1659,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 
 		let certificate = ResharingCertificate {
 			ssid: self.ssid,
-			active_set: self.active_set.clone().expect("set before transcript hash"),
+			active_set,
 			transcript_hash,
 			accepts: self.accepts.clone(),
 		};

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -2148,8 +2148,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		// its own index bit (e.g. the full-committee mask) with an attacker-chosen
 		// `t_partial`, and use it to cancel a public-key deviation introduced by corrupted
 		// residuals — making this invariant check pass on a broken reshare.
-		let allowed_masks: BTreeSet<SubsetMask> =
-			self.new_subset_order.iter().copied().collect();
+		let allowed_masks: BTreeSet<SubsetMask> = self.new_subset_order.iter().copied().collect();
 
 		let mut canonical: BTreeMap<SubsetMask, [[i32; N as usize]; K]> = BTreeMap::new();
 		for (party, broadcast) in &self.round5_broadcasts {
@@ -3382,11 +3381,7 @@ mod tests {
 		let err = protocol
 			.verify_public_key_preservation()
 			.expect_err("non-canonical partial PK mask must be rejected");
-		assert!(
-			err.to_string().contains("non-canonical subset"),
-			"unexpected error: {}",
-			err
-		);
+		assert!(err.to_string().contains("non-canonical subset"), "unexpected error: {}", err);
 	}
 
 	#[test]

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -625,9 +625,10 @@ pub const MAX_ACCEPT_SIGNATURE_LEN: usize = 8192;
 /// causes signature verification to fail on at least one honest party, which
 /// then aborts.
 ///
-/// The signature is over `SHAKE256("resharing-accept-v1" || ssid ||
-/// transcript_hash)`, domain-separating acceptances from any other use of the
-/// same long-term key.
+/// The signature is over `SHAKE256("resharing-accept-v2" || ssid ||
+/// transcript_hash || len(active_set) || active_set)` (see
+/// [`compute_accept_hash`]), domain-separating acceptances from any other use
+/// of the same long-term key and binding the certificate's `active_set`.
 #[derive(Debug, Clone, BorshSerialize)]
 pub struct ResharingAccept {
 	/// Session identifier binding this message to the resharing session.
@@ -773,7 +774,8 @@ impl ResharingCertificate {
 		new_participants: &[ParticipantId],
 		verifying_keys: &BTreeMap<ParticipantId, S::PublicKey>,
 	) -> bool {
-		let accept_hash = compute_accept_hash(&self.ssid, &self.transcript_hash);
+		let accept_hash =
+			compute_accept_hash(&self.ssid, &self.transcript_hash, &self.active_set);
 		new_participants
 			.iter()
 			.all(|p| match (verifying_keys.get(p), self.accepts.get(p)) {
@@ -784,19 +786,39 @@ impl ResharingCertificate {
 }
 
 /// Domain separator for the acceptance hash.
-const ACCEPT_DOMAIN: &[u8] = b"resharing-accept-v1";
+///
+/// Bumped to v2 when `active_set` was folded into the hash; a v1 signature can
+/// therefore never be reinterpreted as a v2 acceptance.
+const ACCEPT_DOMAIN: &[u8] = b"resharing-accept-v2";
 
 /// Compute the 32-byte hash that new committee members sign to accept the
-/// session transcript: `SHAKE256("resharing-accept-v1" || ssid || transcript_hash)`.
+/// session transcript:
+/// `SHAKE256("resharing-accept-v2" || ssid || transcript_hash || len(active_set) || active_set)`.
+///
+/// `active_set` is bound directly (in addition to being committed inside
+/// `transcript_hash`) so that a party holding *only* the certificate — which
+/// cannot recompute `transcript_hash` from the full transcript — still
+/// authenticates the certificate's explicit `active_set` field. Without this,
+/// `active_set` could be rewritten while `ssid`/`transcript_hash`/`accepts`
+/// stayed valid, and the tampered certificate would still verify.
+///
+/// Callers pass `active_set` in the same order stored in the certificate
+/// (the protocol keeps it strictly sorted), so honest signers and verifiers
+/// hash an identical byte string.
 pub fn compute_accept_hash(
 	ssid: &[u8; RESHARING_SSID_SIZE],
 	transcript_hash: &[u8; COMMITMENT_HASH_SIZE],
+	active_set: &[ParticipantId],
 ) -> [u8; 32] {
 	use qp_rusty_crystals_dilithium::fips202;
 	let mut state = fips202::KeccakState::default();
 	fips202::shake256_absorb(&mut state, ACCEPT_DOMAIN);
 	fips202::shake256_absorb(&mut state, ssid);
 	fips202::shake256_absorb(&mut state, transcript_hash);
+	fips202::shake256_absorb(&mut state, &(active_set.len() as u32).to_le_bytes());
+	for &p in active_set {
+		fips202::shake256_absorb(&mut state, &p.to_le_bytes());
+	}
 	fips202::shake256_finalize(&mut state);
 	let mut out = [0u8; 32];
 	fips202::shake256_squeeze(&mut out, &mut state);

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -650,8 +650,10 @@ impl BorshDeserialize for ResharingAccept {
 				"ResharingAccept.signature exceeds MAX_ACCEPT_SIGNATURE_LEN",
 			));
 		}
-		let mut signature = alloc::vec![0u8; sig_len];
-		reader.read_exact(&mut signature)?;
+		// Chunked read: don't allocate the claimed length up front, so a
+		// truncated body cannot force an allocation larger than what was
+		// actually delivered (same pattern as the certificate accepts).
+		let signature = crate::broadcast::read_length_prefixed(reader, sig_len)?;
 		Ok(Self { ssid, party_id, signature })
 	}
 }
@@ -1908,5 +1910,43 @@ mod tests {
 
 		let result: Result<ResharingCertificate, _> = borsh::from_slice(&payload);
 		assert!(result.is_err(), "accepts exceeding MAX_PARTIES must be rejected");
+	}
+
+	/// Regression test (security review): a `ResharingAccept` whose signature
+	/// length prefix claims the maximum but whose body is truncated must fail
+	/// deserialization without allocating the full claimed length up front
+	/// (the chunked `read_length_prefixed` path, mirroring the certificate
+	/// accepts and Round 2/3 broadcasts).
+	#[test]
+	fn test_resharing_accept_rejects_truncated_signature() {
+		// Honest round-trip still works.
+		let accept = ResharingAccept {
+			ssid: TEST_SSID,
+			party_id: 3,
+			signature: alloc::vec![0xAAu8; 4627],
+		};
+		let bytes = borsh::to_vec(&accept).unwrap();
+		let back: ResharingAccept = borsh::from_slice(&bytes).unwrap();
+		assert_eq!(back.party_id, accept.party_id);
+		assert_eq!(back.signature, accept.signature);
+
+		// Claim the maximum signature length but deliver only a few bytes.
+		let mut payload = Vec::new();
+		payload.extend_from_slice(&TEST_SSID); // ssid
+		payload.extend_from_slice(&3u32.to_le_bytes()); // party_id
+		payload.extend_from_slice(&(MAX_ACCEPT_SIGNATURE_LEN as u32).to_le_bytes()); // claimed len
+		payload.extend_from_slice(&[0xBBu8; 8]); // truncated body
+
+		let result: Result<ResharingAccept, _> = borsh::from_slice(&payload);
+		assert!(result.is_err(), "truncated accept signature must be rejected");
+
+		// A length above the maximum is rejected outright.
+		let mut oversized = Vec::new();
+		oversized.extend_from_slice(&TEST_SSID);
+		oversized.extend_from_slice(&3u32.to_le_bytes());
+		oversized.extend_from_slice(&((MAX_ACCEPT_SIGNATURE_LEN + 1) as u32).to_le_bytes());
+
+		let result: Result<ResharingAccept, _> = borsh::from_slice(&oversized);
+		assert!(result.is_err(), "oversized accept signature length must be rejected");
 	}
 }

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -776,8 +776,7 @@ impl ResharingCertificate {
 		new_participants: &[ParticipantId],
 		verifying_keys: &BTreeMap<ParticipantId, S::PublicKey>,
 	) -> bool {
-		let accept_hash =
-			compute_accept_hash(&self.ssid, &self.transcript_hash, &self.active_set);
+		let accept_hash = compute_accept_hash(&self.ssid, &self.transcript_hash, &self.active_set);
 		new_participants
 			.iter()
 			.all(|p| match (verifying_keys.get(p), self.accepts.get(p)) {
@@ -1920,11 +1919,8 @@ mod tests {
 	#[test]
 	fn test_resharing_accept_rejects_truncated_signature() {
 		// Honest round-trip still works.
-		let accept = ResharingAccept {
-			ssid: TEST_SSID,
-			party_id: 3,
-			signature: alloc::vec![0xAAu8; 4627],
-		};
+		let accept =
+			ResharingAccept { ssid: TEST_SSID, party_id: 3, signature: alloc::vec![0xAAu8; 4627] };
 		let bytes = borsh::to_vec(&accept).unwrap();
 		let back: ResharingAccept = borsh::from_slice(&bytes).unwrap();
 		assert_eq!(back.party_id, accept.party_id);

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -700,7 +700,7 @@ impl<S: crate::keygen::dkg::TranscriptSigner> ResharingSignerConfig<S> {
 /// material. A verifier that additionally holds the broadcast transcript can
 /// recompute `transcript_hash` and the `Σ_J t_J^new = T` public-key check
 /// independently.
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize)]
 pub struct ResharingCertificate {
 	/// Session identifier of the completed session.
 	pub ssid: [u8; RESHARING_SSID_SIZE],
@@ -712,6 +712,52 @@ pub struct ResharingCertificate {
 	/// Acceptance signatures from every new committee member, keyed by
 	/// participant ID.
 	pub accepts: BTreeMap<ParticipantId, Vec<u8>>,
+}
+
+impl BorshDeserialize for ResharingCertificate {
+	fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+		let ssid = <[u8; RESHARING_SSID_SIZE]>::deserialize_reader(reader)?;
+
+		// active_set is at most one entry per old committee member.
+		let active_len = u32::deserialize_reader(reader)? as usize;
+		if active_len > MAX_PARTIES as usize {
+			return Err(borsh::io::Error::new(
+				borsh::io::ErrorKind::InvalidData,
+				"ResharingCertificate.active_set exceeds MAX_PARTIES",
+			));
+		}
+		let mut active_set = Vec::with_capacity(active_len);
+		for _ in 0..active_len {
+			active_set.push(ParticipantId::deserialize_reader(reader)?);
+		}
+
+		let transcript_hash = <[u8; COMMITMENT_HASH_SIZE]>::deserialize_reader(reader)?;
+
+		// accepts holds at most one signature per new committee member.
+		let accepts_len = u32::deserialize_reader(reader)? as usize;
+		if accepts_len > MAX_PARTIES as usize {
+			return Err(borsh::io::Error::new(
+				borsh::io::ErrorKind::InvalidData,
+				"ResharingCertificate.accepts exceeds MAX_PARTIES",
+			));
+		}
+		let mut accepts = BTreeMap::new();
+		for _ in 0..accepts_len {
+			let party_id = ParticipantId::deserialize_reader(reader)?;
+			let sig_len = u32::deserialize_reader(reader)? as usize;
+			if sig_len > MAX_ACCEPT_SIGNATURE_LEN {
+				return Err(borsh::io::Error::new(
+					borsh::io::ErrorKind::InvalidData,
+					"ResharingCertificate accept signature exceeds MAX_ACCEPT_SIGNATURE_LEN",
+				));
+			}
+			// Read incrementally rather than pre-allocating the claimed length.
+			let signature = crate::broadcast::read_length_prefixed(reader, sig_len)?;
+			accepts.insert(party_id, signature);
+		}
+
+		Ok(Self { ssid, active_set, transcript_hash, accepts })
+	}
 }
 
 impl ResharingCertificate {
@@ -1772,5 +1818,64 @@ mod tests {
 			&nonce,
 		);
 		assert_ne!(base(0), other_suite, "suite must change the SSID");
+	}
+
+	#[test]
+	fn test_resharing_certificate_roundtrip_within_bounds() {
+		let mut accepts = BTreeMap::new();
+		accepts.insert(1u32, alloc::vec![9u8; 16]);
+		accepts.insert(2u32, alloc::vec![3u8; 4627]);
+
+		let cert = ResharingCertificate {
+			ssid: TEST_SSID,
+			active_set: alloc::vec![0, 1, 2],
+			transcript_hash: [7u8; COMMITMENT_HASH_SIZE],
+			accepts,
+		};
+
+		let bytes = borsh::to_vec(&cert).unwrap();
+		let back: ResharingCertificate = borsh::from_slice(&bytes).unwrap();
+		assert_eq!(back.active_set, cert.active_set);
+		assert_eq!(back.accepts, cert.accepts);
+		assert_eq!(back.transcript_hash, cert.transcript_hash);
+	}
+
+	/// A fully-present certificate whose `active_set` count exceeds `MAX_PARTIES`
+	/// must be rejected. Before the bounded deserializer this parsed successfully
+	/// (borsh would happily build the oversized collection).
+	#[test]
+	fn test_resharing_certificate_rejects_oversized_active_set() {
+		let huge = MAX_PARTIES + 100;
+
+		let mut payload = Vec::new();
+		payload.extend_from_slice(&[0u8; RESHARING_SSID_SIZE]); // ssid
+		payload.extend_from_slice(&huge.to_le_bytes()); // active_set len
+		for i in 0..huge {
+			payload.extend_from_slice(&i.to_le_bytes()); // ParticipantId entries
+		}
+		payload.extend_from_slice(&[0u8; COMMITMENT_HASH_SIZE]); // transcript_hash
+		payload.extend_from_slice(&0u32.to_le_bytes()); // accepts len = 0
+
+		let result: Result<ResharingCertificate, _> = borsh::from_slice(&payload);
+		assert!(result.is_err(), "active_set exceeding MAX_PARTIES must be rejected");
+	}
+
+	/// Same, for the `accepts` map count.
+	#[test]
+	fn test_resharing_certificate_rejects_oversized_accepts() {
+		let huge = MAX_PARTIES + 50;
+
+		let mut payload = Vec::new();
+		payload.extend_from_slice(&[0u8; RESHARING_SSID_SIZE]); // ssid
+		payload.extend_from_slice(&0u32.to_le_bytes()); // active_set len = 0
+		payload.extend_from_slice(&[0u8; COMMITMENT_HASH_SIZE]); // transcript_hash
+		payload.extend_from_slice(&huge.to_le_bytes()); // accepts len
+		for i in 0..huge {
+			payload.extend_from_slice(&i.to_le_bytes()); // key: ParticipantId
+			payload.extend_from_slice(&0u32.to_le_bytes()); // value: empty signature
+		}
+
+		let result: Result<ResharingCertificate, _> = borsh::from_slice(&payload);
+		assert!(result.is_err(), "accepts exceeding MAX_PARTIES must be rejected");
 	}
 }

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -1028,17 +1028,24 @@ impl NewShareData {
 	///
 	/// Returns `true` if all coefficients satisfy `|coeff| <= bound`.
 	/// This is used to reject malicious sub-shares with excessively large coefficients.
+	///
+	/// The magnitude is computed with [`i32::unsigned_abs`], which returns a
+	/// `u32` and therefore handles `i32::MIN` correctly. Using `i32::abs` here
+	/// would panic on `i32::MIN` in overflow-checking builds and, worse, wrap
+	/// back to a negative value in release builds — letting a dealer's
+	/// `i32::MIN` coefficient slip past this trust-boundary check.
 	pub fn coefficients_within_bound(&self, bound: i32) -> bool {
+		let bound = bound.max(0) as u32;
 		for poly in &self.s1 {
 			for &coeff in poly {
-				if coeff.abs() > bound {
+				if coeff.unsigned_abs() > bound {
 					return false;
 				}
 			}
 		}
 		for poly in &self.s2 {
 			for &coeff in poly {
-				if coeff.abs() > bound {
+				if coeff.unsigned_abs() > bound {
 					return false;
 				}
 			}
@@ -1048,17 +1055,19 @@ impl NewShareData {
 
 	/// Find the maximum absolute coefficient value.
 	///
-	/// Useful for debugging and diagnostics.
-	pub fn max_abs_coefficient(&self) -> i32 {
-		let mut max_abs = 0i32;
+	/// Useful for debugging and diagnostics. Returns a `u32` because the
+	/// magnitude of `i32::MIN` (2_147_483_648) does not fit in an `i32`; the
+	/// magnitude is computed with the non-overflowing [`i32::unsigned_abs`].
+	pub fn max_abs_coefficient(&self) -> u32 {
+		let mut max_abs = 0u32;
 		for poly in &self.s1 {
 			for &coeff in poly {
-				max_abs = max_abs.max(coeff.abs());
+				max_abs = max_abs.max(coeff.unsigned_abs());
 			}
 		}
 		for poly in &self.s2 {
 			for &coeff in poly {
-				max_abs = max_abs.max(coeff.abs());
+				max_abs = max_abs.max(coeff.unsigned_abs());
 			}
 		}
 		max_abs

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -628,9 +628,9 @@ impl ThresholdSigner {
 	) -> ThresholdResult<()> {
 		let expected_others = round2_data.active_participants.len().saturating_sub(1);
 		if other_round2.len() != expected_others {
-			return Err(ThresholdError::WrongPartyCount {
+			return Err(ThresholdError::RevealSetMismatch {
 				provided: other_round2.len() + 1,
-				required: round2_data.active_participants.len() as u32,
+				expected: round2_data.active_participants.len() as u32,
 			});
 		}
 		for other in round2_data.active_participants.others(me) {

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -454,7 +454,16 @@ impl ThresholdSigner {
 		let single_commitment_size = 8 * 736; // K * POLY_Q_SIZE
 		let expected_len = k * single_commitment_size;
 
+		// Reject duplicate reveals up front: replaying one party's Round 2 broadcast
+		// must never be counted twice, or the aggregate (and thus the challenge
+		// material for the response) would be silently corrupted.
+		let mut seen_parties: BTreeSet<u32> = BTreeSet::new();
+
 		for r2 in other_round2 {
+			if !seen_parties.insert(r2.party_id) {
+				return Err(ThresholdError::DuplicateBroadcast { party_id: r2.party_id });
+			}
+
 			// Empty commitment_data is NOT allowed - every participant must contribute.
 			// Allowing empty data would let an attacker bypass commitment binding.
 			if r2.commitment_data.is_empty() {
@@ -504,16 +513,46 @@ impl ThresholdSigner {
 			});
 		}
 
-		// Aggregate commitments into round2_data (mutable borrow scope)
+		// Aggregate commitments without mutating persistent state until every reveal
+		// is validated and unpacked. Two properties are enforced here:
+		//
+		// 1. The reveal set must be *exactly* the participants recorded during Round 2
+		//    — no missing, no extra, no duplicate parties. Duplicates were rejected
+		//    above; combined with the exact-count and all-expected-present checks
+		//    below, this pins the reveal set to the session set (an unexpected party
+		//    would force either a duplicate or a missing expected party).
+		// 2. The aggregate is built in a local buffer and only committed once all
+		//    reveals unpack successfully. A malformed-but-hash-bound reveal that fails
+		//    mid-stream therefore leaves `w_aggregated` untouched, so the signer stays
+		//    in a clean AfterRound2 state that a corrected retry can aggregate exactly
+		//    once (rather than double-counting earlier reveals).
 		{
+			let me = self.private_key.party_id();
 			let round2_data =
-				self.state.round2_data.as_mut().ok_or(ThresholdError::InvalidState {
+				self.state.round2_data.as_ref().ok_or(ThresholdError::InvalidState {
 					current: "AfterRound2", // phase already validated above
 					expected: "AfterRound2",
 				})?;
 
+			// Exactly one reveal per other participant recorded at Round 2.
+			let expected_others = round2_data.active_participants.len().saturating_sub(1);
+			if other_round2.len() != expected_others {
+				return Err(ThresholdError::WrongPartyCount {
+					provided: other_round2.len() + 1,
+					required: round2_data.active_participants.len() as u32,
+				});
+			}
+			for other in round2_data.active_participants.others(me) {
+				if !seen_parties.contains(&other) {
+					return Err(ThresholdError::MissingBroadcast { party_id: other });
+				}
+			}
+
+			// Build the aggregate locally (temporary validated state); commit only on
+			// full success so a failed unpack cannot leave partially-mutated state.
+			let mut aggregated = round2_data.w_aggregated.clone();
 			for r2 in other_round2 {
-				for k_idx in 0..k {
+				for (k_idx, agg) in aggregated.iter_mut().take(k).enumerate() {
 					let start = k_idx * single_commitment_size;
 					let end = start + single_commitment_size;
 
@@ -525,9 +564,16 @@ impl ThresholdSigner {
 								k_idx, e
 							),
 						})?;
-					aggregate_commitments_dilithium(&mut round2_data.w_aggregated[k_idx], &w_other);
+					aggregate_commitments_dilithium(agg, &w_other);
 				}
 			}
+
+			// All reveals validated and unpacked: commit the aggregate atomically.
+			self.state
+				.round2_data
+				.as_mut()
+				.expect("round2_data present in AfterRound2")
+				.w_aggregated = aggregated;
 		}
 
 		// Get immutable references for response generation

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -177,10 +177,7 @@ impl SignerState {
 		}
 		let err =
 			|| ThresholdError::InvalidState { current: self.phase_name(), expected: "AfterRound2" };
-		Ok((
-			self.round1_data.as_ref().ok_or_else(err)?,
-			self.round2_data.as_ref().ok_or_else(err)?,
-		))
+		Ok((self.round1_data.as_ref().ok_or_else(err)?, self.round2_data.as_ref().ok_or_else(err)?))
 	}
 
 	/// Verify AfterRound3 phase and return (round2_data, my_responses, message, context).
@@ -474,12 +471,8 @@ impl ThresholdSigner {
 
 		// Validate all reveals against their Round 1 commitments before touching
 		// any state (duplicates, sizes, hash binding).
-		let seen_parties = Self::validate_reveals_against_commitments(
-			ssid,
-			other_round1,
-			other_round2,
-			k,
-		)?;
+		let seen_parties =
+			Self::validate_reveals_against_commitments(ssid, other_round1, other_round2, k)?;
 
 		// Check state
 		if self.state.phase != SigningPhase::AfterRound2 {
@@ -492,15 +485,13 @@ impl ThresholdSigner {
 		// Aggregate commitments without mutating persistent state until every reveal
 		// is validated and unpacked. Two properties are enforced here:
 		//
-		// 1. The reveal set must be *exactly* the participants recorded during Round 2
-		//    — no missing, no extra, no duplicate parties (see
-		//    `check_reveal_set_exact`).
-		// 2. Every reveal is fully validated *before* the first write to persistent
-		//    state (validate-then-commit; see `validate_reveals_unpack` /
-		//    `aggregate_reveals`). A malformed-but-hash-bound reveal therefore
-		//    leaves `w_aggregated` untouched, so the signer stays in a clean
-		//    AfterRound2 state that a corrected retry can aggregate exactly once
-		//    (rather than double-counting earlier reveals).
+		// 1. The reveal set must be *exactly* the participants recorded during Round 2 — no
+		//    missing, no extra, no duplicate parties (see `check_reveal_set_exact`).
+		// 2. Every reveal is fully validated *before* the first write to persistent state
+		//    (validate-then-commit; see `validate_reveals_unpack` / `aggregate_reveals`). A
+		//    malformed-but-hash-bound reveal therefore leaves `w_aggregated` untouched, so the
+		//    signer stays in a clean AfterRound2 state that a corrected retry can aggregate exactly
+		//    once (rather than double-counting earlier reveals).
 		{
 			let me = self.private_key.party_id();
 			let round2_data =

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -521,11 +521,11 @@ impl ThresholdSigner {
 		//    above; combined with the exact-count and all-expected-present checks
 		//    below, this pins the reveal set to the session set (an unexpected party
 		//    would force either a duplicate or a missing expected party).
-		// 2. The aggregate is built in a local buffer and only committed once all
-		//    reveals unpack successfully. A malformed-but-hash-bound reveal that fails
-		//    mid-stream therefore leaves `w_aggregated` untouched, so the signer stays
-		//    in a clean AfterRound2 state that a corrected retry can aggregate exactly
-		//    once (rather than double-counting earlier reveals).
+		// 2. Every reveal is fully validated *before* the first write to persistent
+		//    state (validate-then-commit). A malformed-but-hash-bound reveal therefore
+		//    leaves `w_aggregated` untouched, so the signer stays in a clean
+		//    AfterRound2 state that a corrected retry can aggregate exactly once
+		//    (rather than double-counting earlier reveals).
 		{
 			let me = self.private_key.party_id();
 			let round2_data =
@@ -548,32 +548,45 @@ impl ThresholdSigner {
 				}
 			}
 
-			// Build the aggregate locally (temporary validated state); commit only on
-			// full success so a failed unpack cannot leave partially-mutated state.
-			let mut aggregated = round2_data.w_aggregated.clone();
+			// Pass 1 (validate): unpack every chunk of every reveal, holding at most
+			// one transient Polyveck at a time. No persistent state is touched, so a
+			// failure here is a clean rejection. This deliberately avoids cloning the
+			// whole existing aggregate as a scratch buffer: for large k_iterations
+			// (e.g. k=1600 for 4-of-6) that clone roughly doubled peak memory during
+			// Round 3 (tens of MB), whereas re-unpacking in the commit pass below
+			// costs only a second run of cheap bit-unpacking.
 			for r2 in other_round2 {
-				for (k_idx, agg) in aggregated.iter_mut().take(k).enumerate() {
+				for k_idx in 0..k {
 					let start = k_idx * single_commitment_size;
 					let end = start + single_commitment_size;
 
-					let w_other = unpack_commitment_dilithium(&r2.commitment_data[start..end])
-						.map_err(|e| ThresholdError::InvalidCommitmentData {
+					unpack_commitment_dilithium(&r2.commitment_data[start..end]).map_err(
+						|e| ThresholdError::InvalidCommitmentData {
 							party_id: r2.party_id,
 							reason: format!(
 								"Commitment passed hash check but failed to unpack (k={}): {}",
 								k_idx, e
 							),
-						})?;
-					aggregate_commitments_dilithium(agg, &w_other);
+						},
+					)?;
 				}
 			}
 
-			// All reveals validated and unpacked: commit the aggregate atomically.
-			self.state
-				.round2_data
-				.as_mut()
-				.expect("round2_data present in AfterRound2")
-				.w_aggregated = aggregated;
+			// Pass 2 (commit): aggregate directly into persistent state, in place.
+			// Unpacking is deterministic over the same bytes, so after pass 1
+			// succeeded it cannot fail here — the commit is all-or-nothing.
+			let round2_data =
+				self.state.round2_data.as_mut().expect("round2_data present in AfterRound2");
+			for r2 in other_round2 {
+				for (k_idx, agg) in round2_data.w_aggregated.iter_mut().take(k).enumerate() {
+					let start = k_idx * single_commitment_size;
+					let end = start + single_commitment_size;
+
+					let w_other = unpack_commitment_dilithium(&r2.commitment_data[start..end])
+						.expect("chunk validated in pass 1; unpack is deterministic");
+					aggregate_commitments_dilithium(agg, &w_other);
+				}
+			}
 		}
 
 		// Get immutable references for response generation
@@ -852,5 +865,72 @@ mod tests {
 		// A normal-sized message is still accepted (state advances to Round 2).
 		let ok = s0.round2_reveal(&ssid, b"hello", b"", core::slice::from_ref(&r1_1));
 		assert!(ok.is_ok(), "in-bounds message must still be accepted: {ok:?}");
+	}
+
+	/// Regression test for the validate-then-commit property of
+	/// `round3_respond` (preserved across the removal of the full aggregate
+	/// clone): a reveal that passes the commitment-hash check but fails to
+	/// unpack must be rejected *without* mutating `w_aggregated`, so a
+	/// corrected retry produces exactly the same response as a signer that
+	/// never saw the malformed attempt.
+	#[test]
+	fn test_round3_malformed_reveal_leaves_state_clean_for_retry() {
+		use crate::{
+			broadcast::{Round1Broadcast, Round2Broadcast},
+			generate_with_dealer,
+			protocol::signing::compute_commitment_hash,
+		};
+
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[9u8; 32], config).unwrap();
+
+		let mut s0 = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
+		let mut s1 = ThresholdSigner::new(shares[1].clone(), pk.clone(), config).unwrap();
+		// Control signer: identical to s0 (same share, same seeds) but never
+		// fed the malformed reveal.
+		let mut c0 = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
+
+		let ssid = [0x5Au8; 32];
+		let r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+		let r1_1 = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
+		let r1_c = c0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+		assert_eq!(r1_0, r1_c, "control signer must mirror s0 exactly");
+
+		let msg = b"atomicity";
+		let ctx = b"";
+		s0.round2_reveal(&ssid, msg, ctx, core::slice::from_ref(&r1_1)).unwrap();
+		c0.round2_reveal(&ssid, msg, ctx, core::slice::from_ref(&r1_1)).unwrap();
+		let r2_1 = s1.round2_reveal(&ssid, msg, ctx, core::slice::from_ref(&r1_0)).unwrap();
+
+		// Forge a malformed-but-hash-bound reveal from party 1: correct length,
+		// bound to a matching (forged) Round 1 hash, but every 23-bit
+		// coefficient is 2^23 - 1 >= Q, so unpacking fails.
+		let k = config.k_iterations() as usize;
+		let garbage = alloc::vec![0xFFu8; k * 8 * 736];
+		let forged_hash = compute_commitment_hash(&ssid, 1, &garbage);
+		let fake_r1 = Round1Broadcast::new(ssid, 1, forged_hash);
+		let fake_r2 = Round2Broadcast::new(ssid, 1, garbage);
+
+		let err = s0
+			.round3_respond(&ssid, core::slice::from_ref(&fake_r1), core::slice::from_ref(&fake_r2))
+			.expect_err("hash-bound but malformed reveal must be rejected");
+		assert!(
+			matches!(err, ThresholdError::InvalidCommitmentData { party_id: 1, .. }),
+			"expected InvalidCommitmentData for party 1, got {err:?}"
+		);
+
+		// The corrected retry must succeed and match the control signer's
+		// response byte-for-byte: any residue from the failed attempt (e.g. a
+		// partially-applied aggregate) would change the challenge material.
+		let r3_retry = s0
+			.round3_respond(&ssid, core::slice::from_ref(&r1_1), core::slice::from_ref(&r2_1))
+			.expect("corrected retry must succeed after a rejected reveal");
+		let r3_control = c0
+			.round3_respond(&ssid, core::slice::from_ref(&r1_1), core::slice::from_ref(&r2_1))
+			.expect("control signer round 3");
+		assert_eq!(
+			r3_retry, r3_control,
+			"retry after rejected reveal must match a signer that never saw it"
+		);
 	}
 }

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -817,4 +817,40 @@ mod tests {
 			Ok(_) => panic!("Should reject public key with TR not matching private key TR"),
 		}
 	}
+
+	/// The direct signer must enforce the ML-DSA `MAX_MESSAGE_SIZE` bound before
+	/// hashing/cloning the message, matching the higher-level
+	/// `DilithiumSignProtocol` guard. Without the check, `round2_reveal` would
+	/// hash an oversized buffer and retain it in state to produce a signature
+	/// that verification then rejects.
+	#[test]
+	fn test_round2_reveal_rejects_oversized_message() {
+		use qp_rusty_crystals_dilithium::ml_dsa_87::MAX_MESSAGE_SIZE;
+
+		use crate::generate_with_dealer;
+
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[7u8; 32], config).unwrap();
+
+		let mut s0 = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
+		let mut s1 = ThresholdSigner::new(shares[1].clone(), pk.clone(), config).unwrap();
+
+		let ssid = [0u8; 32];
+		let _r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+		let r1_1 = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
+
+		// One byte over the ML-DSA limit: rejected before any expensive work.
+		let oversized = alloc::vec![0u8; MAX_MESSAGE_SIZE + 1];
+		let err = s0
+			.round2_reveal(&ssid, &oversized, b"", core::slice::from_ref(&r1_1))
+			.expect_err("oversized message must be rejected");
+		assert!(
+			matches!(err, ThresholdError::MessageTooLong { length } if length == MAX_MESSAGE_SIZE + 1),
+			"expected MessageTooLong, got {err:?}"
+		);
+
+		// A normal-sized message is still accepted (state advances to Round 2).
+		let ok = s0.round2_reveal(&ssid, b"hello", b"", core::slice::from_ref(&r1_1));
+		assert!(ok.is_ok(), "in-bounds message must still be accepted: {ok:?}");
+	}
 }

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -54,6 +54,11 @@ use crate::{
 	},
 };
 
+/// Packed size in bytes of one commitment (one `Polyveck` of K polynomials,
+/// 736 bytes each in the 23-bit encoding). Round 2 commitment data is
+/// `k_iterations` of these, concatenated.
+const SINGLE_COMMITMENT_SIZE: usize = 8 * 736; // K * POLY_Q_SIZE
+
 /// A threshold signer for a single party.
 ///
 /// Each party in the threshold scheme creates one `ThresholdSigner` with their
@@ -160,6 +165,22 @@ impl SignerState {
 			current: self.phase_name(),
 			expected: "AfterRound1",
 		})
+	}
+
+	/// Verify AfterRound2 phase and return (round1_data, round2_data).
+	fn expect_round2(&self) -> ThresholdResult<(&Round1Data, &Round2Data)> {
+		if self.phase != SigningPhase::AfterRound2 {
+			return Err(ThresholdError::InvalidState {
+				current: self.phase_name(),
+				expected: "AfterRound2",
+			});
+		}
+		let err =
+			|| ThresholdError::InvalidState { current: self.phase_name(), expected: "AfterRound2" };
+		Ok((
+			self.round1_data.as_ref().ok_or_else(err)?,
+			self.round2_data.as_ref().ok_or_else(err)?,
+		))
 	}
 
 	/// Verify AfterRound3 phase and return (round2_data, my_responses, message, context).
@@ -449,14 +470,99 @@ impl ThresholdSigner {
 		other_round1: &[Round1Broadcast],
 		other_round2: &[Round2Broadcast],
 	) -> ThresholdResult<Round3Broadcast> {
-		// Validate inputs first (before state mutation)
 		let k = self.config.k_iterations() as usize;
-		let single_commitment_size = 8 * 736; // K * POLY_Q_SIZE
-		let expected_len = k * single_commitment_size;
 
-		// Reject duplicate reveals up front: replaying one party's Round 2 broadcast
-		// must never be counted twice, or the aggregate (and thus the challenge
-		// material for the response) would be silently corrupted.
+		// Validate all reveals against their Round 1 commitments before touching
+		// any state (duplicates, sizes, hash binding).
+		let seen_parties = Self::validate_reveals_against_commitments(
+			ssid,
+			other_round1,
+			other_round2,
+			k,
+		)?;
+
+		// Check state
+		if self.state.phase != SigningPhase::AfterRound2 {
+			return Err(ThresholdError::InvalidState {
+				current: self.state.phase_name(),
+				expected: "AfterRound2",
+			});
+		}
+
+		// Aggregate commitments without mutating persistent state until every reveal
+		// is validated and unpacked. Two properties are enforced here:
+		//
+		// 1. The reveal set must be *exactly* the participants recorded during Round 2
+		//    — no missing, no extra, no duplicate parties (see
+		//    `check_reveal_set_exact`).
+		// 2. Every reveal is fully validated *before* the first write to persistent
+		//    state (validate-then-commit; see `validate_reveals_unpack` /
+		//    `aggregate_reveals`). A malformed-but-hash-bound reveal therefore
+		//    leaves `w_aggregated` untouched, so the signer stays in a clean
+		//    AfterRound2 state that a corrected retry can aggregate exactly once
+		//    (rather than double-counting earlier reveals).
+		{
+			let me = self.private_key.party_id();
+			let round2_data =
+				self.state.round2_data.as_mut().ok_or(ThresholdError::InvalidState {
+					current: "AfterRound2", // phase already validated above
+					expected: "AfterRound2",
+				})?;
+
+			Self::check_reveal_set_exact(round2_data, me, other_round2, &seen_parties)?;
+			Self::validate_reveals_unpack(other_round2, k)?;
+
+			if Self::aggregate_reveals(round2_data, other_round2, k).is_err() {
+				// Defensive, believed unreachable: the same bytes unpacked
+				// successfully in `validate_reveals_unpack`. The aggregate may now
+				// be partially mutated, so returning an error alone would let a
+				// retry double-aggregate the committed reveals. Reset the signing
+				// session instead: the caller must restart from Round 1, which
+				// re-derives a clean aggregate.
+				self.state = SignerState::default();
+				return Err(ThresholdError::InvalidData(
+					"Round 3 aggregation failed after validation (logic bug); \
+					 signing session reset — restart from Round 1"
+						.to_string(),
+				));
+			}
+		}
+
+		// Generate the response from the committed aggregate.
+		let (round1_data, round2_data) = self.state.expect_round2()?;
+		let responses =
+			generate_round3_response(&self.private_key, &self.config, round1_data, round2_data)?;
+
+		// Pack responses for broadcast
+		let packed_response = pack_responses(&responses);
+		let broadcast = Round3Broadcast::new(*ssid, self.private_key.party_id(), packed_response);
+
+		// Update state - clear round1_data as it's no longer needed
+		// (dropping the Option zeroizes its contents via ZeroizeOnDrop).
+		self.state.my_responses = Some(responses);
+		self.state.round1_data = None;
+		self.state.phase = SigningPhase::AfterRound3;
+
+		Ok(broadcast)
+	}
+
+	/// Validate Round 2 reveals against their Round 1 commitments: reject
+	/// duplicate reveals, empty or mis-sized commitment data, reveals without a
+	/// matching Round 1 broadcast, and reveals whose data does not hash to the
+	/// Round 1 commitment. Touches no state; returns the set of revealing
+	/// party IDs for the exact-set check.
+	///
+	/// Rejecting duplicates up front matters because replaying one party's
+	/// Round 2 broadcast must never be counted twice, or the aggregate (and
+	/// thus the challenge material for the response) would be silently
+	/// corrupted.
+	fn validate_reveals_against_commitments(
+		ssid: &[u8; 32],
+		other_round1: &[Round1Broadcast],
+		other_round2: &[Round2Broadcast],
+		k: usize,
+	) -> ThresholdResult<BTreeSet<u32>> {
+		let expected_len = k * SINGLE_COMMITMENT_SIZE;
 		let mut seen_parties: BTreeSet<u32> = BTreeSet::new();
 
 		for r2 in other_round2 {
@@ -505,133 +611,89 @@ impl ThresholdSigner {
 			}
 		}
 
-		// Check state
-		if self.state.phase != SigningPhase::AfterRound2 {
-			return Err(ThresholdError::InvalidState {
-				current: self.state.phase_name(),
-				expected: "AfterRound2",
+		Ok(seen_parties)
+	}
+
+	/// Check that the reveal set is *exactly* the other participants recorded
+	/// during Round 2 — no missing, no extra. Duplicates were already rejected
+	/// while building `seen_parties`; combined with the exact-count and
+	/// all-expected-present checks here, this pins the reveal set to the
+	/// session set (an unexpected party would force either a duplicate or a
+	/// missing expected party).
+	fn check_reveal_set_exact(
+		round2_data: &Round2Data,
+		me: u32,
+		other_round2: &[Round2Broadcast],
+		seen_parties: &BTreeSet<u32>,
+	) -> ThresholdResult<()> {
+		let expected_others = round2_data.active_participants.len().saturating_sub(1);
+		if other_round2.len() != expected_others {
+			return Err(ThresholdError::WrongPartyCount {
+				provided: other_round2.len() + 1,
+				required: round2_data.active_participants.len() as u32,
 			});
 		}
-
-		// Aggregate commitments without mutating persistent state until every reveal
-		// is validated and unpacked. Two properties are enforced here:
-		//
-		// 1. The reveal set must be *exactly* the participants recorded during Round 2
-		//    — no missing, no extra, no duplicate parties. Duplicates were rejected
-		//    above; combined with the exact-count and all-expected-present checks
-		//    below, this pins the reveal set to the session set (an unexpected party
-		//    would force either a duplicate or a missing expected party).
-		// 2. Every reveal is fully validated *before* the first write to persistent
-		//    state (validate-then-commit). A malformed-but-hash-bound reveal therefore
-		//    leaves `w_aggregated` untouched, so the signer stays in a clean
-		//    AfterRound2 state that a corrected retry can aggregate exactly once
-		//    (rather than double-counting earlier reveals).
-		{
-			let me = self.private_key.party_id();
-			let round2_data =
-				self.state.round2_data.as_mut().ok_or(ThresholdError::InvalidState {
-					current: "AfterRound2", // phase already validated above
-					expected: "AfterRound2",
-				})?;
-
-			// Exactly one reveal per other participant recorded at Round 2.
-			let expected_others = round2_data.active_participants.len().saturating_sub(1);
-			if other_round2.len() != expected_others {
-				return Err(ThresholdError::WrongPartyCount {
-					provided: other_round2.len() + 1,
-					required: round2_data.active_participants.len() as u32,
-				});
-			}
-			for other in round2_data.active_participants.others(me) {
-				if !seen_parties.contains(&other) {
-					return Err(ThresholdError::MissingBroadcast { party_id: other });
-				}
-			}
-
-			// Pass 1 (validate): unpack every chunk of every reveal, holding at most
-			// one transient Polyveck at a time. No persistent state is touched, so a
-			// failure here is a clean rejection. This deliberately avoids cloning the
-			// whole existing aggregate as a scratch buffer: for large k_iterations
-			// (e.g. k=1600 for 4-of-6) that clone roughly doubled peak memory during
-			// Round 3 (tens of MB), whereas re-unpacking in the commit pass below
-			// costs only a second run of cheap bit-unpacking.
-			for r2 in other_round2 {
-				for k_idx in 0..k {
-					let start = k_idx * single_commitment_size;
-					let end = start + single_commitment_size;
-
-					unpack_commitment_dilithium(&r2.commitment_data[start..end]).map_err(
-						|e| ThresholdError::InvalidCommitmentData {
-							party_id: r2.party_id,
-							reason: format!(
-								"Commitment passed hash check but failed to unpack (k={}): {}",
-								k_idx, e
-							),
-						},
-					)?;
-				}
-			}
-
-			// Pass 2 (commit): aggregate directly into persistent state, in place.
-			// Unpacking is deterministic over the same bytes, so after pass 1
-			// succeeded it cannot fail here. A failure would indicate a logic bug;
-			// rather than panicking, it is handled defensively below.
-			let mut commit_failed = false;
-			'commit: for r2 in other_round2 {
-				for (k_idx, agg) in round2_data.w_aggregated.iter_mut().take(k).enumerate() {
-					let start = k_idx * single_commitment_size;
-					let end = start + single_commitment_size;
-
-					match unpack_commitment_dilithium(&r2.commitment_data[start..end]) {
-						Ok(w_other) => aggregate_commitments_dilithium(agg, &w_other),
-						Err(_) => {
-							commit_failed = true;
-							break 'commit;
-						},
-					}
-				}
-			}
-			if commit_failed {
-				// Defensive, believed unreachable: the same bytes unpacked
-				// successfully in pass 1. The aggregate may now be partially
-				// mutated, so returning an error alone would let a retry
-				// double-aggregate the committed reveals. Reset the signing
-				// session instead: the caller must restart from Round 1, which
-				// re-derives a clean aggregate.
-				self.state = SignerState::default();
-				return Err(ThresholdError::InvalidData(
-					"Round 3 aggregation failed after validation (logic bug); \
-					 signing session reset — restart from Round 1"
-						.to_string(),
-				));
+		for other in round2_data.active_participants.others(me) {
+			if !seen_parties.contains(&other) {
+				return Err(ThresholdError::MissingBroadcast { party_id: other });
 			}
 		}
+		Ok(())
+	}
 
-		// Get immutable references for response generation
-		let round1_data = self.state.round1_data.as_ref().ok_or(ThresholdError::InvalidState {
-			current: "AfterRound2", // phase already validated above
-			expected: "AfterRound2",
-		})?;
-		let round2_data = self.state.round2_data.as_ref().ok_or(ThresholdError::InvalidState {
-			current: "AfterRound2", // phase already validated above
-			expected: "AfterRound2",
-		})?;
+	/// Validation pass of the aggregation: unpack every chunk of every reveal,
+	/// holding at most one transient `Polyveck` at a time, and discard the
+	/// results. No persistent state is touched, so a failure here is a clean
+	/// rejection.
+	///
+	/// This deliberately avoids cloning the whole existing aggregate as a
+	/// scratch buffer: for large k_iterations (e.g. k=1600 for 4-of-6) that
+	/// clone roughly doubled peak memory during Round 3 (tens of MB), whereas
+	/// re-unpacking in [`Self::aggregate_reveals`] costs only a second run of
+	/// cheap bit-unpacking.
+	fn validate_reveals_unpack(other_round2: &[Round2Broadcast], k: usize) -> ThresholdResult<()> {
+		for r2 in other_round2 {
+			for k_idx in 0..k {
+				let start = k_idx * SINGLE_COMMITMENT_SIZE;
+				let end = start + SINGLE_COMMITMENT_SIZE;
 
-		// Generate response
-		let responses =
-			generate_round3_response(&self.private_key, &self.config, round1_data, round2_data)?;
+				unpack_commitment_dilithium(&r2.commitment_data[start..end]).map_err(|e| {
+					ThresholdError::InvalidCommitmentData {
+						party_id: r2.party_id,
+						reason: format!(
+							"Commitment passed hash check but failed to unpack (k={}): {}",
+							k_idx, e
+						),
+					}
+				})?;
+			}
+		}
+		Ok(())
+	}
 
-		// Pack responses for broadcast
-		let packed_response = pack_responses(&responses);
-		let broadcast = Round3Broadcast::new(*ssid, self.private_key.party_id(), packed_response);
+	/// Commit pass of the aggregation: aggregate every reveal directly into
+	/// `round2_data.w_aggregated`, in place. Unpacking is deterministic over
+	/// the same bytes, so after [`Self::validate_reveals_unpack`] succeeded
+	/// this cannot fail. `Err` indicates a logic bug and means the aggregate
+	/// may be partially mutated — the caller must poison the session rather
+	/// than allow a retry.
+	fn aggregate_reveals(
+		round2_data: &mut Round2Data,
+		other_round2: &[Round2Broadcast],
+		k: usize,
+	) -> Result<(), ()> {
+		for r2 in other_round2 {
+			for (k_idx, agg) in round2_data.w_aggregated.iter_mut().take(k).enumerate() {
+				let start = k_idx * SINGLE_COMMITMENT_SIZE;
+				let end = start + SINGLE_COMMITMENT_SIZE;
 
-		// Update state - clear round1_data as it's no longer needed
-		// (dropping the Option zeroizes its contents via ZeroizeOnDrop).
-		self.state.my_responses = Some(responses);
-		self.state.round1_data = None;
-		self.state.phase = SigningPhase::AfterRound3;
-
-		Ok(broadcast)
+				match unpack_commitment_dilithium(&r2.commitment_data[start..end]) {
+					Ok(w_other) => aggregate_commitments_dilithium(agg, &w_other),
+					Err(_) => return Err(()),
+				}
+			}
+		}
+		Ok(())
 	}
 
 	/// Collect all Round 3 responses with duplicate detection.
@@ -761,11 +823,10 @@ impl ThresholdSigner {
 		&self,
 		message: &[u8],
 		context: &[u8],
-		_all_round2: &[Round2Broadcast],
+		all_round2: &[Round2Broadcast],
 		all_round3: &[Round3Broadcast],
 	) -> ThresholdResult<Signature> {
-		let (round2_data, my_responses, bound_message, bound_context) =
-			self.state.expect_round3()?;
+		let (_, _, bound_message, bound_context) = self.state.expect_round3()?;
 
 		// Round 3 responses are bound to the message/context captured in Round 2.
 		// Combining against anything else would silently yield an invalid signature,
@@ -777,18 +838,8 @@ impl ThresholdSigner {
 			));
 		}
 
-		let all_responses = self.collect_responses(my_responses, all_round3)?;
-
-		let signature_bytes = combine_signature(
-			&self.public_key,
-			&self.config,
-			bound_message,
-			bound_context,
-			&round2_data.w_aggregated,
-			&all_responses,
-		)?;
-
-		Ok(Signature::from_vec(signature_bytes))
+		// Identical to `combine` once the binding check has passed.
+		self.combine(all_round2, all_round3)
 	}
 }
 

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -529,7 +529,7 @@ impl ThresholdSigner {
 		{
 			let me = self.private_key.party_id();
 			let round2_data =
-				self.state.round2_data.as_ref().ok_or(ThresholdError::InvalidState {
+				self.state.round2_data.as_mut().ok_or(ThresholdError::InvalidState {
 					current: "AfterRound2", // phase already validated above
 					expected: "AfterRound2",
 				})?;
@@ -574,18 +574,36 @@ impl ThresholdSigner {
 
 			// Pass 2 (commit): aggregate directly into persistent state, in place.
 			// Unpacking is deterministic over the same bytes, so after pass 1
-			// succeeded it cannot fail here — the commit is all-or-nothing.
-			let round2_data =
-				self.state.round2_data.as_mut().expect("round2_data present in AfterRound2");
-			for r2 in other_round2 {
+			// succeeded it cannot fail here. A failure would indicate a logic bug;
+			// rather than panicking, it is handled defensively below.
+			let mut commit_failed = false;
+			'commit: for r2 in other_round2 {
 				for (k_idx, agg) in round2_data.w_aggregated.iter_mut().take(k).enumerate() {
 					let start = k_idx * single_commitment_size;
 					let end = start + single_commitment_size;
 
-					let w_other = unpack_commitment_dilithium(&r2.commitment_data[start..end])
-						.expect("chunk validated in pass 1; unpack is deterministic");
-					aggregate_commitments_dilithium(agg, &w_other);
+					match unpack_commitment_dilithium(&r2.commitment_data[start..end]) {
+						Ok(w_other) => aggregate_commitments_dilithium(agg, &w_other),
+						Err(_) => {
+							commit_failed = true;
+							break 'commit;
+						},
+					}
 				}
+			}
+			if commit_failed {
+				// Defensive, believed unreachable: the same bytes unpacked
+				// successfully in pass 1. The aggregate may now be partially
+				// mutated, so returning an error alone would let a retry
+				// double-aggregate the committed reveals. Reset the signing
+				// session instead: the caller must restart from Round 1, which
+				// re-derives a clean aggregate.
+				self.state = SignerState::default();
+				return Err(ThresholdError::InvalidData(
+					"Round 3 aggregation failed after validation (logic bug); \
+					 signing session reset — restart from Round 1"
+						.to_string(),
+				));
 			}
 		}
 

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -243,13 +243,16 @@ impl fmt::Display for SignProtocolError {
 pub struct Round4Broadcast {
 	/// Session identifier binding this message to a specific signing session.
 	pub ssid: [u8; SSID_SIZE],
-	/// The combined signature bytes.
-	pub signature: Vec<u8>,
+	/// The combined signature. Using the exact-size [`Signature`] type (rather
+	/// than a raw `Vec<u8>`) bounds deserialization to exactly `SIGNATURE_SIZE`
+	/// bytes, so a malformed Round 4 message cannot advertise an oversized
+	/// signature payload before the SSID/leader checks run.
+	pub signature: Signature,
 }
 
 impl Round4Broadcast {
 	/// Create a new Round 4 broadcast.
-	pub fn new(ssid: [u8; SSID_SIZE], signature: Vec<u8>) -> Self {
+	pub fn new(ssid: [u8; SSID_SIZE], signature: Signature) -> Self {
 		Self { ssid, signature }
 	}
 }
@@ -944,10 +947,7 @@ impl DilithiumSignProtocol {
 				match self.signer.combine(&r2_vec, &r3_vec) {
 					Ok(signature) => {
 						// Success! Broadcast signature to all parties
-						let r4 = Round4Broadcast {
-							ssid: self.ssid,
-							signature: signature.as_bytes().to_vec(),
-						};
+						let r4 = Round4Broadcast { ssid: self.ssid, signature: signature.clone() };
 						let msg = SigningMessage::Round4Complete(r4);
 						let data = self.serialize_message(&msg)?;
 						self.state = SignProtocolState::Done;
@@ -1168,10 +1168,9 @@ impl DilithiumSignProtocol {
 				}
 
 				if matches!(self.state, SignProtocolState::WaitingForLeaderDecision) {
-					// We're ready for it - process immediately
-					if let Some(signature) = Signature::from_bytes(&r4.signature) {
-						self.received_signature = Some(signature);
-					}
+					// We're ready for it - process immediately. The signature was
+					// already length-validated during deserialization.
+					self.received_signature = Some(r4.signature);
 				} else if matches!(
 					self.state,
 					SignProtocolState::Round1Generate |
@@ -1255,10 +1254,9 @@ impl DilithiumSignProtocol {
 	/// collected all Round 3 messages (possible when network ordering is not guaranteed).
 	fn process_buffered_round4_complete(&mut self) {
 		if let Some(r4) = self.message_buffer.take_round4_complete() {
-			// SSID already verified when the message was received
-			if let Some(signature) = Signature::from_bytes(&r4.signature) {
-				self.received_signature = Some(signature);
-			}
+			// SSID already verified when the message was received; the signature
+			// was length-validated during deserialization.
+			self.received_signature = Some(r4.signature);
 		}
 	}
 }
@@ -1932,7 +1930,7 @@ mod tests {
 		// (this can happen if leader finishes all rounds faster)
 		let round4_msg = SigningMessage::Round4Complete(Round4Broadcast {
 			ssid: *follower.ssid(),
-			signature: valid_sig.as_bytes().to_vec(),
+			signature: valid_sig.clone(),
 		});
 		let round4_data = follower.serialize_message(&round4_msg).unwrap();
 		follower.message(0, round4_data).unwrap();
@@ -2400,5 +2398,32 @@ mod tests {
 		);
 
 		assert!(result.is_ok(), "Should accept 255-byte context");
+	}
+
+	/// A Round 4 message whose signature field is not exactly `SIGNATURE_SIZE`
+	/// bytes must be rejected at deserialization. Before switching the field to
+	/// the exact-size `Signature` type, the derived `Vec<u8>` deserializer
+	/// accepted any length up to the message cap.
+	#[test]
+	fn test_round4_rejects_wrong_size_signature() {
+		use crate::broadcast::SIGNATURE_SIZE;
+
+		let mut payload = Vec::new();
+		payload.extend_from_slice(&[0xABu8; SSID_SIZE]); // ssid
+		payload.extend_from_slice(&100u32.to_le_bytes()); // sig len = 100 (wrong)
+		payload.extend_from_slice(&[0u8; 100]);
+
+		let result: Result<Round4Broadcast, _> = borsh::from_slice(&payload);
+		assert!(
+			result.is_err(),
+			"Round4Broadcast must reject a signature that is not SIGNATURE_SIZE bytes"
+		);
+
+		// A correctly-sized signature round-trips.
+		let sig = Signature::from_bytes(&[7u8; SIGNATURE_SIZE]).unwrap();
+		let r4 = Round4Broadcast::new([0xABu8; SSID_SIZE], sig);
+		let bytes = borsh::to_vec(&r4).unwrap();
+		let recovered: Round4Broadcast = borsh::from_slice(&bytes).unwrap();
+		assert_eq!(recovered.signature.as_bytes(), r4.signature.as_bytes());
 	}
 }

--- a/threshold/tests/common/mod.rs
+++ b/threshold/tests/common/mod.rs
@@ -12,7 +12,7 @@ use qp_rusty_crystals_threshold::resharing::{
 /// party ID matches the public key (which is just the party ID) and that the
 /// embedded hash matches, so signatures over a *different* transcript hash
 /// fail verification exactly like a real scheme.
-#[derive(Clone)]
+#[derive(Clone, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 pub struct TestSigner {
 	pub id: u32,
 }

--- a/threshold/tests/coverage_tests.rs
+++ b/threshold/tests/coverage_tests.rs
@@ -725,6 +725,7 @@ mod error_display {
 			},
 			ThresholdError::InvalidPartyId { party_id: 5, max_id: 3 },
 			ThresholdError::WrongPartyCount { provided: 2, required: 3 },
+			ThresholdError::RevealSetMismatch { provided: 1, expected: 2 },
 			ThresholdError::InvalidSignatureShare { party_id: 1, reason: "bounds check failed" },
 			ThresholdError::ContextTooLong { length: 300 },
 			ThresholdError::CombinationFailed,

--- a/threshold/tests/integration_tests.rs
+++ b/threshold/tests/integration_tests.rs
@@ -552,7 +552,7 @@ fn test_dealer_sign_6_of_6() {
 // ============================================================================
 
 /// Simple test signer for DKG transcript signing.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 struct TestSigner {
 	id: u32,
 }

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -6,9 +6,9 @@
 use std::collections::HashMap;
 
 use qp_rusty_crystals_threshold::{
-	compute_ssid, convert_shares, generate_subsets_of_size, generate_with_dealer,
-	get_hyperball_params, verify_signature, ParticipantList, PrivateKeyShare, PublicKey,
-	Round1Broadcast, Round2Broadcast, Round3Broadcast, ThresholdConfig, ThresholdSigner,
+	compute_ssid, generate_subsets_of_size, generate_with_dealer, get_hyperball_params,
+	verify_signature, ParticipantList, PrivateKeyShare, PublicKey, Round1Broadcast,
+	Round2Broadcast, Round3Broadcast, ThresholdConfig, ThresholdSigner,
 };
 
 use qp_rusty_crystals_threshold::resharing::{
@@ -2762,7 +2762,7 @@ fn test_coefficient_growth_tracking() {
 	// Get baseline coefficient stats from DKG shares
 	println!("Round 0 (DKG baseline):");
 	for share in &dkg_shares {
-		let (max_abs, min_c, max_c) = share.coefficient_stats();
+		let (max_abs, min_c, max_c) = coefficient_stats(share);
 		println!("  Party {}: max_abs={}, range=[{}, {}]", share.party_id(), max_abs, min_c, max_c);
 	}
 
@@ -2794,7 +2794,7 @@ fn test_coefficient_growth_tracking() {
 			println!("\nRound {}:", round);
 			for party_id in [0, 1, 2] {
 				let share = current_shares.get(&party_id).unwrap();
-				let (max_abs, min_c, max_c) = share.coefficient_stats();
+				let (max_abs, min_c, max_c) = coefficient_stats(share);
 				println!("  Party {}: max_abs={}, range=[{}, {}]", party_id, max_abs, min_c, max_c);
 			}
 			checkpoint_idx += 1;
@@ -2891,6 +2891,83 @@ fn test_resharing_aborts_on_round4_omission() {
 }
 
 // ============================================================================
+// Test-only secret share extraction
+// ============================================================================
+//
+// `PrivateKeyShare` is intentionally opaque: the production API exposes no way
+// to read the secret s1/s2 subset shares. The statistical analyses below need
+// the raw coefficients, so the tests recover them from the share's borsh
+// serialization (which necessarily contains the secret material, since shares
+// must be storable). These mirror structs replicate the serialized field
+// layout of `PrivateKeyShare`; if that layout changes, deserialization here
+// fails loudly and this block must be updated.
+
+/// Mirror of the crate-private `SecretShareData` (L=7, K=8 for ML-DSA-87).
+#[derive(borsh::BorshDeserialize)]
+struct RawSubsetShare {
+	s1: [[i32; 256]; 7],
+	s2: [[i32; 256]; 8],
+}
+
+/// Mirror of `PrivateKeyShare`'s borsh layout.
+#[allow(dead_code)]
+#[derive(borsh::BorshDeserialize)]
+struct RawPrivateKeyShare {
+	party_id: u32,
+	total_parties: u32,
+	threshold: u32,
+	/// `ParticipantList` serializes as just its sorted participants vector.
+	dkg_participants: Vec<u32>,
+	key: [u8; 32],
+	rho: [u8; 32],
+	tr: [u8; 64],
+	shares: std::collections::BTreeMap<u16, RawSubsetShare>,
+}
+
+/// Extract the secret subset shares from a `PrivateKeyShare` via serialization.
+fn extract_subset_shares(
+	share: &PrivateKeyShare,
+) -> std::collections::BTreeMap<u16, RawSubsetShare> {
+	let bytes = borsh::to_vec(share).expect("serialize private key share");
+	let raw: RawPrivateKeyShare =
+		borsh::from_slice(&bytes).expect("parse serialized private key share layout");
+	raw.shares
+}
+
+/// Center a coefficient into (-Q/2, Q/2].
+fn center_coefficient(coeff: i32) -> i32 {
+	const Q: i64 = 8380417;
+	const HALF_Q: i64 = Q / 2;
+	let c = coeff as i64;
+	(if c > HALF_Q { c - Q } else { c }) as i32
+}
+
+/// Collect all centered coefficients from all subset shares of one share.
+fn collect_share_coefficients(share: &PrivateKeyShare) -> Vec<i32> {
+	let mut coeffs = Vec::new();
+	for data in extract_subset_shares(share).values() {
+		for poly in data.s1.iter().chain(data.s2.iter()) {
+			coeffs.extend(poly.iter().map(|&c| center_coefficient(c)));
+		}
+	}
+	coeffs
+}
+
+/// Compute `(max_abs_coeff, min_coeff, max_coeff)` over the centered
+/// coefficients of all subset shares of one share.
+fn coefficient_stats(share: &PrivateKeyShare) -> (i32, i32, i32) {
+	let mut max_abs: i32 = 0;
+	let mut min_coeff: i32 = 0;
+	let mut max_coeff: i32 = 0;
+	for c in collect_share_coefficients(share) {
+		max_abs = max_abs.max(c.abs());
+		min_coeff = min_coeff.min(c);
+		max_coeff = max_coeff.max(c);
+	}
+	(max_abs, min_coeff, max_coeff)
+}
+
+// ============================================================================
 // Coefficient Distribution Analysis
 // ============================================================================
 
@@ -2898,7 +2975,7 @@ fn test_resharing_aborts_on_round4_omission() {
 fn collect_coefficients(shares: &HashMap<u32, PrivateKeyShare>) -> Vec<i32> {
 	let mut coeffs = Vec::new();
 	for share in shares.values() {
-		coeffs.extend(share.collect_all_coefficients());
+		coeffs.extend(collect_share_coefficients(share));
 	}
 	coeffs
 }
@@ -3429,7 +3506,7 @@ fn extract_recovered_coefficients(
 		return None;
 	}
 
-	let shares = convert_shares(share);
+	let shares = extract_subset_shares(share);
 	let threshold = share.threshold();
 	let parties = share.total_parties();
 	let t = threshold as usize;
@@ -3488,15 +3565,15 @@ fn extract_recovered_coefficients(
 		}
 
 		if let Some(secret_share) = shares.get(&u_translated) {
-			for (poly_idx, poly) in secret_share.s1_share.vec.iter().enumerate().take(7) {
-				for (coeff_idx, &coeff) in poly.coeffs.iter().enumerate() {
+			for (poly_idx, poly) in secret_share.s1.iter().enumerate() {
+				for (coeff_idx, &coeff) in poly.iter().enumerate() {
 					let c = coeff as i64;
 					let centered = if c > HALF_Q { c - Q } else { c };
 					s1_acc[poly_idx * 256 + coeff_idx] += centered;
 				}
 			}
-			for (poly_idx, poly) in secret_share.s2_share.vec.iter().enumerate().take(8) {
-				for (coeff_idx, &coeff) in poly.coeffs.iter().enumerate() {
+			for (poly_idx, poly) in secret_share.s2.iter().enumerate() {
+				for (coeff_idx, &coeff) in poly.iter().enumerate() {
 					let c = coeff as i64;
 					let centered = if c > HALF_Q { c - Q } else { c };
 					s2_acc[poly_idx * 256 + coeff_idx] += centered;

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -4202,12 +4202,7 @@ fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
 	accepts.insert(0, Signer { id: 0 }.sign(&accept_hash));
 	accepts.insert(1, Signer { id: 1 }.sign(&accept_hash));
 
-	let cert = ResharingCertificate {
-		ssid,
-		active_set,
-		transcript_hash,
-		accepts: accepts.clone(),
-	};
+	let cert = ResharingCertificate { ssid, active_set, transcript_hash, accepts: accepts.clone() };
 	assert!(cert.verify::<Signer>(&new_participants, &keys), "valid certificate must verify");
 
 	// Missing an acceptance.
@@ -4253,12 +4248,7 @@ fn test_certificate_rejects_forged_active_set() {
 	accepts.insert(0, Signer { id: 0 }.sign(&accept_hash));
 	accepts.insert(1, Signer { id: 1 }.sign(&accept_hash));
 
-	let cert = ResharingCertificate {
-		ssid,
-		active_set: real_active_set,
-		transcript_hash,
-		accepts,
-	};
+	let cert = ResharingCertificate { ssid, active_set: real_active_set, transcript_hash, accepts };
 	assert!(cert.verify::<Signer>(&new_participants, &keys), "honest certificate must verify");
 
 	// Attacker rewrites active_set (drops party 2 / claims a different handoff

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -4193,7 +4193,8 @@ fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
 
 	let ssid = [7u8; 32];
 	let transcript_hash = [9u8; 32];
-	let accept_hash = compute_accept_hash(&ssid, &transcript_hash);
+	let active_set = vec![0u32, 1u32];
+	let accept_hash = compute_accept_hash(&ssid, &transcript_hash, &active_set);
 	let new_participants = vec![0u32, 1u32];
 	let keys: BTreeMap<u32, u32> = new_participants.iter().map(|&p| (p, p)).collect();
 
@@ -4203,7 +4204,7 @@ fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
 
 	let cert = ResharingCertificate {
 		ssid,
-		active_set: vec![0, 1],
+		active_set,
 		transcript_hash,
 		accepts: accepts.clone(),
 	};
@@ -4215,7 +4216,7 @@ fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
 	assert!(!missing.verify::<Signer>(&new_participants, &keys));
 
 	// Acceptance over a different transcript hash.
-	let other_hash = compute_accept_hash(&ssid, &[10u8; 32]);
+	let other_hash = compute_accept_hash(&ssid, &[10u8; 32], &cert.active_set);
 	let mut wrong = cert.clone();
 	wrong.accepts.insert(1, Signer { id: 1 }.sign(&other_hash));
 	assert!(!wrong.verify::<Signer>(&new_participants, &keys));
@@ -4224,6 +4225,59 @@ fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
 	let mut forged = cert;
 	forged.accepts.insert(1, Signer { id: 0 }.sign(&accept_hash));
 	assert!(!forged.verify::<Signer>(&new_participants, &keys));
+}
+
+/// A certificate's `active_set` must be authenticated by the acceptance
+/// signatures. Rewriting `active_set` while leaving `ssid`, `transcript_hash`,
+/// and `accepts` untouched must make verification fail — otherwise an attacker
+/// could publish a certificate that falsely names the old committee members who
+/// participated in the handoff.
+#[test]
+fn test_certificate_rejects_forged_active_set() {
+	use common::TestSigner as Signer;
+	use qp_rusty_crystals_threshold::resharing::{
+		compute_accept_hash, ResharingCertificate, TranscriptSigner as _,
+	};
+	use std::collections::BTreeMap;
+
+	let ssid = [7u8; 32];
+	let transcript_hash = [9u8; 32];
+	// The active set the new committee actually attested to.
+	let real_active_set = vec![0u32, 1u32, 2u32];
+	let accept_hash = compute_accept_hash(&ssid, &transcript_hash, &real_active_set);
+
+	let new_participants = vec![0u32, 1u32];
+	let keys: BTreeMap<u32, u32> = new_participants.iter().map(|&p| (p, p)).collect();
+
+	let mut accepts: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
+	accepts.insert(0, Signer { id: 0 }.sign(&accept_hash));
+	accepts.insert(1, Signer { id: 1 }.sign(&accept_hash));
+
+	let cert = ResharingCertificate {
+		ssid,
+		active_set: real_active_set,
+		transcript_hash,
+		accepts,
+	};
+	assert!(cert.verify::<Signer>(&new_participants, &keys), "honest certificate must verify");
+
+	// Attacker rewrites active_set (drops party 2 / claims a different handoff
+	// set) but keeps ssid, transcript_hash, and the collected signatures. With
+	// active_set bound into the acceptance hash, verification must now fail.
+	let mut forged = cert.clone();
+	forged.active_set = vec![0u32, 1u32];
+	assert!(
+		!forged.verify::<Signer>(&new_participants, &keys),
+		"certificate with a forged active_set must not verify"
+	);
+
+	// Reordering the members is also a mutation of the signed set.
+	let mut reordered = cert;
+	reordered.active_set = vec![2u32, 1u32, 0u32];
+	assert!(
+		!reordered.verify::<Signer>(&new_participants, &keys),
+		"certificate with a reordered active_set must not verify"
+	);
 }
 
 // ============================================================================

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -6,9 +6,9 @@
 use std::collections::HashMap;
 
 use qp_rusty_crystals_threshold::{
-	compute_ssid, generate_subsets_of_size, generate_with_dealer, get_hyperball_params,
-	verify_signature, ParticipantList, PrivateKeyShare, PublicKey, Round1Broadcast,
-	Round2Broadcast, Round3Broadcast, ThresholdConfig, ThresholdSigner,
+	compute_ssid, generate_with_dealer, get_hyperball_params, verify_signature, ParticipantList,
+	PrivateKeyShare, PublicKey, Round1Broadcast, Round2Broadcast, Round3Broadcast, ThresholdConfig,
+	ThresholdSigner,
 };
 
 use qp_rusty_crystals_threshold::resharing::{
@@ -18,6 +18,25 @@ use qp_rusty_crystals_threshold::resharing::{
 
 mod common;
 use common::{new_test_protocol, TestSigner};
+
+/// Local reimplementation of the crate's (now crate-private) subset enumerator,
+/// used only to build expected combinations in these tests. The crate no longer
+/// re-exports its internal `generate_subsets_of_size` helper.
+fn generate_subsets_of_size(n: usize, size: usize) -> Vec<u16> {
+	if size == 0 || size > n || n > 16 {
+		return Vec::new();
+	}
+	let mut subsets = Vec::new();
+	let max_val: u32 = 1u32 << n;
+	let mut subset: u32 = (1u32 << size) - 1;
+	while subset < max_val {
+		subsets.push(subset as u16);
+		let c = subset & subset.wrapping_neg();
+		let r = subset + c;
+		subset = (((r ^ subset) >> 2) / c) | r;
+	}
+	subsets
+}
 
 /// Helper to run the resharing protocol locally with simulated message passing.
 fn run_resharing_protocol(

--- a/threshold/tests/signer_state_tests.rs
+++ b/threshold/tests/signer_state_tests.rs
@@ -148,8 +148,7 @@ fn setup_through_round2(
 	let context = b"replay ctx";
 	let participant_list = ParticipantList::new(&[0u32, 1u32]).unwrap();
 	let attempt_nonce = [0x11; 32];
-	let ssid =
-		compute_ssid(&public_key, 2, 3, &participant_list, message, context, &attempt_nonce);
+	let ssid = compute_ssid(&public_key, 2, 3, &participant_list, message, context, &attempt_nonce);
 
 	let r1: Vec<Round1Broadcast> = signers
 		.iter_mut()
@@ -165,8 +164,7 @@ fn setup_through_round2(
 		.iter_mut()
 		.enumerate()
 		.map(|(i, s)| {
-			let others: Vec<_> =
-				r1.iter().filter(|r| r.party_id != i as u32).cloned().collect();
+			let others: Vec<_> = r1.iter().filter(|r| r.party_id != i as u32).cloned().collect();
 			s.round2_reveal(&ssid, message, context, &others).unwrap()
 		})
 		.collect();

--- a/threshold/tests/signer_state_tests.rs
+++ b/threshold/tests/signer_state_tests.rs
@@ -6,7 +6,7 @@
 
 use qp_rusty_crystals_threshold::{
 	compute_ssid, generate_with_dealer, ParticipantList, Round1Broadcast, Round2Broadcast,
-	ThresholdConfig, ThresholdSigner,
+	ThresholdConfig, ThresholdError, ThresholdSigner,
 };
 
 /// Test SSID for state machine tests (all parties use same SSID).
@@ -126,6 +126,94 @@ fn test_commitment_tampering_detected() {
 		err_str.contains("ommitment") && err_str.contains("mismatch"),
 		"Error should indicate commitment mismatch, got: {}",
 		err_str
+	);
+}
+
+/// Drive two signers (parties 0 and 1) through Rounds 1 and 2 for a 2-of-3
+/// session, returning the signers, the Round 1 broadcasts, the Round 2
+/// broadcasts, and the SSID.
+fn setup_through_round2(
+) -> (Vec<ThresholdSigner>, Vec<Round1Broadcast>, Vec<Round2Broadcast>, [u8; 32]) {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [7u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("key generation");
+
+	let mut signers: Vec<_> = shares
+		.iter()
+		.take(2)
+		.map(|share| ThresholdSigner::new(share.clone(), public_key.clone(), config).unwrap())
+		.collect();
+
+	let message = b"replay test message";
+	let context = b"replay ctx";
+	let participant_list = ParticipantList::new(&[0u32, 1u32]).unwrap();
+	let attempt_nonce = [0x11; 32];
+	let ssid =
+		compute_ssid(&public_key, 2, 3, &participant_list, message, context, &attempt_nonce);
+
+	let r1: Vec<Round1Broadcast> = signers
+		.iter_mut()
+		.enumerate()
+		.map(|(i, s)| {
+			let mut party_seed = [0u8; 32];
+			party_seed[0] = i as u8;
+			s.round1_commit_with_seed(&ssid, &party_seed).unwrap()
+		})
+		.collect();
+
+	let r2: Vec<Round2Broadcast> = signers
+		.iter_mut()
+		.enumerate()
+		.map(|(i, s)| {
+			let others: Vec<_> =
+				r1.iter().filter(|r| r.party_id != i as u32).cloned().collect();
+			s.round2_reveal(&ssid, message, context, &others).unwrap()
+		})
+		.collect();
+
+	(signers, r1, r2, ssid)
+}
+
+/// Replaying one party's Round 2 broadcast must be rejected. Without the
+/// duplicate check, `round3_respond` would aggregate the same commitment twice,
+/// silently corrupting the challenge material and permanently breaking the
+/// signer's ability to produce a valid response for the session.
+#[test]
+fn test_round3_rejects_replayed_round2_broadcast() {
+	let (mut signers, r1, r2, ssid) = setup_through_round2();
+
+	let others_r1: Vec<_> = r1.iter().filter(|r| r.party_id != 0).cloned().collect();
+	let party1_r2 = r2.iter().find(|r| r.party_id == 1).cloned().unwrap();
+	// Party 0 receives party 1's valid Round 2 broadcast twice (a replay).
+	let replayed = vec![party1_r2.clone(), party1_r2];
+
+	let err = signers[0]
+		.round3_respond(&ssid, &others_r1, &replayed)
+		.expect_err("replayed Round 2 broadcast must be rejected");
+
+	assert!(
+		matches!(err, ThresholdError::DuplicateBroadcast { party_id: 1 }),
+		"expected DuplicateBroadcast for the replayed party, got: {err:?}"
+	);
+}
+
+/// The reveal set must match the participants recorded during Round 2. Omitting
+/// an expected participant's reveal (here: providing none) must be rejected
+/// rather than silently signing over an under-aggregated commitment.
+#[test]
+fn test_round3_rejects_incomplete_reveal_set() {
+	let (mut signers, r1, _r2, ssid) = setup_through_round2();
+
+	let others_r1: Vec<_> = r1.iter().filter(|r| r.party_id != 0).cloned().collect();
+
+	// Party 0 expects one other reveal (party 1) but receives none.
+	let err = signers[0]
+		.round3_respond(&ssid, &others_r1, &[])
+		.expect_err("missing participant reveal must be rejected");
+
+	assert!(
+		matches!(err, ThresholdError::WrongPartyCount { provided: 1, required: 2 }),
+		"expected WrongPartyCount for the incomplete reveal set, got: {err:?}"
 	);
 }
 

--- a/threshold/tests/signer_state_tests.rs
+++ b/threshold/tests/signer_state_tests.rs
@@ -212,8 +212,8 @@ fn test_round3_rejects_incomplete_reveal_set() {
 		.expect_err("missing participant reveal must be rejected");
 
 	assert!(
-		matches!(err, ThresholdError::WrongPartyCount { provided: 1, required: 2 }),
-		"expected WrongPartyCount for the incomplete reveal set, got: {err:?}"
+		matches!(err, ThresholdError::RevealSetMismatch { provided: 1, expected: 2 }),
+		"expected RevealSetMismatch for the incomplete reveal set, got: {err:?}"
 	);
 }
 


### PR DESCRIPTION
## Summary

This PR addresses a batch of security-review findings across the three crates
(`dilithium`, `hdwallet`, `threshold`). Each finding was verified, reproduced
with a test where practical, fixed, and re-tested. The changes fall into a few
themes:

- **Memory hygiene / zeroization** — ensure secret material (seeds, shares,
  K_S, signing keys, NTT accumulators, wormhole secrets) is scrubbed and cannot
  be silently copied.
- **Untrusted-input hardening (DoS)** — bound allocations, enforce message-size
  and length limits, and turn panics/overflows on attacker-controlled input into
  clean errors.
- **Cryptographic binding / domain separation** — bind protocol state (session
  SSID, threshold policy, `active_set`) into the values it must authenticate.
- **API-surface reduction** — stop exposing low-level, panic-prone, or
  secret-bearing helpers on the public surface.
- **Correctness / canonicalization** — reject non-canonical encodings that
  would otherwise alias distinct inputs to the same key/address.

No functional behavior changes for honest callers, but several public APIs were
tightened (see **Breaking changes** below).

## Changes by area

### `dilithium`

- **Reject all-zero-`t1` public keys** to prevent a no-secret forgery class.
- **`Keypair::from_bytes` now verifies the public key matches the secret key**,
  re-deriving `t1`/`t0` from the secret half and rejecting inconsistent blobs.
  The `t1`/`t0` derivation is shared between keygen and this check to avoid
  divergence.
- **Zeroize freshly-sampled secret polynomials** (`s1`, `s2`, `t0`) after they
  are packed into the secret key in `keypair()`.
- **Enforce exact-size buffers for low-level polynomial codecs** (`z_pack`,
  `z_unpack`, `k_pack_w1`, etc.) via array-typed parameters and
  `slice::as_chunks`/`first_chunk`; internal-only codecs are now `pub(crate)`.
  This removes a panic-on-short-slice footgun from the public API.
- **Make vector secret samplers `pub(crate)`** to prevent nonce-reuse misuse,
  with feature-gated wrappers for benchmarking.
- **Zero the hint vector in `unpack_sig`** to prevent stale-hint carryover.
- **Absorb message slices instead of concatenating** in `sign`/`verify`,
  eliminating a large-message heap-copy DoS.
- **Prevent a `keccak_squeeze` hang** on an out-of-range `KeccakState.pos`.

### `hdwallet`

- **`WormholePair.secret` is now a move-only `SensitiveBytes32`** instead of a
  public `[u8; 32]`. The array was `Copy`, so `pair.secret` could silently
  duplicate the secret and defeat `ZeroizeOnDrop`. Reads now go through
  `secret.as_bytes()`.
- **`ChildNumber::from_str` requires canonical decimal** — rejects leading `+`,
  redundant leading zeros, and non-ASCII digits so distinct path strings can no
  longer alias to the same derived key.
- **NFKD-normalize mnemonic and passphrase** before BIP39 seed derivation.

### `threshold`

Memory hygiene:
- **Enforce zeroization of DKG/resharing transcript signer keys** by requiring
  `TranscriptSigner: ZeroizeOnDrop`; dropping the config now provably scrubs the
  long-term signing key.
- **Keep queued DKG Round 1 privates as zeroizing structs** (not raw `Vec<u8>`),
  and **zeroize NTT accumulators and dealer share material**.
- **Redact the `SendPrivate` payload in `DkgAction`'s `Debug`** so K_S is not
  leaked to logs/telemetry.
- **Remove secret-extraction APIs from `PrivateKeyShare`'s public surface.**

Untrusted-input hardening:
- **Bound Borsh deserialization before allocation** for `Round2Broadcast`,
  `Round3Broadcast`, `Round4Broadcast`, and `ResharingCertificate`.
- **Enforce `MAX_MESSAGE_SIZE` on the direct signer path.**
- **Enforce exact reveal-set and atomic aggregation in `round3_respond`** so a
  replayed/duplicated Round 2 reveal cannot poison in-progress signing state.
- **Validate `run_local_dkg` input lengths** instead of `unwrap()`/panicking.
- **Reject out-of-range partial-PK coefficients** in `pack_combined_pk` to
  prevent an `i32` overflow (panic in debug / silent wrap in release) during
  public-key aggregation.
- **Harden and unpublish `generate_subsets_of_size`** (u16 overflow / input
  validation; no longer re-exported at the crate root).

Cryptographic binding:
- **Bind dealer keygen to the `(t, n)` threshold policy and subset mask**, so
  distinct policies with the same subset count no longer produce identical
  public keys.
- **Bind DKG Round 1 randomness to the session SSID**, so retries with a fresh
  session nonce don't replay randomness.
- **Bind `active_set` into resharing certificate acceptance signatures**
  (`ACCEPT_DOMAIN` bumped to v2), so it can no longer be forged in an otherwise
  valid certificate.
- **Reject non-canonical subset masks in the public-key-preservation check.**

Correctness:
- **Use non-overflowing magnitude (`unsigned_abs`) for the subshare bound
  check**, fixing an `i32::MIN` edge case.

## Breaking changes

- `dilithium`: several low-level `poly`/`polyvec`/`packing` helpers are now
  `pub(crate)` or take exact-size array references; `Keypair::from_bytes` now
  rejects inconsistent `sk || pk` blobs.
- `hdwallet`: `WormholePair.secret` is a `SensitiveBytes32` (read via
  `.as_bytes()`), not a `[u8; 32]`. Downstream consumers (e.g. `quantus-cli`,
  the Quantus SDK) need trivial `.as_bytes()` updates.
- `threshold`: `TranscriptSigner` now requires `ZeroizeOnDrop`;
  `generate_subsets_of_size` is no longer publicly re-exported; `pack_combined_pk`
  is now fallible; `PrivateKeyShare`'s secret-extraction methods were removed.

## Test plan

- [x] `cargo test -p qp-rusty-crystals-dilithium`
- [x] `cargo test -p qp-rusty-crystals-hdwallet`
- [x] `cargo test -p qp-rusty-crystals-threshold` (lib, integration, doctests)
- [x] `cargo clippy` clean on the touched crates
- [x] New regression tests added for each fix where a runtime test is meaningful
      (public-key/secret-key consistency, canonical child numbers, wormhole
      secret wrapper, transcript-signer zeroization, partial-PK overflow
      rejection, active_set binding, dealer policy binding, SSID randomness
      binding, bounded deserialization, oversized-message rejection, etc.).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication-critical paths (key import, public-key validation, DKG/resharing binding, signing state) and changes public APIs; honest callers should behave the same but integrators must adapt to stricter types and new error cases.
> 
> **Overview**
> Security-review fixes across **dilithium**, **hdwallet**, and **threshold**: tighter secret handling, safer untrusted input, and stronger protocol binding.
> 
> **ML-DSA (`dilithium`)** rejects degenerate all-zero `t1` public keys and verifies that `Keypair::from_bytes` re-derives a matching public key from the secret half. Sign/verify hash `domain_prefix` and message as separate SHAKE absorbs (no full-message heap copy). `unpack_sig` clears hints before decode; Keccak squeeze no longer spins on bad `pos`; internal sign/verify APIs take an explicit domain prefix. Low-level codecs use exact-size buffers; secret vector samplers are crate-internal with a `ct-internals` feature for `ct_bench`.
> 
> **HD wallet** wraps wormhole secrets in move-only `SensitiveBytes32`, requires canonical hardened child indices in paths, and NFKD-normalizes mnemonic/passphrase before BIP39.
> 
> **Threshold** requires `TranscriptSigner: ZeroizeOnDrop`, redacts K_S in `DkgAction` debug output, and queues Round 1 privates as zeroizing structs. Borsh paths use bounded/incremental reads; direct signing enforces `MAX_MESSAGE_SIZE`; `round3_respond` rejects duplicate reveals and commits aggregation atomically. Dealer/DKG bind `(t,n)` and session SSID into randomness; resharing acceptance hashes bind `active_set` (v2); partial PK combine validates coefficients and non-canonical subset masks. Several secret-bearing or panic-prone helpers are narrowed or removed from the public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73e713ebe7922b6d824d881c8dab9fbd9a472b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->