### PR TITLE
Security review again

### DIFF
--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -88,7 +88,7 @@ fn random_class(rng: &mut BenchRng) -> (bool, Class) {
 
 /// Fill a Poly with uniform coefficients in [-bound, bound].
 fn fill_poly(p: &mut Poly, bound: i32, rng: &mut BenchRng) {
-	for c in p.coeffs.iter_mut() {
+	for c in p.coeffs_mut().iter_mut() {
 		*c = rng.random_range(-bound..=bound);
 	}
 }
@@ -110,14 +110,14 @@ fn fill_polyveck(v: &mut Polyveck, bound: i32, rng: &mut BenchRng) {
 /// Plain coefficient copy (no allocation, no zeroize-on-drop of the destination).
 fn copy_polyvecl(dst: &mut Polyvecl, src: &Polyvecl) {
 	for (d, s) in dst.vec.iter_mut().zip(src.vec.iter()) {
-		d.coeffs = s.coeffs;
+		*d.coeffs_mut() = *s.coeffs();
 	}
 }
 
 /// Plain coefficient copy (no allocation, no zeroize-on-drop of the destination).
 fn copy_polyveck(dst: &mut Polyveck, src: &Polyveck) {
 	for (d, s) in dst.vec.iter_mut().zip(src.vec.iter()) {
-		d.coeffs = s.coeffs;
+		*d.coeffs_mut() = *s.coeffs();
 	}
 }
 
@@ -288,7 +288,7 @@ fn sign_make_hint(runner: &mut CtRunner, rng: &mut BenchRng) {
 
 	let fill_w1 = |v: &mut Polyveck, rng: &mut BenchRng| {
 		for p in v.vec.iter_mut() {
-			for c in p.coeffs.iter_mut() {
+			for c in p.coeffs_mut().iter_mut() {
 				*c = rng.random_range(0..16);
 			}
 		}
@@ -346,11 +346,11 @@ fn ntt_pointwise(runner: &mut CtRunner, rng: &mut BenchRng) {
 		fill_poly(&mut scratch_a, Q - 1, rng);
 		fill_poly(&mut scratch_b, Q - 1, rng);
 		if is_left {
-			a.coeffs = fixed_a.coeffs;
-			b.coeffs = fixed_b.coeffs;
+			*a.coeffs_mut() = *fixed_a.coeffs();
+			*b.coeffs_mut() = *fixed_b.coeffs();
 		} else {
-			a.coeffs = scratch_a.coeffs;
-			b.coeffs = scratch_b.coeffs;
+			*a.coeffs_mut() = *scratch_a.coeffs();
+			*b.coeffs_mut() = *scratch_b.coeffs();
 		}
 		runner.run_one(class, || {
 			for _ in 0..BATCH {

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -43,7 +43,10 @@ impl Keypair {
 		let mut sk = [0u8; SECRETKEYBYTES];
 		crate::sign::keypair(&mut pk, &mut sk, entropy);
 		let keypair = Keypair {
-			secret: SecretKey::from_bytes(&sk).expect("Should never fail"),
+			// Constructed directly rather than via `SecretKey::from_bytes`:
+			// a freshly generated key is consistent by construction, and the
+			// import-path validation would redo the keygen-scale derivation.
+			secret: SecretKey { bytes: sk },
 			public: PublicKey::from_bytes(&pk).expect("Should never fail"),
 		};
 		sk.zeroize();
@@ -92,22 +95,24 @@ impl Keypair {
 			return Err(KeyParsingError::BadKeypair);
 		}
 		let (secret_bytes, public_bytes) = bytes.split_at(SECRETKEYBYTES);
-		let secret =
-			SecretKey::from_bytes(secret_bytes).map_err(|_| KeyParsingError::BadKeypair)?;
+		let secret_bytes: [u8; SECRETKEYBYTES] =
+			secret_bytes.try_into().map_err(|_| KeyParsingError::BadKeypair)?;
 		let public =
 			PublicKey::from_bytes(public_bytes).map_err(|_| KeyParsingError::BadKeypair)?;
 
 		// Enforce the cross-field invariants: the secret key must be internally
 		// consistent (tr, t0) and the public key must be the one that corresponds
 		// to it. The derived pk is public data, so a non-constant-time comparison
-		// is fine.
-		let derived_public = crate::sign::public_key_from_secret(&secret.bytes)
+		// is fine. The SecretKey is constructed directly (not via
+		// `SecretKey::from_bytes`) so the keygen-scale derivation runs once, not
+		// twice.
+		let derived_public = crate::sign::public_key_from_secret(&secret_bytes)
 			.ok_or(KeyParsingError::BadKeypair)?;
 		if derived_public != public.bytes {
 			return Err(KeyParsingError::BadKeypair);
 		}
 
-		Ok(Keypair { secret, public })
+		Ok(Keypair { secret: SecretKey { bytes: secret_bytes }, public })
 	}
 
 	/// Compute a signature for a given message.
@@ -179,12 +184,26 @@ impl SecretKey {
 	/// * 'bytes' - private key bytes
 	///
 	/// Returns a SecretKey
+	///
+	/// # Consistency check
+	///
+	/// The packed key's internal invariants are validated, matching the
+	/// defense on the [`Keypair::from_bytes`] path: the stored `t0` must
+	/// equal the low bits re-derived from `(rho, s1, s2)`, and the stored
+	/// `tr` must equal `SHAKE256(pk)` for the re-derived public key. Signing
+	/// consumes both stored fields (`tr` is bound into the message digest,
+	/// `t0` into hint computation), so a corrupted or tampered blob would
+	/// otherwise import cleanly and then produce signatures that fail under
+	/// the corresponding public key. Rejecting it here fails fast at import
+	/// instead of creating a persistent signing outage — and ensures the same
+	/// serialized secret material has the same guarantees whether it is
+	/// imported as a `Keypair` or as a standalone `SecretKey`.
 	pub fn from_bytes(bytes: &[u8]) -> Result<SecretKey, KeyParsingError> {
-		let result = bytes.try_into();
-		match result {
-			Ok(bytes) => Ok(SecretKey { bytes }),
-			Err(_) => Err(BadSecretKey),
-		}
+		let bytes: [u8; SECRETKEYBYTES] = bytes.try_into().map_err(|_| BadSecretKey)?;
+		// Re-derives the public components and checks the stored tr/t0 against
+		// them; the derived pk itself is not needed here.
+		crate::sign::public_key_from_secret(&bytes).ok_or(BadSecretKey)?;
+		Ok(SecretKey { bytes })
 	}
 
 	/// Compute a signature for a given message.
@@ -439,6 +458,42 @@ mod tests {
 		assert!(
 			matches!(Keypair::from_bytes(&bad_t0), Err(KeyParsingError::BadKeypair)),
 			"secret key with corrupted t0 must be rejected"
+		);
+	}
+
+	// The standalone SecretKey import path must enforce the same tr/t0
+	// consistency defense as Keypair::from_bytes. Signing consumes the stored
+	// tr (bound into the message digest) and t0 (hint computation), so a
+	// corrupted standalone key would otherwise import cleanly and then emit
+	// signatures that fail under the corresponding public key — a persistent,
+	// hard-to-diagnose signing outage for callers that store SecretKey alone.
+	#[test]
+	fn secret_key_from_bytes_rejects_corrupted_tr_or_t0() {
+		use super::{KeyParsingError, Keypair, SecretKey, SECRETKEYBYTES};
+		use crate::params::{POLYT0_PACKEDBYTES, SEEDBYTES, TR_BYTES};
+
+		let keys = Keypair::generate(get_random_bytes());
+		let good = keys.secret.to_bytes();
+		assert!(SecretKey::from_bytes(&good).is_ok(), "honest secret key must be accepted");
+
+		// SK layout: rho (32) || key (32) || tr (64) || s1 || s2 || t0.
+		let tr_offset = 2 * SEEDBYTES;
+		let t0_offset = SECRETKEYBYTES - crate::params::K * POLYT0_PACKEDBYTES;
+
+		// Corrupt one byte inside the stored tr region only.
+		let mut bad_tr = good;
+		bad_tr[tr_offset + TR_BYTES / 2] ^= 0x01;
+		assert!(
+			matches!(SecretKey::from_bytes(&bad_tr), Err(KeyParsingError::BadSecretKey)),
+			"standalone secret key with corrupted tr must be rejected"
+		);
+
+		// Corrupt one byte inside the stored t0 region only.
+		let mut bad_t0 = good;
+		bad_t0[t0_offset] ^= 0x01;
+		assert!(
+			matches!(SecretKey::from_bytes(&bad_t0), Err(KeyParsingError::BadSecretKey)),
+			"standalone secret key with corrupted t0 must be rejected"
 		);
 	}
 

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -1,13 +1,45 @@
+//! Low-level polynomial arithmetic for ML-DSA-87.
+//!
+//! # Coefficient-bound contract
+//!
+//! The routines in this module are ports of the reference ML-DSA
+//! implementation. For performance and constant-time behaviour they do **not**
+//! re-validate their inputs; instead each function documents the coefficient
+//! bounds it requires and the bounds its output satisfies. Violating a
+//! precondition can overflow `i32` arithmetic — a panic in builds with
+//! overflow checks, silent wraparound (and a corrupt polynomial) in release
+//! builds.
+//!
+//! To keep those preconditions from being violated by *external* callers,
+//! [`Poly`] seals its coefficient array:
+//!
+//! - [`Poly::from_coeffs`] is the validated entry point for untrusted data; it only accepts
+//!   coefficients in `(-Q, Q)`, which satisfies every precondition in this module.
+//! - The unpack functions (`z_unpack`, `eta_unpack`, …) produce bounded coefficients by
+//!   construction.
+//! - [`Poly::coeffs_mut`] grants raw mutable access and shifts responsibility for the documented
+//!   bounds to the caller. It exists for advanced integrations (e.g. threshold signing) that
+//!   maintain the invariants themselves.
+//!
+//! Preconditions are additionally checked with `debug_assert!` so misuse fails
+//! loudly in tests without costing anything in release builds.
+
 use crate::{fips202, ntt, params, reduce, rounding};
+use core::fmt;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 const N: usize = params::N as usize;
 const UNIFORM_NBLOCKS: usize = (767 + fips202::SHAKE128_RATE) / fips202::SHAKE128_RATE;
 const D_SHL: i32 = 1 << (params::D - 1);
 
 /// Represents a polynomial
+///
+/// The coefficient array is not public: it can only be filled through
+/// validated constructors ([`Poly::from_coeffs`], the unpack functions, the
+/// samplers) or explicitly through [`Poly::coeffs_mut`], which documents the
+/// bounds the caller must uphold. See the module docs for the full contract.
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct Poly {
-	pub coeffs: [i32; N],
+	pub(crate) coeffs: [i32; N],
 }
 
 /// For some reason can't simply derive the Default trait
@@ -17,8 +49,72 @@ impl Default for Poly {
 	}
 }
 
+/// Error returned by [`Poly::from_coeffs`] when a coefficient lies outside
+/// `(-Q, Q)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoefficientOutOfRange {
+	/// Index of the first offending coefficient.
+	pub index: usize,
+	/// The offending value.
+	pub value: i32,
+}
+
+impl fmt::Display for CoefficientOutOfRange {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "coefficient {} at index {} is outside (-Q, Q)", self.value, self.index)
+	}
+}
+
+impl Poly {
+	/// Construct a polynomial from raw coefficients, validating that every
+	/// coefficient lies in `(-Q, Q)`.
+	///
+	/// This is the entry point for coefficients that cross a trust boundary
+	/// (deserialized, received from a peer, …). The accepted range covers both
+	/// standard representatives `[0, Q)` and signed representatives, and is
+	/// well inside the domain of every routine in this module, so a `Poly`
+	/// built here can be passed to any of them without overflow.
+	pub fn from_coeffs(coeffs: [i32; N]) -> Result<Poly, CoefficientOutOfRange> {
+		for (index, &value) in coeffs.iter().enumerate() {
+			if value <= -params::Q || value >= params::Q {
+				return Err(CoefficientOutOfRange { index, value });
+			}
+		}
+		Ok(Poly { coeffs })
+	}
+
+	/// Read-only access to the coefficient array.
+	pub fn coeffs(&self) -> &[i32; N] {
+		&self.coeffs
+	}
+
+	/// Raw mutable access to the coefficient array.
+	///
+	/// **Low-level contract:** writing through this reference bypasses the
+	/// validation performed by [`Poly::from_coeffs`]. The caller becomes
+	/// responsible for upholding the coefficient bounds documented on each
+	/// function in this module before passing the polynomial to it (e.g.
+	/// [`reduce`] requires `c <= 2^31 - 2^22 - 1`, [`invntt_tomont`] requires
+	/// `|c| < Q`). Never write attacker-controlled values here without
+	/// validating them first.
+	pub fn coeffs_mut(&mut self) -> &mut [i32; N] {
+		&mut self.coeffs
+	}
+}
+
 /// Inplace reduction of all coefficients of polynomial to representative in [-6283008,6283008].
+///
+/// # Preconditions
+///
+/// Every coefficient must be at most `2^31 - 2^22 - 1` (there is no lower
+/// limit). Larger values overflow the underlying `reduce32` shift trick:
+/// panic in builds with overflow checks, silent wraparound in release builds.
+/// Checked with `debug_assert!`.
 pub fn reduce(a: &mut Poly) {
+	debug_assert!(
+		a.coeffs.iter().all(|&c| c <= i32::MAX - (1 << 22)),
+		"poly::reduce precondition violated: coefficient > 2^31 - 2^22 - 1"
+	);
 	for coeff in a.coeffs.iter_mut() {
 		*coeff = reduce::reduce32(*coeff);
 	}
@@ -61,22 +157,55 @@ pub fn sub_ip(a: &mut Poly, b: &Poly) {
 }
 
 /// Multiply polynomial by 2^D without modular reduction.
-/// Assumes input coefficients to be less than 2^{31-D} in absolute value.
+///
+/// # Preconditions
+///
+/// Input coefficients must be less than `2^{31-D}` in absolute value,
+/// otherwise the shift overflows. Checked with `debug_assert!`.
 pub fn shiftl(a: &mut Poly) {
+	debug_assert!(
+		a.coeffs.iter().all(|&c| c.unsigned_abs() < 1 << (31 - params::D)),
+		"poly::shiftl precondition violated: |coefficient| >= 2^(31-D)"
+	);
 	for coeff in a.coeffs.iter_mut() {
 		*coeff <<= params::D;
 	}
 }
 
 /// Inplace forward NTT. Coefficients can grow by 8*Q in absolute value.
+///
+/// # Preconditions
+///
+/// Input coefficients must be at most `2^31 - 1 - 8*Q` in absolute value:
+/// each of the 8 butterfly layers can add up to Q to a coefficient's
+/// magnitude, and the additions are performed without modular reduction.
+/// Larger inputs overflow: panic in builds with overflow checks, silent
+/// wraparound in release builds. Checked with `debug_assert!`.
 pub fn ntt(a: &mut Poly) {
+	debug_assert!(
+		a.coeffs.iter().all(|&c| c.unsigned_abs() <= (i32::MAX - 8 * params::Q) as u32),
+		"poly::ntt precondition violated: |coefficient| > 2^31 - 1 - 8*Q"
+	);
 	ntt::ntt(&mut a.coeffs);
 }
 
 /// Inplace inverse NTT and multiplication by 2^{32}.
 /// Input coefficients need to be less than Q in absolute value and output coefficients are again
 /// bounded by Q.
+///
+/// # Preconditions
+///
+/// Input coefficients must be less than Q in absolute value. The inverse
+/// butterflies sum coefficients without modular reduction, and magnitudes can
+/// double at each of the 8 layers (`256 * Q` just fits in `i32`); larger
+/// inputs can overflow. Checked with `debug_assert!`. Forward-NTT output
+/// (which can reach 8*Q) must be brought back into range with
+/// [`reduce`] before being passed here.
 pub fn invntt_tomont(a: &mut Poly) {
+	debug_assert!(
+		a.coeffs.iter().all(|&c| c.unsigned_abs() < params::Q as u32),
+		"poly::invntt_tomont precondition violated: |coefficient| >= Q"
+	);
 	ntt::invntt_tomont(&mut a.coeffs);
 }
 
@@ -110,7 +239,12 @@ pub fn power2round(a1: &mut Poly, a0: &mut Poly) {
 }
 
 /// Check infinity norm of polynomial against given bound.
-/// Assumes input coefficients were reduced by reduce32().
+///
+/// Total for all `i32` coefficient values: the absolute value is computed in
+/// `i64`, so no input can overflow the arithmetic or wrap into a wrong result.
+/// (The classic 32-bit shift trick `c - (mask & 2*c)` overflows `2*c` for
+/// |c| > i32::MAX/2 and mis-handles i32::MIN; out-of-range coefficients would
+/// then *pass* the norm check instead of failing it.)
 ///
 /// # Arguments
 ///
@@ -129,11 +263,14 @@ pub fn check_norm(a: &Poly, b: i32) -> bool {
 	// Always process all coefficients: an early exit would leak the index of the first
 	// out-of-bound coefficient of secret-derived data (e.g. z = y + c*s1).
 	for i in 0..N {
-		let mut t = a.coeffs[i] >> 31;
-		t = a.coeffs[i] - (t & 2 * a.coeffs[i]);
+		// Branchless |c| in i64: sign-mask fold instead of a data-dependent
+		// branch or `abs()` call, correct for every i32 including i32::MIN.
+		let c = a.coeffs[i] as i64;
+		let mask = c >> 63;
+		let t = (c ^ mask) - mask;
 
 		// Bitwise OR accumulation instead of a data-dependent branch
-		result |= t >= b;
+		result |= t >= b as i64;
 	}
 	result
 }
@@ -697,6 +834,9 @@ mod tests {
 
 		let original = poly.clone();
 		ntt(&mut poly);
+		// Forward-NTT output can reach 8*Q; bring it back below Q before the
+		// inverse transform, as its input contract requires.
+		reduce(&mut poly);
 		invntt_tomont(&mut poly);
 
 		// After NTT and inverse NTT, we should get back the original (possibly with Montgomery
@@ -739,6 +879,48 @@ mod tests {
 		let poly = Poly::default(); // All coefficients are 0
 		assert!(!check_norm(&poly, 1)); // Should be within any positive bound
 		assert!(!check_norm(&poly, 1000));
+	}
+
+	#[test]
+	fn test_from_coeffs_validates_range() {
+		// In-range coefficients (signed and standard representatives) are accepted.
+		let mut coeffs = [0i32; N];
+		coeffs[0] = params::Q - 1;
+		coeffs[1] = -(params::Q - 1);
+		let poly = Poly::from_coeffs(coeffs).expect("in-range coefficients must be accepted");
+		assert_eq!(poly.coeffs()[0], params::Q - 1);
+		assert_eq!(poly.coeffs()[1], -(params::Q - 1));
+
+		// Out-of-range coefficients are rejected with the offending position.
+		// (`Poly` has no `Debug` impl by design, so match instead of expect_err.)
+		for bad in [params::Q, -params::Q, i32::MAX, i32::MIN] {
+			let mut coeffs = [0i32; N];
+			coeffs[7] = bad;
+			match Poly::from_coeffs(coeffs) {
+				Ok(_) => panic!("out-of-range coefficient {} must be rejected", bad),
+				Err(err) => assert_eq!(err, CoefficientOutOfRange { index: 7, value: bad }),
+			}
+		}
+	}
+
+	#[test]
+	fn test_chknorm_total_for_all_i32() {
+		// `check_norm` must be correct for every possible i32 coefficient, not
+		// just protocol-bounded ones. The old shift-trick absolute value
+		// (`c - (mask & 2*c)`) overflowed `2*c` for |c| > i32::MAX/2 (panic in
+		// checked builds) and produced a wrong, negative "absolute value" for
+		// i32::MIN in release builds, silently accepting a coefficient that
+		// must be rejected.
+		for extreme in [i32::MIN, i32::MIN + 1, -(params::Q * 2), i32::MAX / 2 + 1, i32::MAX] {
+			let mut poly = Poly::default();
+			poly.coeffs[0] = extreme;
+			assert!(check_norm(&poly, 100), "coefficient {} must exceed bound 100", extreme);
+			assert!(
+				check_norm(&poly, (params::Q - 1) / 8),
+				"coefficient {} must exceed the maximum bound",
+				extreme
+			);
+		}
 	}
 
 	#[test]

--- a/dilithium/src/polyvec.rs
+++ b/dilithium/src/polyvec.rs
@@ -530,6 +530,9 @@ mod tests {
 
 		let original = polyvecl.clone();
 		l_ntt(&mut polyvecl);
+		// Forward-NTT output can reach 8*Q; the inverse transform requires
+		// coefficients below Q in absolute value.
+		l_reduce(&mut polyvecl);
 		l_invntt_tomont(&mut polyvecl);
 
 		// After NTT and inverse NTT, values should be close to original
@@ -561,6 +564,9 @@ mod tests {
 
 		let original = polyveck.clone();
 		k_ntt(&mut polyveck);
+		// Forward-NTT output can reach 8*Q; the inverse transform requires
+		// coefficients below Q in absolute value.
+		k_reduce(&mut polyveck);
 		k_invntt_tomont(&mut polyveck);
 
 		// After NTT and inverse NTT, values should be close to original

--- a/hdwallet/src/hderive.rs
+++ b/hdwallet/src/hderive.rs
@@ -37,10 +37,6 @@ impl ChildNumber {
 	pub fn to_bytes(&self) -> [u8; 4] {
 		self.0.to_be_bytes()
 	}
-
-	pub fn hardened_from_u32(index: u32) -> Self {
-		ChildNumber(index | HARDENED_BIT)
-	}
 }
 
 impl FromStr for ChildNumber {
@@ -259,5 +255,32 @@ mod tests {
 			"m/44'/189189189'/+0'".parse::<DerivationPath>().unwrap_err(),
 			Error::InvalidChildNumber
 		);
+	}
+
+	// Every ChildNumber construction path must enforce `index < 2^31` before
+	// setting the hardened bit. An index with the bit already set (e.g.
+	// 2147483648) would encode to the same four bytes as its low alias (0'),
+	// and since only those bytes feed the HMAC derivation, two distinct
+	// advertised indexes would silently derive the same wallet key. The
+	// string parser is the only remaining public constructor (the unchecked
+	// numeric constructor `hardened_from_u32` was removed for exactly this
+	// aliasing risk), so pin the parser's rejection here.
+	#[test]
+	fn child_indexes_with_hardened_bit_set_rejected() {
+		// The largest valid index and its would-be aliases.
+		assert_eq!("2147483647'".parse::<ChildNumber>().unwrap(), ChildNumber(u32::MAX));
+		for (aliased, canonical) in [("2147483648'", "0'"), ("2147483692'", "44'")] {
+			assert!(
+				canonical.parse::<ChildNumber>().is_ok(),
+				"canonical child number {canonical:?} must parse"
+			);
+			assert_eq!(
+				aliased.parse::<ChildNumber>().unwrap_err(),
+				Error::InvalidChildNumber,
+				"{aliased:?} must be rejected, not alias {canonical:?}"
+			);
+		}
+		// Beyond u32 entirely.
+		assert_eq!("4294967296'".parse::<ChildNumber>().unwrap_err(), Error::InvalidChildNumber);
 	}
 }

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -190,6 +190,11 @@ pub fn derive_key_from_seed(seed: SensitiveBytes64, path: &str) -> Result<Keypai
 
 /// Keypair derivation from mnemonic with passphrase.
 ///
+/// The derivation path is validated *before* BIP39 seed stretching, so a
+/// request that is guaranteed to fail path validation cannot force the
+/// expensive PBKDF2 work (the seed-based entrypoints reject bad paths before
+/// any derivation; the mnemonic wrappers must not be a cheaper DoS target).
+///
 /// # Security Note
 /// Takes the mnemonic by reference and does not copy it into a heap buffer,
 /// avoiding a redundant duplicate of the secret. The caller retains ownership
@@ -199,11 +204,15 @@ pub fn derive_key_from_mnemonic(
 	passphrase: Option<&str>,
 	path: &str,
 ) -> Result<Keypair, HDLatticeError> {
+	check_derivation_path(path)?;
 	let mut seed = parse_mnemonic_to_seed(mnemonic, passphrase)?;
 	derive_key_from_seed(SensitiveBytes64::from(&mut seed), path)
 }
 
 /// Wormhole pair derivation from mnemonic with passphrase.
+///
+/// The derivation path (including the wormhole chain-ID requirement) is
+/// validated *before* BIP39 seed stretching; see [`derive_key_from_mnemonic`].
 ///
 /// # Security Note
 /// Takes the mnemonic by reference and does not copy it into a heap buffer,
@@ -214,6 +223,7 @@ pub fn derive_wormhole_from_mnemonic(
 	passphrase: Option<&str>,
 	path: &str,
 ) -> Result<WormholePair, HDLatticeError> {
+	check_wormhole_path(path)?;
 	let mut seed = parse_mnemonic_to_seed(mnemonic, passphrase)?;
 	generate_wormhole_from_seed(SensitiveBytes64::from(&mut seed), path)
 }
@@ -227,11 +237,7 @@ pub fn generate_wormhole_from_seed(
 	seed: SensitiveBytes64,
 	path: &str,
 ) -> Result<WormholePair, HDLatticeError> {
-	check_derivation_path(path)?;
-
-	if path.split("/").nth(2) != Some(QUANTUS_WORMHOLE_CHAIN_ID) {
-		return Err(HDLatticeError::InvalidWormholePath(path.to_string()));
-	}
+	check_wormhole_path(path)?;
 
 	// Derive entropy at the specified path
 	let xpriv = ExtendedPrivKey::derive(seed.as_bytes(), path)
@@ -245,6 +251,16 @@ pub fn generate_wormhole_from_seed(
 	// seed and derived_entropy are automatically zeroized when they drop
 
 	Ok(wormhole_pair)
+}
+
+/// Validate a wormhole derivation path: generic path checks plus the
+/// wormhole chain-ID requirement in the third segment.
+fn check_wormhole_path(path: &str) -> Result<(), HDLatticeError> {
+	check_derivation_path(path)?;
+	if path.split("/").nth(2) != Some(QUANTUS_WORMHOLE_CHAIN_ID) {
+		return Err(HDLatticeError::InvalidWormholePath(path.to_string()));
+	}
+	Ok(())
 }
 
 /// Validate a derivation path — bounds first, then hardened-only syntax via parsing.

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -48,6 +48,10 @@ pub enum HDLatticeError {
 	PathTooLong(usize),
 	#[error("Derivation path too deep: {0} segments")]
 	PathTooDeep(usize),
+	#[error("Mnemonic too long: {0} bytes")]
+	MnemonicTooLong(usize),
+	#[error("Passphrase too long: {0} bytes")]
+	PassphraseTooLong(usize),
 	#[error("hderive error: {0:?}")]
 	GenericError(hderive::Error),
 }
@@ -65,6 +69,18 @@ pub const MAX_DERIVATION_DEPTH: usize = 16;
 /// Maximum raw byte length of an accepted derivation path string.
 /// Sized for 16 segments of up to ~14 chars plus the `m/` prefix.
 pub const MAX_DERIVATION_PATH_BYTES: usize = 256;
+
+/// Maximum raw byte length of an accepted mnemonic string.
+/// The longest valid BIP39 English phrase (24 words of 8 chars plus separators)
+/// is ~215 bytes; 1 KiB leaves ample headroom (e.g. exotic whitespace, decomposed
+/// Unicode) while bounding the normalization and parsing work an attacker can force.
+pub const MAX_MNEMONIC_BYTES: usize = 1024;
+
+/// Maximum raw byte length of an accepted passphrase string.
+/// BIP39 places no limit on passphrases, but normalization allocates a full
+/// copy and PBKDF2 absorbs the passphrase into its salt, so an unbounded
+/// passphrase is a CPU/memory DoS vector. 1 KiB far exceeds any realistic use.
+pub const MAX_PASSPHRASE_BYTES: usize = 1024;
 
 /// Convert a BIP39 mnemonic phrase to a seed
 ///
@@ -120,10 +136,23 @@ fn nfkd_owned(s: &str) -> Option<Zeroizing<String>> {
 /// assume the *caller* already normalized their inputs, so we normalize here. Without
 /// this, canonically equivalent inputs (e.g. a composed "é" vs a decomposed "e"+combining
 /// accent in a passphrase) would silently derive different seeds and thus different keys.
+///
+/// Both inputs are size-capped ([`MAX_MNEMONIC_BYTES`], [`MAX_PASSPHRASE_BYTES`])
+/// *before* normalization, so attacker-controlled text cannot drive unbounded
+/// allocation, normalization scans, or PBKDF2 work prior to rejection.
 fn parse_mnemonic_to_seed(
 	mnemonic: &str,
 	passphrase: Option<&str>,
 ) -> Result<[u8; 64], HDLatticeError> {
+	if mnemonic.len() > MAX_MNEMONIC_BYTES {
+		return Err(HDLatticeError::MnemonicTooLong(mnemonic.len()));
+	}
+	if let Some(p) = passphrase {
+		if p.len() > MAX_PASSPHRASE_BYTES {
+			return Err(HDLatticeError::PassphraseTooLong(p.len()));
+		}
+	}
+
 	let normalized_mnemonic = nfkd_owned(mnemonic);
 	let mnemonic = normalized_mnemonic.as_ref().map_or(mnemonic, |m| m.as_str());
 

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -662,6 +662,44 @@ mod hdwallet_tests {
 		}
 	}
 
+	/// Mnemonic and passphrase inputs must be size-capped before Unicode
+	/// normalization and seed derivation, mirroring the derivation-path caps.
+	/// Without bounds, a caller-controlled huge passphrase (or a huge
+	/// non-normalized mnemonic) drives unbounded allocation, normalization
+	/// scans, and PBKDF2 work before any rejection.
+	#[test]
+	fn test_rejects_oversized_mnemonic_and_passphrase() {
+		use crate::{derive_key_from_mnemonic, MAX_MNEMONIC_BYTES, MAX_PASSPHRASE_BYTES};
+
+		let valid = "rocket primary way job input cactus submit menu zoo burger rent impose";
+
+		// A valid mnemonic paired with an oversized passphrase must be rejected
+		// up front instead of deriving a seed over attacker-sized input.
+		let huge_passphrase = "p".repeat(MAX_PASSPHRASE_BYTES + 1);
+		let err = mnemonic_to_seed(valid.to_string(), Some(&huge_passphrase))
+			.expect_err("oversized passphrase must be rejected");
+		assert!(matches!(err, HDLatticeError::PassphraseTooLong(_)), "got {err:?}");
+
+		// An oversized mnemonic must be rejected before normalization/parsing.
+		// Use a non-NFKD char so the pre-fix code path would also allocate a
+		// normalized copy of the whole input.
+		let huge_mnemonic = "\u{00e9} ".repeat(MAX_MNEMONIC_BYTES / 2 + 1);
+		let err = mnemonic_to_seed(huge_mnemonic, None)
+			.expect_err("oversized mnemonic must be rejected");
+		assert!(matches!(err, HDLatticeError::MnemonicTooLong(_)), "got {err:?}");
+
+		// The borrowed-mnemonic helpers share the same parser and must enforce
+		// the same caps.
+		let err = derive_key_from_mnemonic(valid, Some(&huge_passphrase), "m/44'/189189'/0'")
+			.expect_err("oversized passphrase must be rejected in derive_key_from_mnemonic");
+		assert!(matches!(err, HDLatticeError::PassphraseTooLong(_)), "got {err:?}");
+
+		// Inputs at exactly the caps must still be accepted.
+		let max_passphrase = "p".repeat(MAX_PASSPHRASE_BYTES);
+		mnemonic_to_seed(valid.to_string(), Some(&max_passphrase))
+			.expect("passphrase at exactly MAX_PASSPHRASE_BYTES must be accepted");
+	}
+
 	#[test]
 	fn test_mnemonic_to_seed_zeroizes_on_parse_failure() {
 		let bogus = "not a valid bip39 mnemonic phrase at all".to_string();

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -725,8 +725,8 @@ mod hdwallet_tests {
 		// Use a non-NFKD char so the pre-fix code path would also allocate a
 		// normalized copy of the whole input.
 		let huge_mnemonic = "\u{00e9} ".repeat(MAX_MNEMONIC_BYTES / 2 + 1);
-		let err = mnemonic_to_seed(huge_mnemonic, None)
-			.expect_err("oversized mnemonic must be rejected");
+		let err =
+			mnemonic_to_seed(huge_mnemonic, None).expect_err("oversized mnemonic must be rejected");
 		assert!(matches!(err, HDLatticeError::MnemonicTooLong(_)), "got {err:?}");
 
 		// The borrowed-mnemonic helpers share the same parser and must enforce

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -697,8 +697,9 @@ mod hdwallet_tests {
 		// syntactically valid but uses the Dilithium chain ID, not the wormhole one.
 		match derive_wormhole_from_mnemonic(bogus_mnemonic, None, "m/44'/189189'/0'") {
 			Err(HDLatticeError::InvalidWormholePath(_)) => {},
-			Err(other) =>
-				panic!("wrong chain ID must be rejected before seed stretching, got {other:?}"),
+			Err(other) => {
+				panic!("wrong chain ID must be rejected before seed stretching, got {other:?}")
+			},
 			Ok(_) => panic!("expected InvalidWormholePath, got Ok"),
 		}
 	}

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -662,6 +662,47 @@ mod hdwallet_tests {
 		}
 	}
 
+	/// The mnemonic-based helpers must validate the derivation path *before*
+	/// BIP39 seed stretching, matching the seed-based entrypoints. The error
+	/// precedence makes the ordering observable: with a bogus mnemonic AND a
+	/// bad path, a path error proves the cheap check ran first, while a
+	/// Bip39Error would prove the expensive mnemonic work ran first.
+	#[test]
+	fn test_mnemonic_helpers_validate_path_before_seed_stretching() {
+		use crate::{
+			derive_key_from_mnemonic, derive_wormhole_from_mnemonic, MAX_DERIVATION_PATH_BYTES,
+		};
+
+		let bogus_mnemonic = "not a valid bip39 mnemonic phrase at all";
+		let mut oversized = String::from("m");
+		while oversized.len() <= MAX_DERIVATION_PATH_BYTES {
+			oversized.push_str("/1'");
+		}
+
+		let err = derive_key_from_mnemonic(bogus_mnemonic, None, &oversized).unwrap_err();
+		assert!(
+			matches!(err, HDLatticeError::PathTooLong(_)),
+			"path must be rejected before seed stretching, got {err:?}"
+		);
+
+		// WormholePair has no Debug impl (it holds a secret), so match instead
+		// of unwrap_err.
+		match derive_wormhole_from_mnemonic(bogus_mnemonic, None, &oversized) {
+			Err(HDLatticeError::PathTooLong(_)) => {},
+			Err(other) => panic!("path must be rejected before seed stretching, got {other:?}"),
+			Ok(_) => panic!("expected PathTooLong, got Ok"),
+		}
+
+		// The wormhole chain-ID check must also precede seed work: this path is
+		// syntactically valid but uses the Dilithium chain ID, not the wormhole one.
+		match derive_wormhole_from_mnemonic(bogus_mnemonic, None, "m/44'/189189'/0'") {
+			Err(HDLatticeError::InvalidWormholePath(_)) => {},
+			Err(other) =>
+				panic!("wrong chain ID must be rejected before seed stretching, got {other:?}"),
+			Ok(_) => panic!("expected InvalidWormholePath, got Ok"),
+		}
+	}
+
 	/// Mnemonic and passphrase inputs must be size-capped before Unicode
 	/// normalization and seed derivation, mirroring the derivation-path caps.
 	/// Without bounds, a caller-controlled huge passphrase (or a huge

--- a/threshold/src/circl_ntt.rs
+++ b/threshold/src/circl_ntt.rs
@@ -87,13 +87,13 @@ pub fn mul_hat(p: &mut Poly, a: &Poly, b: &Poly) {
 	let mut a_u32 = [0u32; N];
 	let mut b_u32 = [0u32; N];
 
-	for (i, (a_coeff, b_coeff)) in a.coeffs.iter().zip(b.coeffs.iter()).enumerate() {
+	for (i, (a_coeff, b_coeff)) in a.coeffs().iter().zip(b.coeffs().iter()).enumerate() {
 		a_u32[i] = if *a_coeff < 0 { (*a_coeff + Q as i32) as u32 } else { *a_coeff as u32 };
 		b_u32[i] = if *b_coeff < 0 { (*b_coeff + Q as i32) as u32 } else { *b_coeff as u32 };
 	}
 
 	// Pointwise Montgomery multiplication
-	for (p_coeff, (a_val, b_val)) in p.coeffs.iter_mut().zip(a_u32.iter().zip(b_u32.iter())) {
+	for (p_coeff, (a_val, b_val)) in p.coeffs_mut().iter_mut().zip(a_u32.iter().zip(b_u32.iter())) {
 		let result = mont_reduce_le2q(*a_val as u64 * *b_val as u64);
 		*p_coeff = result as i32;
 	}
@@ -107,7 +107,7 @@ pub fn mul_hat(p: &mut Poly, a: &Poly, b: &Poly) {
 ///
 /// Matches the reference implementation for compatibility.
 pub fn ntt(p: &mut Poly) {
-	let coeffs = &mut p.coeffs;
+	let coeffs = p.coeffs_mut();
 
 	// Convert i32 coefficients to u32 for NTT computation
 	let mut coeffs_u32 = [0u32; N];
@@ -153,7 +153,7 @@ pub fn ntt(p: &mut Poly) {
 ///
 /// Matches the reference implementation for compatibility.
 pub fn inv_ntt(p: &mut Poly) {
-	let coeffs = &mut p.coeffs;
+	let coeffs = p.coeffs_mut();
 
 	// Convert i32 coefficients to u32 for NTT computation
 	let mut coeffs_u32 = [0u32; N];
@@ -206,9 +206,9 @@ mod tests {
 	fn test_ntt_basic() {
 		let mut p = Poly::default();
 		// Set up a simple test polynomial
-		p.coeffs[0] = 1;
-		p.coeffs[1] = 2;
-		p.coeffs[2] = 3;
+		p.coeffs_mut()[0] = 1;
+		p.coeffs_mut()[1] = 2;
+		p.coeffs_mut()[2] = 3;
 
 		ntt(&mut p);
 		inv_ntt(&mut p);
@@ -226,14 +226,14 @@ mod tests {
 
 		// Set up simple test values
 		for i in 0..5 {
-			a.coeffs[i] = (i + 1) as i32;
-			b.coeffs[i] = (i + 2) as i32;
+			a.coeffs_mut()[i] = (i + 1) as i32;
+			b.coeffs_mut()[i] = (i + 2) as i32;
 		}
 
 		mul_hat(&mut result, &a, &b);
 
 		// Basic sanity check - results should be non-zero
-		assert_ne!(result.coeffs[0], 0);
+		assert_ne!(result.coeffs()[0], 0);
 	}
 
 	#[test]
@@ -274,18 +274,18 @@ mod tests {
 			8380417, 8380417, 8380416, 8380415,
 		];
 
-		for (dst, src) in p.coeffs.iter_mut().zip(go_coeffs.iter()) {
+		for (dst, src) in p.coeffs_mut().iter_mut().zip(go_coeffs.iter()) {
 			*dst = *src;
 		}
 
 		ntt(&mut p);
 
 		// Expected output from Go: [34915453 37803751 41654889 51878135 44099773]
-		assert_eq!(p.coeffs[0], 34915453, "coeff[0] mismatch");
-		assert_eq!(p.coeffs[1], 37803751, "coeff[1] mismatch");
-		assert_eq!(p.coeffs[2], 41654889, "coeff[2] mismatch");
-		assert_eq!(p.coeffs[3], 51878135, "coeff[3] mismatch");
-		assert_eq!(p.coeffs[4], 44099773, "coeff[4] mismatch");
+		assert_eq!(p.coeffs()[0], 34915453, "coeff[0] mismatch");
+		assert_eq!(p.coeffs()[1], 37803751, "coeff[1] mismatch");
+		assert_eq!(p.coeffs()[2], 41654889, "coeff[2] mismatch");
+		assert_eq!(p.coeffs()[3], 51878135, "coeff[3] mismatch");
+		assert_eq!(p.coeffs()[4], 44099773, "coeff[4] mismatch");
 	}
 
 	#[test]
@@ -293,11 +293,11 @@ mod tests {
 		// Test NTT of a simple challenge polynomial with just one non-zero coefficient
 		// This test creates a polynomial with c[4] = Q-1 (representing -1)
 		let mut p = Poly::default();
-		p.coeffs[4] = 8380416; // Q-1, representing -1
+		p.coeffs_mut()[4] = 8380416; // Q-1, representing -1
 
 		ntt(&mut p);
 
 		// Verify the NTT produces consistent output
-		assert_ne!(p.coeffs[0], 0, "NTT should produce non-zero coefficients");
+		assert_ne!(p.coeffs()[0], 0, "NTT should produce non-zero coefficients");
 	}
 }

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -11,13 +11,34 @@
 //! 1. Each party derives a DKG contribution from their master share + tweak
 //! 2. Parties run full DKG using these contributions for randomness
 //! 3. The resulting shares are stored (cannot be recomputed on-the-fly)
-//! 4. The derived public key is deterministic for the same (master_key, tweak)
+//! 4. There is one canonical derived key per `(master_key, tweak)`: the key produced by the single
+//!    DKG run performed for that tweak, then stored and looked up by [`DerivedKeyId`]
+//!
+//! # The derived key is NOT recomputable
+//!
+//! Only the per-party *contribution* ([`derive_dkg_contribution`]) is a
+//! deterministic function of `(master_share, tweak)`. The derived public key
+//! itself is **not** a pure function of `(master_key, tweak)`: every DKG
+//! session mixes a mandatory fresh `session_nonce` (via the session SSID) into
+//! each party's Round 1 randomness, and the final key is derived from the
+//! aggregated `global_randomness`. This is deliberate — without the nonce
+//! binding, an adversary who observed a failed attempt's Round 2 reveals could
+//! predict honest randomness on retry and grind the result.
+//!
+//! Consequently, re-running the DKG for the same `(master_key, tweak)` — e.g.
+//! during node re-provisioning, disaster recovery, or to cross-check a
+//! contract-stored address — yields a **different** key. Recovery flows must
+//! restore the *stored* derived shares (step 3); they can never regenerate
+//! them.
 //!
 //! # Tweak Computation
 //!
 //! The tweak should be computed by the caller using the same algorithm as the
-//! NEAR MPC contract (`derive_dilithium_tweak`). This ensures consistency between
-//! the contract (which stores derived public keys) and the MPC nodes (which run DKG).
+//! NEAR MPC contract (`derive_dilithium_tweak`). This keeps the contract and
+//! the MPC nodes agreed on *which* derived key a request refers to: the
+//! contract stores the derived public key produced by the canonical DKG run,
+//! keyed by the same tweak the nodes use to derive their contributions and
+//! look up their stored shares.
 //!
 //! # Security
 //!

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -168,7 +168,7 @@ pub fn generate_with_dealer(
 	// Normalize t
 	for t_poly in t.vec.iter_mut().take(K) {
 		poly::reduce(t_poly);
-		for coeff in t_poly.coeffs.iter_mut() {
+		for coeff in t_poly.coeffs_mut().iter_mut() {
 			let normalized = ((*coeff % Q) + Q) % Q;
 			*coeff = normalized;
 		}
@@ -204,12 +204,12 @@ pub fn generate_with_dealer(
 		for (subset_id, share) in party_shares_map {
 			let mut s1_data = [[0i32; 256]; L];
 			for (i, s1_item) in s1_data.iter_mut().enumerate() {
-				s1_item.copy_from_slice(&share.s1_share.vec[i].coeffs);
+				s1_item.copy_from_slice(share.s1_share.vec[i].coeffs());
 			}
 
 			let mut s2_data = [[0i32; 256]; K];
 			for (i, s2_item) in s2_data.iter_mut().enumerate() {
-				s2_item.copy_from_slice(&share.s2_share.vec[i].coeffs);
+				s2_item.copy_from_slice(share.s2_share.vec[i].coeffs());
 			}
 
 			shares_data.insert(subset_id, SecretShareData { s1: s1_data, s2: s2_data });
@@ -341,7 +341,7 @@ fn generate_threshold_shares(
 		// the sum is bounded by ±12870, well within i32 range.
 		for (total_poly, share_poly) in s1_total.vec.iter_mut().zip(s1_share.vec.iter()).take(L) {
 			for (total_coeff, share_coeff) in
-				total_poly.coeffs.iter_mut().zip(share_poly.coeffs.iter())
+				total_poly.coeffs_mut().iter_mut().zip(share_poly.coeffs().iter())
 			{
 				*total_coeff += *share_coeff;
 			}
@@ -349,7 +349,7 @@ fn generate_threshold_shares(
 
 		for (total_poly, share_poly) in s2_total.vec.iter_mut().zip(s2_share.vec.iter()).take(K) {
 			for (total_coeff, share_coeff) in
-				total_poly.coeffs.iter_mut().zip(share_poly.coeffs.iter())
+				total_poly.coeffs_mut().iter_mut().zip(share_poly.coeffs().iter())
 			{
 				*total_coeff += *share_coeff;
 			}
@@ -366,7 +366,7 @@ fn generate_threshold_shares(
 
 	// Normalize s1_total (η-bounded sums)
 	for total_poly in s1_total.vec.iter_mut().take(L) {
-		for total_coeff in total_poly.coeffs.iter_mut() {
+		for total_coeff in total_poly.coeffs_mut().iter_mut() {
 			let coeff_u32 =
 				if *total_coeff < 0 { (*total_coeff + Q) as u32 } else { *total_coeff as u32 };
 			*total_coeff = mod_q(coeff_u32) as i32;
@@ -375,7 +375,7 @@ fn generate_threshold_shares(
 
 	// Normalize s2_total (η-bounded sums)
 	for total_poly in s2_total.vec.iter_mut().take(K) {
-		for total_coeff in total_poly.coeffs.iter_mut() {
+		for total_coeff in total_poly.coeffs_mut().iter_mut() {
 			let coeff_u32 =
 				if *total_coeff < 0 { (*total_coeff + Q) as u32 } else { *total_coeff as u32 };
 			*total_coeff = mod_q(coeff_u32) as i32;

--- a/threshold/src/keygen/dkg/mod.rs
+++ b/threshold/src/keygen/dkg/mod.rs
@@ -28,10 +28,18 @@
 //!
 //! # Channel Requirements
 //!
-//! **IMPORTANT: `SendPrivate` messages (Round 1 K_S distribution) require an
-//! authenticated and encrypted channel.**
+//! All DKG messages require transport-level sender authentication:
 //!
-//! The caller must ensure that when handling `DkgAction::SendPrivate(to, data)`:
+//! | Action | Transport requirement |
+//! |--------|----------------------|
+//! | `DkgAction::SendMany` (Rounds 1–4 broadcasts) | Authenticated broadcast (integrity + sender authentication) |
+//! | `DkgAction::SendPrivate` (Round 1 K_S distribution) | **Authenticated encryption** (confidentiality + integrity + sender authentication) |
+//!
+//! The `from` argument to [`Dkg::message`] is trusted: it MUST be the
+//! transport-authenticated identity of the sender, never derived from
+//! attacker-controllable packet contents.
+//!
+//! For `DkgAction::SendPrivate(to, data)` the caller must ensure:
 //! - **Confidentiality**: The message is encrypted so only the recipient can read it
 //! - **Authenticity**: The recipient can verify the sender's identity
 //! - **Integrity**: The message cannot be modified in transit
@@ -39,6 +47,15 @@
 //! Failure to provide these guarantees compromises the threshold scheme's security:
 //! - Without encryption, an eavesdropper learns K_S and can compute subset shares
 //! - Without authentication, an attacker could inject fake K_S values
+//!
+//! For `DkgAction::SendMany` broadcasts, confidentiality is not needed (the
+//! payloads are public), but authenticity and integrity are: round buffers
+//! keep the first message received per sender (a memory-exhaustion defense),
+//! so on an unauthenticated transport an attacker who injects a forged
+//! broadcast first occupies that participant's slot and the honest broadcast
+//! is ignored. The forgery is detected by commitment or transcript
+//! verification, but only as a late abort — repeated injection denies
+//! completion of every session.
 //!
 //! # Security Properties and Limitations
 //!

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -2238,6 +2238,46 @@ mod tests {
 		}
 	}
 
+	/// The DKG output public key is intentionally NOT a pure function of the
+	/// parties' seeds: each party's Round 1 randomness is bound to the session
+	/// SSID (which incorporates `session_nonce`), and the final key is
+	/// computed from `rho = h_seed(global_randomness)`. Re-running the DKG
+	/// with identical seeds but a fresh nonce therefore yields a different
+	/// key — that is the security property that stops an adversary who saw a
+	/// failed attempt's Round 2 reveals from predicting honest randomness and
+	/// grinding `global_randomness` on retry (see `derive_round1_randomness`).
+	///
+	/// This test pins that behavior so documentation like `derivation.rs`
+	/// ("one canonical stored key per (master_key, tweak)", not "recomputable
+	/// from (master_key, tweak)") stays honest: derived keys must be stored,
+	/// never recovered by re-running the DKG.
+	#[test]
+	fn test_dkg_public_key_depends_on_session_nonce() {
+		let seed = [42u8; 32];
+		let run = |nonce: &[u8; 32]| {
+			let signers: Vec<TestSigner> = (0..3).map(|id| TestSigner { id }).collect();
+			let public_keys: Vec<u32> = (0..3).collect();
+			run_local_dkg(2, 3, signers, public_keys, seed, nonce).unwrap()
+		};
+
+		let nonce_a = [0xA1u8; 32];
+		let nonce_b = [0xB2u8; 32];
+
+		let pk_a = run(&nonce_a)[0].public_key.clone();
+		let pk_b = run(&nonce_b)[0].public_key.clone();
+		assert_ne!(
+			pk_a.as_bytes(),
+			pk_b.as_bytes(),
+			"identical seeds with a fresh session nonce must produce a different public key; \
+			 if this ever fails, Round 1 randomness lost its SSID binding (grinding risk)"
+		);
+
+		// Within one session (same nonce), the protocol is deterministic for
+		// fixed seeds — honest parties agree and reruns reproduce the key.
+		let pk_a2 = run(&nonce_a)[0].public_key.clone();
+		assert_eq!(pk_a.as_bytes(), pk_a2.as_bytes());
+	}
+
 	/// Mismatched input vector lengths must return a `DkgError`, not panic.
 	/// `run_local_dkg` is public, so untrusted setup parameters reaching a
 	/// `.unwrap()` or `dkgs[party_id]` index would be an availability DoS.

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -585,8 +585,8 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// requirements.
 	///
 	/// # Arguments
-	/// * `from` - The party ID of the sender. MUST come from transport-level sender
-	///   authentication, never from attacker-controllable packet contents.
+	/// * `from` - The party ID of the sender. MUST come from transport-level sender authentication,
+	///   never from attacker-controllable packet contents.
 	/// * `data` - The serialized message bytes
 	///
 	/// # Errors

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -163,7 +163,7 @@ impl fmt::Display for DkgError {
 ///
 /// The caller should handle each action appropriately:
 /// - `Wait`: No action needed, call `poke()` again after receiving messages
-/// - `SendMany`: Broadcast the data to all other participants
+/// - `SendMany`: Broadcast the data to all other participants via authenticated channel
 /// - `SendPrivate`: Send the data to a specific participant via secure channel
 /// - `Return`: The DKG is complete, the output contains the keys
 ///
@@ -180,6 +180,25 @@ pub enum DkgAction {
 	/// Wait for more messages before proceeding.
 	Wait,
 	/// Broadcast data to all other participants.
+	///
+	/// **IMPORTANT: This message MUST be sent over an authenticated channel
+	/// (integrity + sender authentication).**
+	///
+	/// The caller is responsible for ensuring:
+	/// - **Authenticity**: Receivers can verify the broadcast came from us — the `from` argument
+	///   that peers pass to [`Dkg::message`] is trusted and must be derived from transport-level
+	///   sender authentication, not from attacker-controllable packet contents
+	/// - **Integrity**: The message cannot be modified in transit
+	///
+	/// Confidentiality is not required; broadcast payloads are public.
+	///
+	/// Without sender authentication, an attacker who can inject packets can
+	/// spoof a participant's broadcast before the genuine one arrives. Round
+	/// buffers keep the first message per sender (first-message-wins, a
+	/// memory-exhaustion defense), so the forged packet occupies that
+	/// participant's slot and the honest broadcast is ignored. The poisoned
+	/// data is then caught by commitment or transcript verification, but only
+	/// as a late abort: the attacker can deny completion of every session.
 	SendMany(Vec<u8>),
 	/// Send data privately to a specific participant.
 	///
@@ -553,8 +572,21 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// before processing. This prevents quorum inflation attacks where an attacker
 	/// injects messages with fake sender IDs to satisfy broadcast quorum checks.
 	///
+	/// **The `from` value is a trust boundary.** This function performs no
+	/// cryptographic authentication of the sender; it only checks that `from`
+	/// is a participant and matches the party ID embedded in the message. The
+	/// transport layer MUST authenticate the sender of every message (private
+	/// *and* broadcast) and pass the authenticated identity as `from`. If
+	/// `from` can be spoofed, a forged broadcast can occupy a participant's
+	/// first-message-wins slot in the round buffers, causing the honest
+	/// party's broadcast to be ignored and the session to stall or abort
+	/// during commitment/transcript verification (denial of service). See
+	/// [`DkgAction::SendMany`] and [`DkgAction::SendPrivate`] for the channel
+	/// requirements.
+	///
 	/// # Arguments
-	/// * `from` - The party ID of the sender (from the transport layer)
+	/// * `from` - The party ID of the sender. MUST come from transport-level sender
+	///   authentication, never from attacker-controllable packet contents.
 	/// * `data` - The serialized message bytes
 	///
 	/// # Errors

--- a/threshold/src/keygen/dkg/state.rs
+++ b/threshold/src/keygen/dkg/state.rs
@@ -281,11 +281,16 @@ impl<S: TranscriptSigner> Zeroize for DkgState<S> {
 		}
 		self.my_contributions = None;
 
-		// Drop the config, which owns the transcript signer (this party's
-		// long-term authentication key). The `TranscriptSigner: Zeroize +
-		// ZeroizeOnDrop` bound guarantees that dropping the signer erases any
-		// secret-key bytes it holds, so the authentication key does not survive
-		// past this zeroization boundary in freed memory.
+		// Explicitly zeroize the transcript signer (this party's long-term
+		// authentication key) before dropping the config that owns it.
+		// `ZeroizeOnDrop` is only a marker trait: a hand-written implementation
+		// may satisfy `TranscriptSigner: Zeroize + ZeroizeOnDrop` without its
+		// `Drop` ever calling `zeroize()`. Invoking the `Zeroize` method here
+		// makes erasure a state-machine invariant rather than a matter of
+		// downstream implementer discipline.
+		if let Some(ref mut config) = self.config {
+			config.my_signer.zeroize();
+		}
 		self.config = None;
 
 		// Clear non-sensitive data
@@ -525,6 +530,88 @@ mod tests {
 		fn public_key(&self) -> Self::PublicKey {
 			self.id
 		}
+	}
+
+	/// A signer whose `ZeroizeOnDrop` is a *bare marker*: `Zeroize` is
+	/// implemented correctly, but `Drop` never calls it. This is legal under
+	/// the trait contract (`ZeroizeOnDrop` carries no behavior of its own), so
+	/// the state machine must not rely on drop side effects to erase the key.
+	struct LazySigner {
+		id: u32,
+		secret: Vec<u8>,
+		zeroized: Rc<Cell<bool>>,
+	}
+
+	impl Zeroize for LazySigner {
+		fn zeroize(&mut self) {
+			self.secret.zeroize();
+			self.zeroized.set(true);
+		}
+	}
+
+	// Deliberately no `Drop` impl: dropping a LazySigner frees the secret
+	// without wiping it.
+	impl ZeroizeOnDrop for LazySigner {}
+
+	impl TranscriptSigner for LazySigner {
+		type Signature = Vec<u8>;
+		type PublicKey = u32;
+
+		fn sign(&self, hash: &[u8; 32]) -> Self::Signature {
+			let mut sig = Vec::with_capacity(36);
+			sig.extend_from_slice(&self.id.to_le_bytes());
+			sig.extend_from_slice(hash);
+			sig
+		}
+
+		fn verify(pk: &Self::PublicKey, hash: &[u8; 32], sig: &Self::Signature) -> bool {
+			Self::verify_bytes(pk, hash, sig)
+		}
+
+		fn verify_bytes(pk: &Self::PublicKey, hash: &[u8; 32], sig: &[u8]) -> bool {
+			if sig.len() < 36 {
+				return false;
+			}
+			let sig_id = u32::from_le_bytes(sig[..4].try_into().unwrap());
+			sig_id == *pk && &sig[4..36] == hash
+		}
+
+		fn public_key(&self) -> Self::PublicKey {
+			self.id
+		}
+	}
+
+	/// `DkgState::zeroize()` must invoke the signer's `Zeroize` impl directly
+	/// instead of relying on `ZeroizeOnDrop` drop side effects: a bare-marker
+	/// implementation satisfies the trait bounds but wipes nothing on drop.
+	#[test]
+	fn zeroize_erases_key_even_for_bare_marker_zeroize_on_drop() {
+		let zeroized = Rc::new(Cell::new(false));
+
+		let mut public_keys = BTreeMap::new();
+		public_keys.insert(0u32, 0u32);
+		public_keys.insert(1u32, 1u32);
+		public_keys.insert(2u32, 2u32);
+
+		let signer =
+			LazySigner { id: 0, secret: [0xCDu8; 64].to_vec(), zeroized: zeroized.clone() };
+
+		let config = DkgConfig::new(
+			ThresholdConfig::new(2, 3).unwrap(),
+			0,
+			Vec::from([0u32, 1, 2]),
+			signer,
+			public_keys,
+		)
+		.unwrap();
+
+		let mut state = DkgState::new(config);
+		state.zeroize();
+		assert!(
+			zeroized.get(),
+			"DkgState::zeroize() must explicitly zeroize the transcript signer; \
+			 dropping a bare-marker ZeroizeOnDrop signer wipes nothing"
+		);
 	}
 
 	/// Regression test: `DkgState::zeroize()` must erase the transcript signer's

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -53,8 +53,9 @@ use qp_rusty_crystals_dilithium::fips202;
 /// `TranscriptSigner` requires [`Zeroize`] + [`ZeroizeOnDrop`] because
 /// implementors hold a long-term signing key (`my_signer` in [`DkgConfig`]).
 /// The DKG/resharing state machines own the signer for the whole protocol
-/// lifetime and rely on dropping the configuration to erase that key at their
-/// zeroization boundary.
+/// lifetime and call its `zeroize()` method directly at their zeroization
+/// boundary, so key erasure does not depend on the implementor's `Drop`
+/// behavior.
 ///
 /// **Implement this with `#[derive(Zeroize, ZeroizeOnDrop)]`** (using
 /// `#[zeroize(skip)]` on non-secret fields such as public keys). The derive

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -795,12 +795,12 @@ pub fn derive_subset_contribution(combined_seed: &[u8; SUBSET_SEED_SIZE]) -> Sub
 
 	for i in 0..L {
 		poly::uniform_eta(&mut temp_poly, combined_seed, i as u16);
-		contribution.s1[i].copy_from_slice(&temp_poly.coeffs);
+		contribution.s1[i].copy_from_slice(temp_poly.coeffs());
 	}
 
 	for i in 0..K {
 		poly::uniform_eta(&mut temp_poly, combined_seed, (L + i) as u16);
-		contribution.s2[i].copy_from_slice(&temp_poly.coeffs);
+		contribution.s2[i].copy_from_slice(temp_poly.coeffs());
 	}
 
 	contribution

--- a/threshold/src/protocol/partial_pk.rs
+++ b/threshold/src/protocol/partial_pk.rs
@@ -30,12 +30,12 @@ pub fn compute_partial_pk_t(
 
 	let mut s1_pv = polyvec::Polyvecl::default();
 	for (i, poly_coeffs) in s1.iter().enumerate() {
-		s1_pv.vec[i].coeffs.copy_from_slice(poly_coeffs);
+		s1_pv.vec[i].coeffs_mut().copy_from_slice(poly_coeffs);
 	}
 
 	let mut s2_pv = polyvec::Polyveck::default();
 	for (i, poly_coeffs) in s2.iter().enumerate() {
-		s2_pv.vec[i].coeffs.copy_from_slice(poly_coeffs);
+		s2_pv.vec[i].coeffs_mut().copy_from_slice(poly_coeffs);
 	}
 
 	let mut s1_hat = s1_pv.clone();
@@ -43,6 +43,10 @@ pub fn compute_partial_pk_t(
 
 	let mut t = polyvec::Polyveck::default();
 	polyvec::matrix_pointwise_montgomery(&mut t, &mat, &s1_hat);
+	// The accumulated dot products can reach L*Q in absolute value; the
+	// inverse NTT requires coefficients below Q (same as the keygen flow in
+	// dilithium's sign.rs).
+	polyvec::k_reduce(&mut t);
 	polyvec::k_invntt_tomont(&mut t);
 	polyvec::k_add(&mut t, &s2_pv);
 	polyvec::k_reduce(&mut t);
@@ -50,7 +54,7 @@ pub fn compute_partial_pk_t(
 
 	let mut t_coeffs = [[0i32; N as usize]; K];
 	for (i, poly) in t.vec.iter().enumerate() {
-		t_coeffs[i].copy_from_slice(&poly.coeffs);
+		t_coeffs[i].copy_from_slice(poly.coeffs());
 	}
 	t_coeffs
 }
@@ -99,7 +103,7 @@ where
 				if !(0..Q).contains(&coeff) {
 					return Err(PackCombinedPkError::CoefficientOutOfRange);
 				}
-				t.vec[i].coeffs[j] = (t.vec[i].coeffs[j] + coeff) % Q;
+				t.vec[i].coeffs_mut()[j] = (t.vec[i].coeffs()[j] + coeff) % Q;
 			}
 		}
 	}

--- a/threshold/src/protocol/primitives.rs
+++ b/threshold/src/protocol/primitives.rs
@@ -76,12 +76,11 @@ pub(crate) fn mod_q(x: u32) -> u32 {
 /// Normalize polynomial coefficients assuming they are ≤ 2Q.
 /// Converts to [0, Q) range. Matches reference implementation behavior.
 pub(crate) fn normalize_assuming_le2q(poly: &mut poly::Poly) {
-	for j in 0..N as usize {
-		let coeff = poly.coeffs[j];
+	for coeff in poly.coeffs_mut().iter_mut() {
 		// First ensure value is positive and in reasonable range
-		let coeff_u32 = if coeff < 0 { (coeff + Q) as u32 } else { coeff as u32 };
+		let coeff_u32 = if *coeff < 0 { (*coeff + Q) as u32 } else { *coeff as u32 };
 		// Apply le2q_mod_q to get into [0, Q) range
-		poly.coeffs[j] = le2q_mod_q(coeff_u32) as i32;
+		*coeff = le2q_mod_q(coeff_u32) as i32;
 	}
 }
 
@@ -126,7 +125,7 @@ impl<const VECS: usize> NttAccumulator<VECS> {
 	#[inline]
 	pub fn add_poly(&mut self, vec_idx: usize, poly: &poly::Poly) {
 		debug_assert!(vec_idx < VECS);
-		for (j, &coeff) in poly.coeffs.iter().enumerate() {
+		for (j, &coeff) in poly.coeffs().iter().enumerate() {
 			// NTT output should be non-negative, but handle signed just in case
 			let coeff_u64 = if coeff < 0 { (coeff as i64 + Q as i64) as u64 } else { coeff as u64 };
 			self.coeffs[vec_idx][j] += coeff_u64;
@@ -140,7 +139,7 @@ impl<const VECS: usize> NttAccumulator<VECS> {
 		core::array::from_fn(|i| {
 			let mut poly = poly::Poly::default();
 			for (j, &acc) in self.coeffs[i].iter().enumerate() {
-				poly.coeffs[j] = (acc % (Q as u64)) as i32;
+				poly.coeffs_mut()[j] = (acc % (Q as u64)) as i32;
 			}
 			poly
 		})
@@ -243,10 +242,10 @@ pub(crate) fn decompose_polyveck(
 ) {
 	for i in 0..K {
 		for j in 0..N as usize {
-			let a = input.vec[i].coeffs[j] as u32;
+			let a = input.vec[i].coeffs()[j] as u32;
 			let (a0, a1) = decompose_coefficient(a);
-			w0.vec[i].coeffs[j] = a0 as i32;
-			w1.vec[i].coeffs[j] = a1 as i32;
+			w0.vec[i].coeffs_mut()[j] = a0 as i32;
+			w1.vec[i].coeffs_mut()[j] = a1 as i32;
 		}
 	}
 }
@@ -265,16 +264,14 @@ pub(crate) fn compute_ntt_dot_product(
 	b: &polyvec::Polyvecl,
 ) {
 	// Zero out result
-	for i in 0..N as usize {
-		result.coeffs[i] = 0;
-	}
+	result.coeffs_mut().fill(0);
 
 	// Compute dot product
 	for i in 0..L {
 		let mut tmp = poly::Poly::default();
 		crate::circl_ntt::mul_hat(&mut tmp, &a.vec[i], &b.vec[i]);
-		for j in 0..N as usize {
-			result.coeffs[j] += tmp.coeffs[j];
+		for (r, &t) in result.coeffs_mut().iter_mut().zip(tmp.coeffs().iter()) {
+			*r += t;
 		}
 	}
 }
@@ -388,7 +385,7 @@ impl HyperballSampleVector {
 				} else if reduced < -(Q / 2) {
 					reduced += Q;
 				}
-				z.vec[i].coeffs[j] = reduced;
+				z.vec[i].coeffs_mut()[j] = reduced;
 			}
 		}
 	}
@@ -408,7 +405,7 @@ impl HyperballSampleVector {
 				} else if reduced < -(Q / 2) {
 					reduced += Q;
 				}
-				s1.vec[i].coeffs[j] = reduced;
+				s1.vec[i].coeffs_mut()[j] = reduced;
 			}
 		}
 
@@ -424,7 +421,7 @@ impl HyperballSampleVector {
 				} else if reduced < -(Q / 2) {
 					reduced += Q;
 				}
-				s2.vec[i].coeffs[j] = reduced;
+				s2.vec[i].coeffs_mut()[j] = reduced;
 			}
 		}
 	}
@@ -474,7 +471,7 @@ impl HyperballSampleVector {
 		// Copy s1 polynomials (first L polynomials)
 		for i in 0..L {
 			for j in 0..N as usize {
-				let mut u = s1.vec[i].coeffs[j];
+				let mut u = s1.vec[i].coeffs()[j];
 				// Center modulo Q
 				u += Q / 2;
 				let t = u - Q;
@@ -488,7 +485,7 @@ impl HyperballSampleVector {
 		// Copy s2 polynomials (next K polynomials)
 		for i in 0..K {
 			for j in 0..N as usize {
-				let mut u = s2.vec[i].coeffs[j];
+				let mut u = s2.vec[i].coeffs()[j];
 				// Center modulo Q
 				u += Q / 2;
 				let t = u - Q;
@@ -517,8 +514,8 @@ pub(crate) fn compute_dilithium_hint(
 	let mut pop = 0;
 	for i in 0..K {
 		for j in 0..N as usize {
-			let h = make_hint_single(w0pf.vec[i].coeffs[j], w1.vec[i].coeffs[j]);
-			hint.vec[i].coeffs[j] = h;
+			let h = make_hint_single(w0pf.vec[i].coeffs()[j], w1.vec[i].coeffs()[j]);
+			hint.vec[i].coeffs_mut()[j] = h;
 			pop += h as usize;
 		}
 	}
@@ -558,7 +555,7 @@ pub(crate) fn poly_pack_w(p: &poly::Poly, buf: &mut [u8]) {
 
 	let mut bit_pos = 0usize;
 	for i in 0..N as usize {
-		let coeff = p.coeffs[i] as u32;
+		let coeff = p.coeffs()[i] as u32;
 
 		// Write 23 bits starting at bit_pos
 		let byte_pos = bit_pos / 8;
@@ -628,7 +625,7 @@ pub(crate) fn poly_unpack_w(buf: &[u8]) -> Result<poly::Poly, &'static str> {
 			return Err("coefficient out of range (>= Q)");
 		}
 
-		p.coeffs[i] = val as i32;
+		p.coeffs_mut()[i] = val as i32;
 		bit_pos += 23;
 	}
 
@@ -732,7 +729,7 @@ mod tests {
 	fn test_poly_pack_unpack_w() {
 		let mut p = poly::Poly::default();
 		for i in 0..N as usize {
-			p.coeffs[i] = (i * 12345) as i32 % Q;
+			p.coeffs_mut()[i] = (i * 12345) as i32 % Q;
 		}
 
 		let mut buf = vec![0u8; 736];
@@ -741,7 +738,7 @@ mod tests {
 		let p2 = poly_unpack_w(&buf).expect("valid coefficients should unpack");
 
 		for i in 0..N as usize {
-			assert_eq!(p.coeffs[i], p2.coeffs[i], "Mismatch at index {}", i);
+			assert_eq!(p.coeffs()[i], p2.coeffs()[i], "Mismatch at index {}", i);
 		}
 	}
 

--- a/threshold/src/protocol/signing.rs
+++ b/threshold/src/protocol/signing.rs
@@ -220,11 +220,11 @@ pub(crate) fn convert_shares(share: &PrivateKeyShare) -> BTreeMap<u16, SecretSha
 		let mut s2_share = polyvec::Polyveck::default();
 
 		for i in 0..L {
-			s1_share.vec[i].coeffs.copy_from_slice(&share_data.s1[i]);
+			s1_share.vec[i].coeffs_mut().copy_from_slice(&share_data.s1[i]);
 		}
 
 		for i in 0..K {
-			s2_share.vec[i].coeffs.copy_from_slice(&share_data.s2[i]);
+			s2_share.vec[i].coeffs_mut().copy_from_slice(&share_data.s2[i]);
 		}
 
 		shares.insert(*subset_id, SecretShare { s1_share, s2_share });
@@ -354,9 +354,9 @@ pub(crate) fn generate_round1(
 
 			// Apply ReduceLe2Q in NTT domain BEFORE InvNTT
 			for j in 0..N as usize {
-				let coeff = w_k.vec[i].coeffs[j];
+				let coeff = w_k.vec[i].coeffs()[j];
 				let coeff_u32 = if coeff < 0 { (coeff + Q) as u32 } else { coeff as u32 };
-				w_k.vec[i].coeffs[j] = reduce_le2q(coeff_u32) as i32;
+				w_k.vec[i].coeffs_mut()[j] = reduce_le2q(coeff_u32) as i32;
 			}
 
 			crate::circl_ntt::inv_ntt(&mut w_k.vec[i]);
@@ -366,9 +366,9 @@ pub(crate) fn generate_round1(
 
 			// Apply ReduceLe2Q after Add
 			for j in 0..N as usize {
-				let coeff = w_k.vec[i].coeffs[j];
+				let coeff = w_k.vec[i].coeffs()[j];
 				let coeff_u32 = if coeff < 0 { (coeff + Q) as u32 } else { coeff as u32 };
-				w_k.vec[i].coeffs[j] = reduce_le2q(coeff_u32) as i32;
+				w_k.vec[i].coeffs_mut()[j] = reduce_le2q(coeff_u32) as i32;
 			}
 		}
 
@@ -642,7 +642,7 @@ pub(crate) fn generate_round3_response(
 		}
 		// Normalize z
 		for j in 0..L {
-			for coeff in z.vec[j].coeffs.iter_mut() {
+			for coeff in z.vec[j].coeffs_mut().iter_mut() {
 				let c = *coeff;
 				let c_u32 = if c < 0 { (c + Q) as u32 } else { c as u32 };
 				*coeff = mod_q(c_u32) as i32;
@@ -657,7 +657,7 @@ pub(crate) fn generate_round3_response(
 		}
 		// Normalize cs2
 		for j in 0..K {
-			for coeff in cs2.vec[j].coeffs.iter_mut() {
+			for coeff in cs2.vec[j].coeffs_mut().iter_mut() {
 				let c = *coeff;
 				let c_u32 = if c < 0 { (c + Q) as u32 } else { c as u32 };
 				*coeff = mod_q(c_u32) as i32;
@@ -679,7 +679,7 @@ pub(crate) fn generate_round3_response(
 
 		// Convert from centered format to [0, Q) format
 		for j in 0..L {
-			for coeff in z_out.vec[j].coeffs.iter_mut() {
+			for coeff in z_out.vec[j].coeffs_mut().iter_mut() {
 				if *coeff < 0 {
 					*coeff += Q;
 				}
@@ -702,7 +702,7 @@ pub(crate) fn pack_responses(responses: &[polyvec::Polyvecl]) -> Vec<u8> {
 		// Convert to centered format for packing
 		let mut z_centered = z.clone();
 		for j in 0..L {
-			for coeff in z_centered.vec[j].coeffs.iter_mut() {
+			for coeff in z_centered.vec[j].coeffs_mut().iter_mut() {
 				if *coeff > Q / 2 {
 					*coeff -= Q;
 				}
@@ -773,7 +773,7 @@ pub(crate) fn unpack_responses(
 /// valid threshold contributions (they pass norm checks) but don't actually contain
 /// valid cryptographic data, breaking threshold linearity.
 fn is_zero_response(z_i: &polyvec::Polyvecl) -> bool {
-	z_i.vec.iter().take(L).all(|poly| poly.coeffs.iter().all(|&c| c == 0))
+	z_i.vec.iter().take(L).all(|poly| poly.coeffs().iter().all(|&c| c == 0))
 }
 
 /// Check if a single party's z response for one iteration satisfies the norm bound.
@@ -782,7 +782,7 @@ fn is_zero_response(z_i: &polyvec::Polyvecl) -> bool {
 /// Checks the norm bound on a party's response vector.
 fn check_party_z_norm(z_i: &polyvec::Polyvecl, gamma1_minus_beta: i32) -> bool {
 	for z_poly in z_i.vec.iter().take(L) {
-		for coeff in z_poly.coeffs.iter() {
+		for coeff in z_poly.coeffs().iter() {
 			let centered = if *coeff > Q / 2 { *coeff - Q } else { *coeff };
 			if centered.abs() >= gamma1_minus_beta {
 				return false;
@@ -855,7 +855,7 @@ pub(crate) fn combine_signature(
 						z_aggregated.vec.iter_mut().zip(z_i.vec.iter()).take(L)
 					{
 						for (agg_coeff, party_coeff) in
-							agg_poly.coeffs.iter_mut().zip(party_poly.coeffs.iter())
+							agg_poly.coeffs_mut().iter_mut().zip(party_poly.coeffs().iter())
 						{
 							*agg_coeff = (*agg_coeff + *party_coeff) % Q;
 						}
@@ -879,7 +879,7 @@ pub(crate) fn combine_signature(
 		// Check aggregated z-norm (may still exceed due to sum of valid parties)
 		let mut z_exceeds = false;
 		'z_check: for z_poly in z_aggregated.vec.iter().take(L) {
-			for coeff in z_poly.coeffs.iter() {
+			for coeff in z_poly.coeffs().iter() {
 				let centered = if *coeff > Q / 2 { *coeff - Q } else { *coeff };
 				if centered.abs() >= gamma1_minus_beta {
 					z_exceeds = true;
@@ -894,7 +894,7 @@ pub(crate) fn combine_signature(
 		// Compute Az (z in NTT domain)
 		let mut zh = z_aggregated.clone();
 		for zh_poly in zh.vec.iter_mut().take(L) {
-			for coeff in zh_poly.coeffs.iter_mut() {
+			for coeff in zh_poly.coeffs_mut().iter_mut() {
 				if *coeff > Q / 2 {
 					*coeff -= Q;
 				}
@@ -930,7 +930,8 @@ pub(crate) fn combine_signature(
 		let mut scaled_challenge_t1 = polyvec::Polyveck::default();
 		for (scaled_poly, t1_poly) in scaled_challenge_t1.vec.iter_mut().zip(t1.vec.iter()).take(K)
 		{
-			for (scaled_coeff, t1_coeff) in scaled_poly.coeffs.iter_mut().zip(t1_poly.coeffs.iter())
+			for (scaled_coeff, t1_coeff) in
+				scaled_poly.coeffs_mut().iter_mut().zip(t1_poly.coeffs().iter())
 			{
 				*scaled_coeff = *t1_coeff << D;
 			}
@@ -942,7 +943,8 @@ pub(crate) fn combine_signature(
 		// Compute Az - 2^d * c * t1
 		for (scaled_poly, az_poly) in scaled_challenge_t1.vec.iter_mut().zip(az.vec.iter()).take(K)
 		{
-			for (scaled_coeff, az_coeff) in scaled_poly.coeffs.iter_mut().zip(az_poly.coeffs.iter())
+			for (scaled_coeff, az_coeff) in
+				scaled_poly.coeffs_mut().iter_mut().zip(az_poly.coeffs().iter())
 			{
 				*scaled_coeff = *az_coeff - *scaled_coeff;
 			}
@@ -960,14 +962,14 @@ pub(crate) fn combine_signature(
 			.take(K)
 		{
 			for (diff_coeff, (scaled_coeff, w_coeff)) in diff_poly
-				.coeffs
+				.coeffs_mut()
 				.iter_mut()
-				.zip(scaled_poly.coeffs.iter().zip(w_poly.coeffs.iter()))
+				.zip(scaled_poly.coeffs().iter().zip(w_poly.coeffs().iter()))
 			{
 				*diff_coeff = *scaled_coeff - *w_coeff;
 			}
 			// Normalize coefficients to [0, Q)
-			for coeff in diff_poly.coeffs.iter_mut() {
+			for coeff in diff_poly.coeffs_mut().iter_mut() {
 				let coeff_u32 = if *coeff < 0 { (*coeff + Q) as u32 } else { *coeff as u32 };
 				*coeff = mod_q(coeff_u32) as i32;
 			}
@@ -977,7 +979,7 @@ pub(crate) fn combine_signature(
 		let gamma2 = GAMMA2 as i32;
 		let mut difference_exceeds = false;
 		'diff_check: for diff_poly in difference.vec.iter().take(K) {
-			for coeff in diff_poly.coeffs.iter() {
+			for coeff in diff_poly.coeffs().iter() {
 				let centered = if *coeff > Q / 2 { *coeff - Q } else { *coeff };
 				if centered.abs() >= gamma2 {
 					difference_exceeds = true;
@@ -998,14 +1000,14 @@ pub(crate) fn combine_signature(
 			.take(K)
 		{
 			for (w0pd_coeff, (w0_coeff, diff_coeff)) in w0pd_poly
-				.coeffs
+				.coeffs_mut()
 				.iter_mut()
-				.zip(w0_poly.coeffs.iter().zip(diff_poly.coeffs.iter()))
+				.zip(w0_poly.coeffs().iter().zip(diff_poly.coeffs().iter()))
 			{
 				*w0pd_coeff = *w0_coeff + *diff_coeff;
 			}
 			// Normalize coefficients to [0, Q)
-			for coeff in w0pd_poly.coeffs.iter_mut() {
+			for coeff in w0pd_poly.coeffs_mut().iter_mut() {
 				let coeff_u32 = if *coeff < 0 { (*coeff + Q) as u32 } else { *coeff as u32 };
 				*coeff = mod_q(coeff_u32) as i32;
 			}
@@ -1019,7 +1021,7 @@ pub(crate) fn combine_signature(
 			// Convert z to centered form for packing
 			let mut z_centered = z_aggregated.clone();
 			for z_poly in z_centered.vec.iter_mut().take(L) {
-				for coeff in z_poly.coeffs.iter_mut() {
+				for coeff in z_poly.coeffs_mut().iter_mut() {
 					if *coeff > Q / 2 {
 						*coeff -= Q;
 					}
@@ -1066,10 +1068,11 @@ fn unpack_t1(pk_bytes: &[u8]) -> ThresholdResult<polyvec::Polyveck> {
 			let b3 = t1_bytes[byte_idx + 3] as i32;
 			let b4 = t1_bytes[byte_idx + 4] as i32;
 
-			t1.vec[poly_idx].coeffs[i] = b0 | ((b1 & 0x03) << 8);
-			t1.vec[poly_idx].coeffs[i + 1] = (b1 >> 2) | ((b2 & 0x0F) << 6);
-			t1.vec[poly_idx].coeffs[i + 2] = (b2 >> 4) | ((b3 & 0x3F) << 4);
-			t1.vec[poly_idx].coeffs[i + 3] = (b3 >> 6) | (b4 << 2);
+			let t1_coeffs = t1.vec[poly_idx].coeffs_mut();
+			t1_coeffs[i] = b0 | ((b1 & 0x03) << 8);
+			t1_coeffs[i + 1] = (b1 >> 2) | ((b2 & 0x0F) << 6);
+			t1_coeffs[i + 2] = (b2 >> 4) | ((b3 & 0x3F) << 4);
+			t1_coeffs[i + 3] = (b3 >> 6) | (b4 << 2);
 		}
 	}
 
@@ -1093,7 +1096,7 @@ mod tests {
 	fn test_is_zero_response_allows_nonzero() {
 		// Response with a single non-zero coefficient should not be zero
 		let mut nonzero_response = polyvec::Polyvecl::default();
-		nonzero_response.vec[0].coeffs[0] = 1;
+		nonzero_response.vec[0].coeffs_mut()[0] = 1;
 		assert!(
 			!is_zero_response(&nonzero_response),
 			"Non-zero response should not be detected as zero"
@@ -1101,7 +1104,7 @@ mod tests {
 
 		// Response with non-zero in last position
 		let mut nonzero_response2 = polyvec::Polyvecl::default();
-		nonzero_response2.vec[L - 1].coeffs[N as usize - 1] = 42;
+		nonzero_response2.vec[L - 1].coeffs_mut()[N as usize - 1] = 42;
 		assert!(
 			!is_zero_response(&nonzero_response2),
 			"Response with non-zero in last position should not be detected as zero"
@@ -1188,7 +1191,7 @@ mod tests {
 		// Scenario 2: Only 1 party has a non-zero response, below threshold
 		// Even though 3 parties "responded", only 1 is valid
 		let mut one_nonzero = polyvec::Polyvecl::default();
-		one_nonzero.vec[0].coeffs[0] = 1; // Small value within norm bounds
+		one_nonzero.vec[0].coeffs_mut()[0] = 1; // Small value within norm bounds
 
 		let mixed_responses: Vec<Vec<polyvec::Polyvecl>> = vec![
 			vec![one_nonzero.clone(); k_iterations], // Party 1: valid

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -83,14 +83,16 @@ Round 6: Signed Transcript Acceptance (Certificate)
 │   SHAKE256("resharing-transcript-v1" || ssid || Act || session_seed ||
 │   Round 3 broadcasts (Act, sorted) || Round 5 broadcasts (Act ∪ new, sorted)).
 ├── Each new committee member signs
-│   SHAKE256("resharing-accept-v1" || ssid || transcript_hash) with its
-│   long-term key (TranscriptSigner) and broadcasts the signature.
+│   SHAKE256("resharing-accept-v3" || ssid || transcript_hash || Act ||
+│   new committee) with its long-term key (TranscriptSigner) and broadcasts
+│   the signature.
 ├── Every party verifies every acceptance against its *own* transcript hash.
 │   A dealer that equivocated (sent different broadcasts to different parties)
 │   causes verification to fail on at least one honest party, which aborts.
-└── The output includes a ResharingCertificate (ssid, Act, transcript hash,
-    acceptance signatures) verifiable by any third party holding the new
-    committee's verifying keys.
+└── The output includes a ResharingCertificate (ssid, Act, new committee,
+    transcript hash, acceptance signatures) verifiable by any third party
+    holding exactly the new committee's verifying keys; the required signer
+    set comes from the certificate's own signed new-committee field.
 ```
 
 Because `Σ_J s_J^new = Σ_J Σ_I r_{I→J} = Σ_I s_I^old = s`, the secret — and hence the public key `t = A·s1 + s2` — is preserved.

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -35,8 +35,9 @@
 //! - **Round 4**: Private delivery - dealers send `r_{I→J}` to new committee (**secure channel**)
 //! - **Round 5**: Verification - share commitments, partial PKs
 //! - **Round 6**: Signed transcript acceptance - new committee members sign the transcript hash
-//!   (bound together with the `active_set`) using their long-term keys ([`TranscriptSigner`]); the
-//!   collected signatures form a publicly verifiable [`ResharingCertificate`]
+//!   (bound together with the `active_set` and `new_committee`) using their long-term keys
+//!   ([`TranscriptSigner`]); the collected signatures form a publicly verifiable
+//!   [`ResharingCertificate`]
 //!
 //! For each old RSS subset `I` (a `k_old`-subset of the old committee whose members all hold the
 //! η-bounded share `s_I^old`), the lowest-ID *active* member of `I` (the "designated dealer"
@@ -76,9 +77,11 @@
 //! - **Transcript agreement + attestation**: Round 6 acceptance signatures are verified by every
 //!   party against its own transcript hash, so completion implies all parties observed identical
 //!   broadcasts (equivocation causes an abort). The signed hash also binds the certificate's
-//!   `active_set` directly, so a third party holding only the certificate (and the new committee's
-//!   verifying keys) authenticates both the transcript hash *and* the named active old members; the
-//!   `active_set` field cannot be rewritten without invalidating the signatures.
+//!   `active_set` and `new_committee` fields directly, so a third party holding only the
+//!   certificate (and the new committee's verifying keys) authenticates the transcript hash, the
+//!   named active old members, and the attested new committee; neither field can be rewritten
+//!   without invalidating the signatures, and the certificate itself names the complete set of
+//!   required acceptors.
 //!
 //! # Proactive Security Model
 //!

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -1464,12 +1464,16 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// members (status) plus new committee members (new-share commitments +
 	/// partial PKs). `None` until the active set is agreed.
 	///
-	/// This is the single trust boundary for Round 5 consumption. Completion
+	/// This is the outer trust boundary for Round 5 consumption. Completion
 	/// ([`Self::have_all_round5`]), the failure-abort scan in Combining, and
-	/// the transcript hash all use exactly this set, so a broadcast from an
-	/// old member excluded from `Act` can never influence the outcome — the
-	/// protocol's liveness promise is that it proceeds without such members,
-	/// and honoring their failure reports would let a single excluded (e.g.
+	/// the transcript hash use exactly this set; the Combining share-data
+	/// checks ([`Self::verify_new_share_consistency`],
+	/// [`Self::verify_public_key_preservation`]) restrict further to new
+	/// committee members, a subset of this set. Together these ensure a
+	/// broadcast from an old member excluded from `Act` never influences the
+	/// outcome — the protocol's liveness promise is that it proceeds without
+	/// such members, and honoring their failure reports (or hard-failing on
+	/// their poisoned share data) would let a single excluded (e.g.
 	/// compromised, being-rotated-out) member abort every session.
 	fn required_round5_senders(&self) -> Option<alloc::collections::BTreeSet<ParticipantId>> {
 		let act = self.active_set.as_ref()?;
@@ -2117,11 +2121,21 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// All members of new subset J must produce identical `s_J^new` (and thus identical
 	/// commitments). Cross-verify that.
 	///
-	/// Only accepts share commitments from parties that are actually in the new subset.
+	/// Only considers broadcasts from new committee members (the only honest
+	/// producers of share commitments), and within those, only commitments
+	/// for subsets the sender belongs to.
 	fn verify_new_share_consistency(&self) -> Result<(), ResharingProtocolError> {
 		let mut by_subset: BTreeMap<SubsetMask, Vec<(ParticipantId, [u8; COMMITMENT_HASH_SIZE])>> =
 			BTreeMap::new();
 		for (party, broadcast) in &self.round5_broadcasts {
+			// Round 5 broadcasts are buffered from any participant (an
+			// observer catching up may store them before Act is known), but
+			// only new committee members contribute share commitments. Skip
+			// everyone else before any content check, so a non-required
+			// sender's broadcast cannot influence the outcome.
+			if !self.config.new_participants().contains(*party) {
+				continue;
+			}
 			for (j_mask, commit) in &broadcast.share_commitments {
 				// Only accept commitments from parties that are in this new subset
 				if self.config.new_participants().is_in_mask(*party, *j_mask) {
@@ -2181,7 +2195,9 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// Cross-check the broadcast partial PKs and sum them to confirm the
 	/// resharing reconstructs the original public key.
 	///
-	/// Only accepts partial PK contributions from parties that are actually in the new subset.
+	/// Only considers broadcasts from new committee members (the only honest
+	/// producers of partial PKs), and within those, only contributions for
+	/// subsets the sender belongs to.
 	fn verify_public_key_preservation(&self) -> Result<(), ResharingProtocolError> {
 		// The public key is the sum of exactly one partial PK per canonical new subset
 		// (`new_subset_order`). Any other `j_mask` is not part of that sum, so we must
@@ -2194,6 +2210,22 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 
 		let mut canonical: BTreeMap<SubsetMask, [[i32; N as usize]; K]> = BTreeMap::new();
 		for (party, broadcast) in &self.round5_broadcasts {
+			// Skip broadcasts from senders outside the new committee BEFORE
+			// the non-canonical-mask hard reject below. Round 5 broadcasts
+			// are buffered from any participant, so without this filter an
+			// old member excluded from the active set — whose broadcast the
+			// session must be able to proceed without — could abort every
+			// session by sending success=true with a single poisoned mask,
+			// and only on the parties that happened to receive it.
+			if !self.config.new_participants().contains(*party) {
+				if !broadcast.partial_pks.is_empty() {
+					log::warn!(
+						"Ignoring partial PKs from party {}: not a new committee member",
+						party
+					);
+				}
+				continue;
+			}
 			for (j_mask, t_partial) in &broadcast.partial_pks {
 				// Reject partial PKs keyed by any mask that is not a canonical new subset.
 				// An honest party never broadcasts one; a malicious party could use it to
@@ -3426,6 +3458,72 @@ mod tests {
 		assert!(err.to_string().contains("non-canonical subset"), "unexpected error: {}", err);
 	}
 
+	/// Companion to the test above (security review follow-up): the
+	/// non-canonical-mask hard reject only applies to new committee members.
+	/// A sender outside the new committee (e.g. an old member excluded from
+	/// the active set) never contributes partial PKs honestly, so its
+	/// broadcast must be skipped entirely — otherwise a poisoned mask from a
+	/// party the session is promised to proceed without would abort every
+	/// session, and only on the parties that happened to receive it.
+	#[test]
+	fn test_public_key_preservation_ignores_poisoned_mask_from_non_member() {
+		let config = crate::ThresholdConfig::new(2, 3).expect("valid config");
+		let (public_key, shares) =
+			crate::keygen::generate_with_dealer(&[13u8; 32], config).expect("keygen");
+		// Old committee {0,1,2}, new committee {0,1,3}: party 2 is OldOnly.
+		let resharing_config = ResharingConfig::new(
+			Some(shares[0].clone()),
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 3],
+			0,
+			public_key,
+		)
+		.expect("valid resharing config");
+		let mut protocol = ResharingProtocol::new(
+			resharing_config,
+			test_signer_config(0, &[0, 1, 2, 3]),
+			[1u8; 32],
+			&[2u8; 32],
+			0,
+		);
+
+		let full_mask: SubsetMask = 0b111;
+		assert!(!protocol.new_subset_order.contains(&full_mask));
+
+		let mut partial_pks: BTreeMap<SubsetMask, [[i32; N as usize]; K]> = BTreeMap::new();
+		partial_pks.insert(full_mask, [[7i32; N as usize]; K]);
+		protocol.round5_broadcasts.insert(
+			2, // not a new committee member
+			ResharingRound5Broadcast {
+				ssid: protocol.ssid,
+				party_id: 2,
+				share_commitments: BTreeMap::new(),
+				partial_pks,
+				success: true,
+				error_message: None,
+			},
+		);
+
+		// The poisoned broadcast must be skipped: verification then fails
+		// only because this bare setup has no partial PK data at all — not
+		// with the non-canonical hard reject.
+		let err = protocol
+			.verify_public_key_preservation()
+			.expect_err("bare setup has no partial PK contributions");
+		assert!(
+			!err.to_string().contains("non-canonical"),
+			"poisoned mask from a non-member must be ignored, got: {}",
+			err
+		);
+		assert!(
+			err.to_string().contains("missing partial PK contribution"),
+			"unexpected error: {}",
+			err
+		);
+	}
+
 	/// Regression test (security review): a Round 5 failure report from an old
 	/// member that was excluded from the active set must not abort the
 	/// session. Liveness is defined over `Act ∪ new_participants`
@@ -3433,6 +3531,12 @@ mod tests {
 	/// Combining must use the same sender set — otherwise a single excluded
 	/// (offline-then-recovered, leaving, or compromised) old member could
 	/// deny completion of every resharing session.
+	///
+	/// The excluded member's broadcast also carries a partial PK keyed by a
+	/// non-canonical mask: before the sender filter in
+	/// `verify_public_key_preservation`, that was a second independent abort
+	/// vector (the non-canonical hard reject ran before any membership
+	/// check).
 	#[test]
 	fn test_combining_ignores_failure_from_excluded_old_member() {
 		let mut protocol = combining_protocol_with_round5_failure_from(2);
@@ -3443,9 +3547,14 @@ mod tests {
 			"excluded old member's failure report must not abort the session, got: {}",
 			err
 		);
-		// With the excluded member's failure ignored, Combining proceeds to
+		assert!(
+			!err.to_string().contains("non-canonical"),
+			"excluded old member's poisoned partial PK mask must be ignored, got: {}",
+			err
+		);
+		// With the excluded member's broadcast ignored, Combining proceeds to
 		// share verification, which fails on this bare test setup for lack of
-		// partial PK data — proving the abort path was not taken.
+		// partial PK data — proving neither abort path was taken.
 		assert!(
 			matches!(err, ResharingProtocolError::ShareVerificationFailed(_)),
 			"unexpected error: {}",
@@ -3469,7 +3578,9 @@ mod tests {
 
 	/// Build a protocol poised at Combining with active set {0, 1} out of old
 	/// committee {0, 1, 2} and new committee {0, 1, 3}. All required Round 5
-	/// senders report success; `failure_from` reports failure.
+	/// senders report success; `failure_from` reports failure. The excluded
+	/// old member (2) additionally smuggles a partial PK keyed by a
+	/// non-canonical mask, which must be ignored, not hard-rejected.
 	fn combining_protocol_with_round5_failure_from(
 		failure_from: ParticipantId,
 	) -> ResharingProtocol<TestSigner> {
@@ -3498,16 +3609,26 @@ mod tests {
 		protocol.active_set = Some(vec![0, 1]);
 
 		// Round 5 broadcasts: required senders (act {0,1} ∪ new {0,1,3}) all
-		// report success; `failure_from` reports failure.
+		// report success; `failure_from` reports failure. The excluded old
+		// member (2) also carries a poisoned non-canonical partial PK mask.
 		for party in [0u32, 1, 2, 3] {
 			let success = party != failure_from;
+			let mut partial_pks: BTreeMap<SubsetMask, [[i32; N as usize]; K]> = BTreeMap::new();
+			if party == 2 {
+				let full_mask: SubsetMask = 0b111;
+				assert!(
+					!protocol.new_subset_order.contains(&full_mask),
+					"full-committee mask must not be a canonical subset"
+				);
+				partial_pks.insert(full_mask, [[7i32; N as usize]; K]);
+			}
 			protocol.round5_broadcasts.insert(
 				party,
 				ResharingRound5Broadcast {
 					ssid: protocol.ssid,
 					party_id: party,
 					share_commitments: BTreeMap::new(),
-					partial_pks: BTreeMap::new(),
+					partial_pks,
 					success,
 					error_message: (!success).then(|| "forged failure".to_string()),
 				},

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -1608,7 +1608,11 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 				"AcceptGenerate reached without an agreed active set".to_string(),
 			)
 		})?;
-		let accept_hash = compute_accept_hash(&self.ssid, &transcript_hash, &active_set);
+		// ParticipantList iterates in sorted order, giving the canonical
+		// (strictly ascending) committee encoding the acceptance hash binds.
+		let new_committee: Vec<ParticipantId> = self.config.new_participants().iter().collect();
+		let accept_hash =
+			compute_accept_hash(&self.ssid, &transcript_hash, &active_set, &new_committee);
 		let signature = self.signer_config.my_signer.sign(&accept_hash);
 		let my_id = self.config.my_party_id();
 		self.accepts.insert(my_id, signature.as_ref().to_vec());
@@ -1645,7 +1649,8 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		// Verify every signature against *our own* transcript hash. A signer
 		// that observed a different transcript (dealer equivocation, tampered
 		// broadcast) produces a signature that fails here, and we abort.
-		let accept_hash = compute_accept_hash(&self.ssid, &transcript_hash, &active_set);
+		let accept_hash =
+			compute_accept_hash(&self.ssid, &transcript_hash, &active_set, &new_participants);
 		for p in &new_participants {
 			let pk = self.signer_config.verifying_keys.get(p).ok_or_else(|| {
 				ResharingProtocolError::InternalError(format!(
@@ -1668,6 +1673,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		let certificate = ResharingCertificate {
 			ssid: self.ssid,
 			active_set,
+			new_committee: new_participants,
 			transcript_hash,
 			accepts: self.accepts.clone(),
 		};

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -1460,14 +1460,27 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		self.round5_broadcasts.insert(from, broadcast);
 	}
 
+	/// The Round 5 senders this session actually depends on: active old
+	/// members (status) plus new committee members (new-share commitments +
+	/// partial PKs). `None` until the active set is agreed.
+	///
+	/// This is the single trust boundary for Round 5 consumption. Completion
+	/// ([`Self::have_all_round5`]), the failure-abort scan in Combining, and
+	/// the transcript hash all use exactly this set, so a broadcast from an
+	/// old member excluded from `Act` can never influence the outcome — the
+	/// protocol's liveness promise is that it proceeds without such members,
+	/// and honoring their failure reports would let a single excluded (e.g.
+	/// compromised, being-rotated-out) member abort every session.
+	fn required_round5_senders(&self) -> Option<alloc::collections::BTreeSet<ParticipantId>> {
+		let act = self.active_set.as_ref()?;
+		Some(act.iter().copied().chain(self.config.new_participants().iter()).collect())
+	}
+
 	fn have_all_round5(&self) -> bool {
-		// Round 5 has contributions from active old members (status) and new
-		// committee members (new-share commitments + partial PKs). Old members
-		// outside the active set may be offline, so they are not required —
-		// though if an online one reports failure, Combining still honors it.
-		let Some(act) = &self.active_set else { return false };
-		let required: alloc::collections::BTreeSet<ParticipantId> =
-			act.iter().copied().chain(self.config.new_participants().iter()).collect();
+		// Old members outside the active set may be offline, so they are not
+		// required; their Round 5 broadcasts (if any) are ignored outright —
+		// see `required_round5_senders`.
+		let Some(required) = self.required_round5_senders() else { return false };
 		required.iter().all(|p| self.round5_broadcasts.contains_key(p))
 	}
 
@@ -1476,11 +1489,22 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	// ========================================================================
 
 	fn handle_combining(&mut self) -> Result<Action<ResharingOutput>, ResharingProtocolError> {
-		// Check if any party reported failure - abort without attribution
+		// Check if any *required* party reported failure - abort without
+		// attribution. The scan is restricted to the same sender set that
+		// gates Round 5 completion and the transcript hash: an old member
+		// excluded from the active set is exactly the party the session must
+		// be able to proceed without, so its failure report must not be able
+		// to abort the session (and other parties may not even have received
+		// it, so honoring it would also make parties diverge).
+		let required = self.required_round5_senders().ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"Combining reached before active set is agreed".to_string(),
+			)
+		})?;
 		let failed_parties: Vec<ParticipantId> = self
 			.round5_broadcasts
 			.iter()
-			.filter(|(_, b)| !b.success)
+			.filter(|(id, b)| required.contains(id) && !b.success)
 			.map(|(id, _)| *id)
 			.collect();
 
@@ -1561,9 +1585,13 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		}
 
 		// Required Round 5 broadcasts: active old members + new committee, in
-		// sorted order (matches `have_all_round5`).
-		let required: alloc::collections::BTreeSet<ParticipantId> =
-			act.iter().copied().chain(self.config.new_participants().iter()).collect();
+		// sorted order (the same set that gates `have_all_round5` and the
+		// Combining failure scan).
+		let required = self.required_round5_senders().ok_or_else(|| {
+			ResharingProtocolError::InternalError(
+				"Computing transcript hash before active set is agreed".to_string(),
+			)
+		})?;
 		for p in required {
 			let broadcast = self.round5_broadcasts.get(&p).ok_or_else(|| {
 				ResharingProtocolError::InternalError(format!(
@@ -3396,6 +3424,98 @@ mod tests {
 			.verify_public_key_preservation()
 			.expect_err("non-canonical partial PK mask must be rejected");
 		assert!(err.to_string().contains("non-canonical subset"), "unexpected error: {}", err);
+	}
+
+	/// Regression test (security review): a Round 5 failure report from an old
+	/// member that was excluded from the active set must not abort the
+	/// session. Liveness is defined over `Act ∪ new_participants`
+	/// (`have_all_round5`, transcript hash), so the failure-abort scan in
+	/// Combining must use the same sender set — otherwise a single excluded
+	/// (offline-then-recovered, leaving, or compromised) old member could
+	/// deny completion of every resharing session.
+	#[test]
+	fn test_combining_ignores_failure_from_excluded_old_member() {
+		let mut protocol = combining_protocol_with_round5_failure_from(2);
+
+		let err = protocol.poke().expect_err("bare combining state cannot fully verify");
+		assert!(
+			!matches!(err, ResharingProtocolError::ProtocolAborted(_)),
+			"excluded old member's failure report must not abort the session, got: {}",
+			err
+		);
+		// With the excluded member's failure ignored, Combining proceeds to
+		// share verification, which fails on this bare test setup for lack of
+		// partial PK data — proving the abort path was not taken.
+		assert!(
+			matches!(err, ResharingProtocolError::ShareVerificationFailed(_)),
+			"unexpected error: {}",
+			err
+		);
+	}
+
+	/// Companion to the test above: a failure report from a *required* Round 5
+	/// sender (here an active old member) must still abort.
+	#[test]
+	fn test_combining_aborts_on_failure_from_required_party() {
+		let mut protocol = combining_protocol_with_round5_failure_from(1);
+
+		let err = protocol.poke().expect_err("failure from required party must abort");
+		assert!(
+			matches!(err, ResharingProtocolError::ProtocolAborted(_)),
+			"active member's failure report must abort the session, got: {}",
+			err
+		);
+	}
+
+	/// Build a protocol poised at Combining with active set {0, 1} out of old
+	/// committee {0, 1, 2} and new committee {0, 1, 3}. All required Round 5
+	/// senders report success; `failure_from` reports failure.
+	fn combining_protocol_with_round5_failure_from(
+		failure_from: ParticipantId,
+	) -> ResharingProtocol<TestSigner> {
+		let config = crate::ThresholdConfig::new(2, 3).expect("valid config");
+		let (public_key, shares) =
+			crate::keygen::generate_with_dealer(&[21u8; 32], config).expect("keygen");
+		let resharing_config = ResharingConfig::new(
+			Some(shares[0].clone()),
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 3],
+			0,
+			public_key,
+		)
+		.expect("valid resharing config");
+		let mut protocol = ResharingProtocol::new(
+			resharing_config,
+			test_signer_config(0, &[0, 1, 2, 3]),
+			[1u8; 32],
+			&[2u8; 32],
+			0,
+		);
+
+		// Old member 2 is excluded from the active set.
+		protocol.active_set = Some(vec![0, 1]);
+
+		// Round 5 broadcasts: required senders (act {0,1} ∪ new {0,1,3}) all
+		// report success; `failure_from` reports failure.
+		for party in [0u32, 1, 2, 3] {
+			let success = party != failure_from;
+			protocol.round5_broadcasts.insert(
+				party,
+				ResharingRound5Broadcast {
+					ssid: protocol.ssid,
+					party_id: party,
+					share_commitments: BTreeMap::new(),
+					partial_pks: BTreeMap::new(),
+					success,
+					error_message: (!success).then(|| "forged failure".to_string()),
+				},
+			);
+		}
+
+		protocol.state = ResharingState::Combining;
+		protocol
 	}
 
 	#[test]

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -411,6 +411,14 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		self.pending_round4.clear();
 		self.round4_messages.clear();
 		self.config.zeroize_existing_share();
+		// Explicitly zeroize the transcript signer (this party's long-term
+		// authentication key). `ZeroizeOnDrop` is only a marker trait, so
+		// relying on the signer's own Drop would leave erasure to downstream
+		// implementer discipline; calling `zeroize()` makes it an invariant.
+		// Safe here: the signer is only used for the Round 6 acceptance
+		// signature, which has already been produced by the time this runs
+		// (successful completion or drop).
+		self.signer_config.my_signer.zeroize();
 	}
 
 	/// Whether the old committee share has been erased from the config.

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -625,10 +625,11 @@ pub const MAX_ACCEPT_SIGNATURE_LEN: usize = 8192;
 /// causes signature verification to fail on at least one honest party, which
 /// then aborts.
 ///
-/// The signature is over `SHAKE256("resharing-accept-v2" || ssid ||
-/// transcript_hash || len(active_set) || active_set)` (see
-/// [`compute_accept_hash`]), domain-separating acceptances from any other use
-/// of the same long-term key and binding the certificate's `active_set`.
+/// The signature is over `SHAKE256("resharing-accept-v3" || ssid ||
+/// transcript_hash || len(active_set) || active_set || len(new_committee) ||
+/// new_committee)` (see [`compute_accept_hash`]), domain-separating
+/// acceptances from any other use of the same long-term key and binding the
+/// certificate's `active_set` and `new_committee`.
 #[derive(Debug, Clone, BorshSerialize)]
 pub struct ResharingAccept {
 	/// Session identifier binding this message to the resharing session.
@@ -703,12 +704,21 @@ impl<S: crate::keygen::dkg::TranscriptSigner> ResharingSignerConfig<S> {
 /// material. A verifier that additionally holds the broadcast transcript can
 /// recompute `transcript_hash` and the `Σ_J t_J^new = T` public-key check
 /// independently.
+///
+/// The certificate is self-describing: `new_committee` names the complete set
+/// of required acceptors and is bound into the acceptance hash, so
+/// [`verify`](Self::verify) derives the required signer set from the signed
+/// certificate itself rather than trusting the caller to supply it.
 #[derive(Debug, Clone, BorshSerialize)]
 pub struct ResharingCertificate {
 	/// Session identifier of the completed session.
 	pub ssid: [u8; RESHARING_SSID_SIZE],
 	/// The active set of old committee members that dealt in this session.
 	pub active_set: Vec<ParticipantId>,
+	/// The new committee members, strictly sorted ascending. Every member
+	/// must contribute an acceptance signature. Bound into the acceptance
+	/// hash, so it cannot be rewritten without invalidating the signatures.
+	pub new_committee: Vec<ParticipantId>,
 	/// Hash of the session transcript (active set, session seed, Round 3
 	/// dealer commitments, Round 5 broadcasts).
 	pub transcript_hash: [u8; COMMITMENT_HASH_SIZE],
@@ -732,6 +742,19 @@ impl BorshDeserialize for ResharingCertificate {
 		let mut active_set = Vec::with_capacity(active_len);
 		for _ in 0..active_len {
 			active_set.push(ParticipantId::deserialize_reader(reader)?);
+		}
+
+		// new_committee is at most one entry per new committee member.
+		let committee_len = u32::deserialize_reader(reader)? as usize;
+		if committee_len > MAX_PARTIES as usize {
+			return Err(borsh::io::Error::new(
+				borsh::io::ErrorKind::InvalidData,
+				"ResharingCertificate.new_committee exceeds MAX_PARTIES",
+			));
+		}
+		let mut new_committee = Vec::with_capacity(committee_len);
+		for _ in 0..committee_len {
+			new_committee.push(ParticipantId::deserialize_reader(reader)?);
 		}
 
 		let transcript_hash = <[u8; COMMITMENT_HASH_SIZE]>::deserialize_reader(reader)?;
@@ -759,25 +782,59 @@ impl BorshDeserialize for ResharingCertificate {
 			accepts.insert(party_id, signature);
 		}
 
-		Ok(Self { ssid, active_set, transcript_hash, accepts })
+		Ok(Self { ssid, active_set, new_committee, transcript_hash, accepts })
 	}
 }
 
 impl ResharingCertificate {
-	/// Verify the certificate: every new committee member has a valid
-	/// acceptance signature over this certificate's `ssid` and
-	/// `transcript_hash`.
+	/// Verify the certificate: every member of the certificate's own
+	/// `new_committee` has a valid acceptance signature over this
+	/// certificate's `ssid`, `transcript_hash`, `active_set`, and
+	/// `new_committee`.
 	///
-	/// `verifying_keys` must contain a key for every member of
-	/// `new_participants`; returns `false` if any key or signature is missing
-	/// or invalid.
+	/// The required signer set comes from the certificate itself (where it is
+	/// bound into the signed acceptance hash), not from a caller-supplied
+	/// list, so a caller cannot accidentally weaken verification by passing a
+	/// truncated or empty committee.
+	///
+	/// # Security
+	///
+	/// `verifying_keys` is the one remaining trusted input: it MUST be
+	/// exactly the authentic key map of the expected new committee, obtained
+	/// from a trusted source (e.g., the verifier's own configuration or key
+	/// registry for the handoff). Verification fails unless the key map's key
+	/// set equals `new_committee` exactly — a superset (e.g., an all-parties
+	/// registry) is rejected, because it would let any subset of key holders
+	/// mint a certificate naming only themselves. An empty or non-canonical
+	/// (unsorted/duplicated) committee is rejected outright.
 	pub fn verify<S: crate::keygen::dkg::TranscriptSigner>(
 		&self,
-		new_participants: &[ParticipantId],
 		verifying_keys: &BTreeMap<ParticipantId, S::PublicKey>,
 	) -> bool {
-		let accept_hash = compute_accept_hash(&self.ssid, &self.transcript_hash, &self.active_set);
-		new_participants
+		// An empty committee would make the `.all(...)` below vacuously true;
+		// no signature would be checked, so an unsigned certificate would
+		// verify.
+		if self.new_committee.is_empty() {
+			return false;
+		}
+		// Canonical form: strictly ascending (also rejects duplicates), so a
+		// padded list cannot satisfy the length check below.
+		if !self.new_committee.windows(2).all(|w| w[0] < w[1]) {
+			return false;
+		}
+		// The caller's trusted key map must match the committee exactly:
+		// together with the membership check in the loop below, equal lengths
+		// mean equal sets.
+		if verifying_keys.len() != self.new_committee.len() {
+			return false;
+		}
+		let accept_hash = compute_accept_hash(
+			&self.ssid,
+			&self.transcript_hash,
+			&self.active_set,
+			&self.new_committee,
+		);
+		self.new_committee
 			.iter()
 			.all(|p| match (verifying_keys.get(p), self.accepts.get(p)) {
 				(Some(pk), Some(sig)) => S::verify_bytes(pk, &accept_hash, sig),
@@ -788,28 +845,32 @@ impl ResharingCertificate {
 
 /// Domain separator for the acceptance hash.
 ///
-/// Bumped to v2 when `active_set` was folded into the hash; a v1 signature can
-/// therefore never be reinterpreted as a v2 acceptance.
-const ACCEPT_DOMAIN: &[u8] = b"resharing-accept-v2";
+/// Bumped to v2 when `active_set` was folded into the hash, and to v3 when
+/// `new_committee` was; a signature under an older domain can therefore never
+/// be reinterpreted as a newer acceptance.
+const ACCEPT_DOMAIN: &[u8] = b"resharing-accept-v3";
 
 /// Compute the 32-byte hash that new committee members sign to accept the
 /// session transcript:
-/// `SHAKE256("resharing-accept-v2" || ssid || transcript_hash || len(active_set) || active_set)`.
+/// `SHAKE256("resharing-accept-v3" || ssid || transcript_hash || len(active_set) || active_set ||
+/// len(new_committee) || new_committee)`.
 ///
-/// `active_set` is bound directly (in addition to being committed inside
-/// `transcript_hash`) so that a party holding *only* the certificate — which
-/// cannot recompute `transcript_hash` from the full transcript — still
-/// authenticates the certificate's explicit `active_set` field. Without this,
-/// `active_set` could be rewritten while `ssid`/`transcript_hash`/`accepts`
-/// stayed valid, and the tampered certificate would still verify.
+/// `active_set` and `new_committee` are bound directly (in addition to being
+/// committed inside `transcript_hash` and the SSID respectively) so that a
+/// party holding *only* the certificate — which cannot recompute
+/// `transcript_hash` or open the SSID — still authenticates the certificate's
+/// explicit fields. Without this, `active_set` or `new_committee` could be
+/// rewritten while `ssid`/`transcript_hash`/`accepts` stayed valid, and the
+/// tampered certificate would still verify.
 ///
-/// Callers pass `active_set` in the same order stored in the certificate
-/// (the protocol keeps it strictly sorted), so honest signers and verifiers
-/// hash an identical byte string.
+/// Callers pass both lists in the same order stored in the certificate (the
+/// protocol keeps them strictly sorted), so honest signers and verifiers hash
+/// an identical byte string.
 pub fn compute_accept_hash(
 	ssid: &[u8; RESHARING_SSID_SIZE],
 	transcript_hash: &[u8; COMMITMENT_HASH_SIZE],
 	active_set: &[ParticipantId],
+	new_committee: &[ParticipantId],
 ) -> [u8; 32] {
 	use qp_rusty_crystals_dilithium::fips202;
 	let mut state = fips202::KeccakState::default();
@@ -818,6 +879,10 @@ pub fn compute_accept_hash(
 	fips202::shake256_absorb(&mut state, transcript_hash);
 	fips202::shake256_absorb(&mut state, &(active_set.len() as u32).to_le_bytes());
 	for &p in active_set {
+		fips202::shake256_absorb(&mut state, &p.to_le_bytes());
+	}
+	fips202::shake256_absorb(&mut state, &(new_committee.len() as u32).to_le_bytes());
+	for &p in new_committee {
 		fips202::shake256_absorb(&mut state, &p.to_le_bytes());
 	}
 	fips202::shake256_finalize(&mut state);
@@ -1861,6 +1926,7 @@ mod tests {
 		let cert = ResharingCertificate {
 			ssid: TEST_SSID,
 			active_set: alloc::vec![0, 1, 2],
+			new_committee: alloc::vec![1, 2],
 			transcript_hash: [7u8; COMMITMENT_HASH_SIZE],
 			accepts,
 		};
@@ -1868,6 +1934,7 @@ mod tests {
 		let bytes = borsh::to_vec(&cert).unwrap();
 		let back: ResharingCertificate = borsh::from_slice(&bytes).unwrap();
 		assert_eq!(back.active_set, cert.active_set);
+		assert_eq!(back.new_committee, cert.new_committee);
 		assert_eq!(back.accepts, cert.accepts);
 		assert_eq!(back.transcript_hash, cert.transcript_hash);
 	}
@@ -1885,11 +1952,31 @@ mod tests {
 		for i in 0..huge {
 			payload.extend_from_slice(&i.to_le_bytes()); // ParticipantId entries
 		}
+		payload.extend_from_slice(&0u32.to_le_bytes()); // new_committee len = 0
 		payload.extend_from_slice(&[0u8; COMMITMENT_HASH_SIZE]); // transcript_hash
 		payload.extend_from_slice(&0u32.to_le_bytes()); // accepts len = 0
 
 		let result: Result<ResharingCertificate, _> = borsh::from_slice(&payload);
 		assert!(result.is_err(), "active_set exceeding MAX_PARTIES must be rejected");
+	}
+
+	/// Same, for the `new_committee` list count.
+	#[test]
+	fn test_resharing_certificate_rejects_oversized_new_committee() {
+		let huge = MAX_PARTIES + 100;
+
+		let mut payload = Vec::new();
+		payload.extend_from_slice(&[0u8; RESHARING_SSID_SIZE]); // ssid
+		payload.extend_from_slice(&0u32.to_le_bytes()); // active_set len = 0
+		payload.extend_from_slice(&huge.to_le_bytes()); // new_committee len
+		for i in 0..huge {
+			payload.extend_from_slice(&i.to_le_bytes()); // ParticipantId entries
+		}
+		payload.extend_from_slice(&[0u8; COMMITMENT_HASH_SIZE]); // transcript_hash
+		payload.extend_from_slice(&0u32.to_le_bytes()); // accepts len = 0
+
+		let result: Result<ResharingCertificate, _> = borsh::from_slice(&payload);
+		assert!(result.is_err(), "new_committee exceeding MAX_PARTIES must be rejected");
 	}
 
 	/// Same, for the `accepts` map count.
@@ -1900,6 +1987,7 @@ mod tests {
 		let mut payload = Vec::new();
 		payload.extend_from_slice(&[0u8; RESHARING_SSID_SIZE]); // ssid
 		payload.extend_from_slice(&0u32.to_le_bytes()); // active_set len = 0
+		payload.extend_from_slice(&0u32.to_le_bytes()); // new_committee len = 0
 		payload.extend_from_slice(&[0u8; COMMITMENT_HASH_SIZE]); // transcript_hash
 		payload.extend_from_slice(&huge.to_le_bytes()); // accepts len
 		for i in 0..huge {

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -96,7 +96,8 @@
 //! use qp_rusty_crystals_threshold::signing_protocol::{DilithiumSignProtocol, Action};
 //! use qp_rusty_crystals_threshold::{ThresholdSigner, ThresholdConfig};
 //!
-//! // Create the protocol instance
+//! // Create the protocol instance. This party's identity is the share's
+//! // party_id — it must be one of the participating parties.
 //! let signer = ThresholdSigner::new(my_share, public_key, config)?;
 //! let round1_seed: [u8; 32] = get_random_seed(); // Must be cryptographically random
 //! let mut protocol = DilithiumSignProtocol::new(
@@ -104,7 +105,6 @@
 //!     message.to_vec(),
 //!     context.to_vec(),
 //!     vec![0, 1, 2],  // participating parties
-//!     my_party_id,
 //!     leader_id,
 //!     round1_seed,
 //! );
@@ -465,11 +465,10 @@ impl SignMessageBuffer {
 /// ```ignore
 /// let round1_seed: [u8; 32] = get_random_seed(); // Must be cryptographically random
 /// let mut protocol = DilithiumSignProtocol::new(
-///     signer,
+///     signer, // this party's identity is signer.party_id()
 ///     b"message to sign".to_vec(),
 ///     b"context".to_vec(),
 ///     vec![0, 1, 2],
-///     1,  // my party id
 ///     0,  // leader id
 ///     round1_seed,
 /// );
@@ -540,17 +539,22 @@ impl DilithiumSignProtocol {
 	/// * `message` - The message to sign
 	/// * `context` - The context string (can be empty, max 255 bytes)
 	/// * `participants` - All participant IDs in this signing session (can be arbitrary u32 values)
-	/// * `my_participant_id` - This party's identifier
 	/// * `leader_id` - The leader's identifier (responsible for combine/retry decisions)
 	/// * `round1_seed` - A 32-byte cryptographically random seed for Round 1
 	/// * `attempt_nonce` - A 32-byte nonce unique to this signing attempt (must be agreed upon by
 	///   all participants, e.g., derived from the transport layer's session/channel ID)
 	///
+	/// This party's protocol identity is the signer share's `party_id()`. There is deliberately
+	/// no separate "my id" parameter: broadcast payloads, the local broadcast maps, and the RSS
+	/// share position used by `combine` all key on the share's id, so a caller-supplied envelope
+	/// identity could silently diverge and stall the session (peers drop messages whose payload
+	/// `party_id` differs from the envelope sender).
+	///
 	/// # Errors
 	///
 	/// Returns `Err(SignProtocolError::InvalidConfig)` if:
 	/// - `participants` contains duplicates
-	/// - `my_participant_id` is not in `participants`
+	/// - the signer share's `party_id()` is not in `participants`
 	/// - `leader_id` is not in `participants`
 	/// - Any participant is not in the original DKG participant set
 	///
@@ -565,19 +569,24 @@ impl DilithiumSignProtocol {
 		message: Vec<u8>,
 		context: Vec<u8>,
 		participants: Vec<ParticipantId>,
-		my_participant_id: ParticipantId,
 		leader_id: ParticipantId,
 		round1_seed: [u8; 32],
 		attempt_nonce: [u8; 32],
 	) -> Result<Self, SignProtocolError> {
+		// This party's protocol identity IS the share's party_id, by
+		// construction: the state machine keys self-broadcasts, stamps
+		// payloads, and recovers RSS shares all under the same identifier.
+		let my_participant_id = signer.party_id();
+
 		let participant_list = ParticipantList::new(&participants).ok_or_else(|| {
 			SignProtocolError::InvalidConfig("participants contains duplicates".to_string())
 		})?;
 
 		if !participant_list.contains(my_participant_id) {
-			return Err(SignProtocolError::InvalidConfig(
-				"my_participant_id is not in participants".to_string(),
-			));
+			return Err(SignProtocolError::InvalidConfig(format!(
+				"this signer's party_id ({}) is not in participants",
+				my_participant_id
+			)));
 		}
 
 		if !participant_list.contains(leader_id) {
@@ -1335,14 +1344,12 @@ pub fn run_local_signing(
 	let mut protocols: Vec<DilithiumSignProtocol> = signers
 		.into_iter()
 		.map(|signer| {
-			let my_id = signer.party_id();
-			let round1_seed = derive_party_seed(session_seed, my_id);
+			let round1_seed = derive_party_seed(session_seed, signer.party_id());
 			DilithiumSignProtocol::new(
 				signer,
 				message.to_vec(),
 				context.to_vec(),
 				participants.clone(),
-				my_id,
 				leader_id,
 				round1_seed,
 				attempt_nonce,
@@ -1416,7 +1423,6 @@ mod tests {
 			b"test message".to_vec(),
 			b"context".to_vec(),
 			vec![0, 1], // exactly threshold participants
-			0,
 			0,          // leader_id
 			[0xAA; 32], // round1_seed
 			[0xBB; 32], // attempt_nonce
@@ -1441,7 +1447,6 @@ mod tests {
 			b"ctx".to_vec(),
 			vec![0, 1, 1], // duplicate!
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		);
@@ -1449,24 +1454,34 @@ mod tests {
 		assert!(matches!(result, Err(SignProtocolError::InvalidConfig(_))));
 	}
 
+	/// This party's identity is the signer share's `party_id()` (there is no
+	/// separate "my id" parameter, so envelope identity and share position can
+	/// never diverge — see the security review on id/share mismatches). A
+	/// share whose id is outside the agreed signing set must be rejected.
 	#[test]
-	fn test_protocol_rejects_missing_my_participant() {
+	fn test_protocol_rejects_signer_outside_participants() {
 		let config = ThresholdConfig::new(2, 3).unwrap();
 		let (pk, shares) = generate_with_dealer(&[42u8; 32], config).unwrap();
 
-		let signer = ThresholdSigner::new(shares[0].clone(), pk, config).unwrap();
+		// Share belongs to party 2; the signing set is {0, 1}. Every other
+		// check passes: no duplicates, leader in set, both participants in
+		// the DKG set, exactly threshold participants.
+		let signer = ThresholdSigner::new(shares[2].clone(), pk, config).unwrap();
+		assert_eq!(signer.party_id(), 2);
 		let result = DilithiumSignProtocol::new(
 			signer,
 			b"test".to_vec(),
 			b"ctx".to_vec(),
-			vec![0, 1, 2],
-			99, // not in participants!
+			vec![0, 1],
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		);
 
-		assert!(matches!(result, Err(SignProtocolError::InvalidConfig(_))));
+		assert!(
+			matches!(result, Err(SignProtocolError::InvalidConfig(_))),
+			"a signer share outside the signing participant set must be rejected"
+		);
 	}
 
 	#[test]
@@ -1480,7 +1495,6 @@ mod tests {
 			b"test".to_vec(),
 			b"ctx".to_vec(),
 			vec![0, 1, 2],
-			0,
 			99, // leader not in participants!
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -1501,7 +1515,6 @@ mod tests {
 			b"ctx".to_vec(),
 			vec![0, 1, 99], // 99 was not in DKG!
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		);
@@ -1520,7 +1533,6 @@ mod tests {
 			b"test".to_vec(),
 			b"ctx".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -1552,7 +1564,6 @@ mod tests {
 			b"test".to_vec(),
 			b"ctx".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -1654,7 +1665,6 @@ mod tests {
 			b"ctx".to_vec(),
 			vec![0, 1],
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		)
@@ -1685,7 +1695,6 @@ mod tests {
 			b"ctx".to_vec(),
 			vec![0, 1],
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		)
@@ -1715,7 +1724,6 @@ mod tests {
 			b"test".to_vec(),
 			b"ctx".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -1811,8 +1819,7 @@ mod tests {
 			b"test message".to_vec(),
 			b"context".to_vec(),
 			vec![0, 1], // exactly threshold participants
-			0,
-			0, // leader_id
+			0,          // leader_id
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		)
@@ -1849,8 +1856,7 @@ mod tests {
 			b"test message".to_vec(),
 			b"context".to_vec(),
 			vec![0, 1], // exactly threshold participants
-			0,
-			0, // leader_id
+			0,          // leader_id
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		)
@@ -1915,7 +1921,6 @@ mod tests {
 			message.clone(),
 			context.clone(),
 			vec![0, 1],
-			1, // follower
 			0, // leader is party 0
 			[0xDD; 32],
 			[0xEE; 32], // attempt_nonce
@@ -1980,8 +1985,7 @@ mod tests {
 			b"test message".to_vec(),
 			b"context".to_vec(),
 			vec![0, 1], // exactly threshold participants
-			0,
-			0, // leader_id
+			0,          // leader_id
 			[0xAA; 32],
 			[0xCC; 32], // attempt_nonce
 		)
@@ -1994,7 +1998,6 @@ mod tests {
 			b"test message".to_vec(),
 			b"context".to_vec(),
 			vec![0, 1], // exactly threshold participants
-			1,
 			0,          // leader_id
 			[0xBB; 32], // Different seed for party 1
 			[0xCC; 32], // Same attempt_nonce for both parties
@@ -2055,7 +2058,6 @@ mod tests {
 			b"test message".to_vec(),
 			b"context".to_vec(),
 			vec![0, 1], // exactly threshold participants
-			1,          // follower
 			0,          // leader is party 0
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -2127,7 +2129,6 @@ mod tests {
 			message.clone(),
 			context.clone(),
 			vec![0, 1], // exactly threshold participants
-			1,          // follower
 			0,          // leader is party 0
 			[0xCC; 32],
 			[0xDD; 32], // attempt_nonce
@@ -2165,7 +2166,6 @@ mod tests {
 			b"test".to_vec(),
 			b"ctx".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -2209,7 +2209,6 @@ mod tests {
 			b"test".to_vec(),
 			b"ctx".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -2256,7 +2255,6 @@ mod tests {
 			b"ctx".to_vec(),
 			vec![0, 1],
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		)
@@ -2298,7 +2296,6 @@ mod tests {
 			b"ctx".to_vec(),
 			vec![0, 1],
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		)
@@ -2336,7 +2333,6 @@ mod tests {
 			b"ctx".to_vec(),
 			vec![0, 1],
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32],
 		);
@@ -2364,7 +2360,6 @@ mod tests {
 			oversized_context,
 			vec![0, 1],
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32],
 		);
@@ -2391,7 +2386,6 @@ mod tests {
 			b"test".to_vec(),
 			max_context,
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32],

--- a/threshold/tests/coverage_tests.rs
+++ b/threshold/tests/coverage_tests.rs
@@ -38,7 +38,6 @@ mod participant_count_validation {
 			b"".to_vec(),
 			vec![0, 1], // Only 2 participants, need 3
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		);
@@ -70,7 +69,6 @@ mod participant_count_validation {
 			b"".to_vec(),
 			vec![0, 1, 2], // Exactly threshold
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		);
@@ -96,7 +94,6 @@ mod malformed_message_handling {
 			b"test".to_vec(),
 			b"".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -125,7 +122,6 @@ mod malformed_message_handling {
 			b"test".to_vec(),
 			b"".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -161,7 +157,6 @@ mod malformed_message_handling {
 			b"test".to_vec(),
 			b"".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -305,7 +300,6 @@ mod edge_cases {
 			b"".to_vec(),
 			vec![0, 1], // Missing party 2
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		);
@@ -328,7 +322,6 @@ mod edge_cases {
 			b"test".to_vec(),
 			max_context,
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -353,7 +346,6 @@ mod edge_cases {
 			b"test".to_vec(),
 			b"".to_vec(),
 			vec![0, 1],
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -395,7 +387,6 @@ mod message_buffering {
 			b"".to_vec(),
 			vec![0, 1],
 			0,
-			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
 		)
@@ -432,7 +423,6 @@ mod sender_validation {
 			b"test".to_vec(),
 			b"".to_vec(),
 			vec![0, 1],
-			0, // my_id is 0
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -466,7 +456,6 @@ mod sender_validation {
 			b"test".to_vec(),
 			b"".to_vec(),
 			vec![0, 1], // Only parties 0 and 1
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce
@@ -502,7 +491,6 @@ mod sender_validation {
 			b"test".to_vec(),
 			b"".to_vec(),
 			vec![0, 1], // Exactly threshold participants
-			0,
 			0,
 			[0xAA; 32],
 			[0xBB; 32], // attempt_nonce

--- a/threshold/tests/integration_tests.rs
+++ b/threshold/tests/integration_tests.rs
@@ -990,7 +990,6 @@ fn test_signing_rejects_more_than_threshold_parties() {
 		b"test message".to_vec(),
 		b"".to_vec(),
 		signing_parties,
-		0, // my_participant_id
 		0, // leader_id
 		[0u8; 32],
 		[0u8; 32], // attempt_nonce

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -4138,14 +4138,18 @@ fn test_slow_old_only_member_observes_and_completes() {
 ///
 /// The malicious party (2, OldOnly, leaving the committee) withholds its Round
 /// 1 Ready signal and instead sends a syntactically valid Round 5 broadcast
-/// with `success = false`. Every other party buffers that broadcast long before
-/// Combining (Round 5 messages are accepted in any state). The leader's ready
-/// window then closes without party 2, so `Act = {0, 1}` — the session is
-/// explicitly promised to proceed without party 2. Before the fix, the
-/// Combining failure scan honored the excluded member's stored failure report
-/// and every honest party aborted; the scan must instead be restricted to the
-/// required Round 5 senders (`Act ∪ new committee`), the same set that gates
-/// completion and the transcript hash.
+/// with `success = false` AND a partial PK keyed by a non-canonical subset
+/// mask. Every other party buffers that broadcast long before Combining
+/// (Round 5 messages are accepted in any state). The leader's ready window
+/// then closes without party 2, so `Act = {0, 1}` — the session is explicitly
+/// promised to proceed without party 2.
+///
+/// Both payloads were independent abort vectors before their respective
+/// fixes: the Combining failure scan honored the excluded member's stored
+/// failure report, and `verify_public_key_preservation` hard-rejected the
+/// non-canonical mask before checking that the sender is a new committee
+/// member. Combining must instead restrict every Round 5 consumer to the
+/// required sender set (and share-data checks to the new committee).
 #[test]
 fn test_excluded_old_member_cannot_abort_with_forged_round5_failure() {
 	let config = ThresholdConfig::new(2, 3).expect("valid config");
@@ -4168,11 +4172,17 @@ fn test_excluded_old_member_cannot_abort_with_forged_round5_failure() {
 			Err(_) => return data,
 		};
 		if matches!(msg, ResharingMessage::Round1(_)) {
+			use qp_rusty_crystals_dilithium::params::{K, N};
+			// A partial PK keyed by the (non-canonical) full-committee mask:
+			// before the sender filter, this hard-failed pk preservation on
+			// every party that received it.
+			let mut poisoned_partial_pks = std::collections::BTreeMap::new();
+			poisoned_partial_pks.insert(0b111u16, [[7i32; N as usize]; K]);
 			let forged = ResharingMessage::Round5(ResharingRound5Broadcast {
 				ssid: *msg.ssid(),
 				party_id: 2,
 				share_commitments: std::collections::BTreeMap::new(),
-				partial_pks: std::collections::BTreeMap::new(),
+				partial_pks: poisoned_partial_pks,
 				success: false,
 				error_message: Some("forged failure from excluded member".to_string()),
 			});

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -13,7 +13,7 @@ use qp_rusty_crystals_threshold::{
 
 use qp_rusty_crystals_threshold::resharing::{
 	resharing_norm_enlargement, Action, NewShareData, ResharingConfig, ResharingMessage,
-	ResharingProtocol, ResharingState,
+	ResharingProtocol, ResharingRound5Broadcast, ResharingState,
 };
 
 mod common;
@@ -4129,6 +4129,83 @@ fn test_slow_old_only_member_observes_and_completes() {
 		vec![new_shares.get(&1).unwrap().clone(), new_shares.get(&3).unwrap().clone()];
 	let is_valid =
 		run_signing_and_verify(&signing_shares, &public_key, new_config, b"oldonly observer", b"");
+	assert!(is_valid, "Signature with reshared shares should verify");
+}
+
+/// Regression test (security review): an old committee member that is excluded
+/// from the active set must not be able to abort the session with a forged
+/// Round 5 failure report.
+///
+/// The malicious party (2, OldOnly, leaving the committee) withholds its Round
+/// 1 Ready signal and instead sends a syntactically valid Round 5 broadcast
+/// with `success = false`. Every other party buffers that broadcast long before
+/// Combining (Round 5 messages are accepted in any state). The leader's ready
+/// window then closes without party 2, so `Act = {0, 1}` — the session is
+/// explicitly promised to proceed without party 2. Before the fix, the
+/// Combining failure scan honored the excluded member's stored failure report
+/// and every honest party aborted; the scan must instead be restricted to the
+/// required Round 5 senders (`Act ∪ new committee`), the same set that gates
+/// completion and the transcript hash.
+#[test]
+fn test_excluded_old_member_cannot_abort_with_forged_round5_failure() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let seed = [42u8; 32];
+	let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+	let mut old_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	for share in &shares {
+		old_shares.insert(share.party_id(), share.clone());
+	}
+
+	// Party 2: swallow the Round 1 Ready signal (so the ready-window timeout
+	// excludes party 2 from Act) and send a forged Round 5 failure instead.
+	let tamper: TamperFn = Box::new(move |sender, _recipient, data| {
+		if sender != 2 {
+			return data;
+		}
+		let msg: ResharingMessage = match borsh::from_slice(&data) {
+			Ok(m) => m,
+			Err(_) => return data,
+		};
+		if matches!(msg, ResharingMessage::Round1(_)) {
+			let forged = ResharingMessage::Round5(ResharingRound5Broadcast {
+				ssid: *msg.ssid(),
+				party_id: 2,
+				share_commitments: std::collections::BTreeMap::new(),
+				partial_pks: std::collections::BTreeMap::new(),
+				success: false,
+				error_message: Some("forged failure from excluded member".to_string()),
+			});
+			borsh::to_vec(&forged).expect("serialize forged Round 5")
+		} else {
+			data
+		}
+	});
+
+	let result = run_resharing_protocol_full(
+		2,
+		vec![0, 1, 2],
+		2,
+		vec![0, 1, 3],
+		&old_shares,
+		&public_key,
+		Some(tamper),
+		&[],
+		&[],
+		None,
+	);
+
+	let new_shares =
+		result.expect("an excluded old member's forged Round 5 failure must not abort the session");
+	assert_eq!(new_shares.len(), 3);
+	assert!(!new_shares.contains_key(&2), "OldOnly member must not receive a share");
+
+	// The reshared key material must be genuine.
+	let new_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let signing_shares =
+		vec![new_shares.get(&0).unwrap().clone(), new_shares.get(&3).unwrap().clone()];
+	let is_valid =
+		run_signing_and_verify(&signing_shares, &public_key, new_config, b"forged round5", b"");
 	assert!(is_valid, "Signature with reshared shares should verify");
 }
 

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -319,8 +319,9 @@ fn run_resharing_protocol_full(
 	// Collect outputs from every online party (new members carry shares;
 	// old-only observers carry just the certificate).
 	let mut new_shares: HashMap<u32, PrivateKeyShare> = HashMap::new();
+	// Certificate verification requires exactly the new committee's keys.
 	let verifying_keys: std::collections::BTreeMap<u32, u32> =
-		all_parties.iter().map(|&p| (p, p)).collect();
+		new_participants.iter().map(|&p| (p, p)).collect();
 	let mut reference_transcript_hash: Option<[u8; 32]> = None;
 
 	for &party_id in &all_parties {
@@ -340,8 +341,16 @@ fn run_resharing_protocol_full(
 
 		// Every party must emit a valid certificate over the same transcript.
 		let cert = &output.certificate;
-		if !cert.verify::<TestSigner>(&new_participants, &verifying_keys) {
+		if !cert.verify::<TestSigner>(&verifying_keys) {
 			return Err(format!("Party {}'s certificate does not verify", party_id));
+		}
+		let mut expected_committee: Vec<u32> = new_participants.clone();
+		expected_committee.sort_unstable();
+		if cert.new_committee != expected_committee {
+			return Err(format!(
+				"Party {}'s certificate names committee {:?}, expected {:?}",
+				party_id, cert.new_committee, expected_committee
+			));
 		}
 		match reference_transcript_hash {
 			None => reference_transcript_hash = Some(cert.transcript_hash),
@@ -4194,32 +4203,152 @@ fn test_certificate_verification_rejects_missing_or_wrong_accepts() {
 	let ssid = [7u8; 32];
 	let transcript_hash = [9u8; 32];
 	let active_set = vec![0u32, 1u32];
-	let accept_hash = compute_accept_hash(&ssid, &transcript_hash, &active_set);
-	let new_participants = vec![0u32, 1u32];
-	let keys: BTreeMap<u32, u32> = new_participants.iter().map(|&p| (p, p)).collect();
+	let new_committee = vec![0u32, 1u32];
+	let accept_hash = compute_accept_hash(&ssid, &transcript_hash, &active_set, &new_committee);
+	let keys: BTreeMap<u32, u32> = new_committee.iter().map(|&p| (p, p)).collect();
 
 	let mut accepts: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
 	accepts.insert(0, Signer { id: 0 }.sign(&accept_hash));
 	accepts.insert(1, Signer { id: 1 }.sign(&accept_hash));
 
-	let cert = ResharingCertificate { ssid, active_set, transcript_hash, accepts: accepts.clone() };
-	assert!(cert.verify::<Signer>(&new_participants, &keys), "valid certificate must verify");
+	let cert = ResharingCertificate {
+		ssid,
+		active_set,
+		new_committee,
+		transcript_hash,
+		accepts: accepts.clone(),
+	};
+	assert!(cert.verify::<Signer>(&keys), "valid certificate must verify");
 
 	// Missing an acceptance.
 	let mut missing = cert.clone();
 	missing.accepts.remove(&1);
-	assert!(!missing.verify::<Signer>(&new_participants, &keys));
+	assert!(!missing.verify::<Signer>(&keys));
 
 	// Acceptance over a different transcript hash.
-	let other_hash = compute_accept_hash(&ssid, &[10u8; 32], &cert.active_set);
+	let other_hash = compute_accept_hash(&ssid, &[10u8; 32], &cert.active_set, &cert.new_committee);
 	let mut wrong = cert.clone();
 	wrong.accepts.insert(1, Signer { id: 1 }.sign(&other_hash));
-	assert!(!wrong.verify::<Signer>(&new_participants, &keys));
+	assert!(!wrong.verify::<Signer>(&keys));
 
 	// Signature by the wrong party.
 	let mut forged = cert;
 	forged.accepts.insert(1, Signer { id: 0 }.sign(&accept_hash));
-	assert!(!forged.verify::<Signer>(&new_participants, &keys));
+	assert!(!forged.verify::<Signer>(&keys));
+}
+
+/// `ResharingCertificate::verify` iterates the committee with `.all(...)`,
+/// which is vacuously true for an empty iterator. An unsigned certificate
+/// claiming an empty committee must NOT verify — otherwise a forged handoff
+/// certificate is accepted without checking a single acceptance signature.
+#[test]
+fn test_certificate_rejects_empty_committee() {
+	use common::TestSigner as Signer;
+	use qp_rusty_crystals_threshold::resharing::ResharingCertificate;
+	use std::collections::BTreeMap;
+
+	// A completely unsigned certificate: empty committee, no signatures.
+	let cert = ResharingCertificate {
+		ssid: [7u8; 32],
+		active_set: vec![0u32, 1u32],
+		new_committee: vec![],
+		transcript_hash: [9u8; 32],
+		accepts: BTreeMap::new(),
+	};
+
+	let keys: BTreeMap<u32, u32> = BTreeMap::new();
+	assert!(
+		!cert.verify::<Signer>(&keys),
+		"certificate claiming an empty new committee must not verify"
+	);
+}
+
+/// The certificate's `new_committee` is bound into the acceptance hash and
+/// must match the verifier's key map exactly. Rewriting the committee list,
+/// truncating the key map, or verifying against a superset registry must all
+/// fail — otherwise a subset of key holders could mint a certificate naming
+/// only themselves and have it verify.
+#[test]
+fn test_certificate_rejects_committee_mismatch() {
+	use common::TestSigner as Signer;
+	use qp_rusty_crystals_threshold::resharing::{
+		compute_accept_hash, ResharingCertificate, TranscriptSigner as _,
+	};
+	use std::collections::BTreeMap;
+
+	let ssid = [7u8; 32];
+	let transcript_hash = [9u8; 32];
+	let active_set = vec![0u32, 1u32, 2u32];
+	let new_committee = vec![0u32, 1u32];
+	let accept_hash = compute_accept_hash(&ssid, &transcript_hash, &active_set, &new_committee);
+	let keys: BTreeMap<u32, u32> = new_committee.iter().map(|&p| (p, p)).collect();
+
+	let mut accepts: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
+	accepts.insert(0, Signer { id: 0 }.sign(&accept_hash));
+	accepts.insert(1, Signer { id: 1 }.sign(&accept_hash));
+
+	let cert = ResharingCertificate { ssid, active_set, new_committee, transcript_hash, accepts };
+	assert!(cert.verify::<Signer>(&keys), "honest certificate must verify");
+
+	// Insider forgery: party 0 rewrites the committee to just itself and
+	// re-signs. The certificate is internally consistent, but the verifier's
+	// trusted key map (the real committee) no longer matches exactly.
+	let mut solo = cert.clone();
+	solo.new_committee = vec![0u32];
+	let solo_hash =
+		compute_accept_hash(&ssid, &solo.transcript_hash, &solo.active_set, &solo.new_committee);
+	solo.accepts = BTreeMap::from([(0u32, Signer { id: 0 }.sign(&solo_hash))]);
+	assert!(
+		!solo.verify::<Signer>(&keys),
+		"certificate naming a sub-committee must not verify against the real committee's keys"
+	);
+
+	// Rewriting the stored committee without re-signing breaks the signatures.
+	let mut rewritten = cert.clone();
+	rewritten.new_committee = vec![0u32, 1u32, 2u32];
+	let three_keys: BTreeMap<u32, u32> = (0..3u32).map(|p| (p, p)).collect();
+	assert!(
+		!rewritten.verify::<Signer>(&three_keys),
+		"certificate with a rewritten committee must not verify"
+	);
+
+	// A superset key map (e.g., an all-parties registry) is rejected.
+	assert!(
+		!cert.verify::<Signer>(&three_keys),
+		"verification against a superset key map must fail"
+	);
+
+	// A truncated key map is rejected.
+	let one_key: BTreeMap<u32, u32> = BTreeMap::from([(0u32, 0u32)]);
+	assert!(!cert.verify::<Signer>(&one_key), "verification with missing keys must fail");
+
+	// A non-canonical (unsorted or duplicated) committee is rejected even if
+	// internally signed consistently.
+	let mut unsorted = cert.clone();
+	unsorted.new_committee = vec![1u32, 0u32];
+	let unsorted_hash = compute_accept_hash(
+		&ssid,
+		&unsorted.transcript_hash,
+		&unsorted.active_set,
+		&unsorted.new_committee,
+	);
+	unsorted.accepts = BTreeMap::from([
+		(0u32, Signer { id: 0 }.sign(&unsorted_hash)),
+		(1u32, Signer { id: 1 }.sign(&unsorted_hash)),
+	]);
+	assert!(!unsorted.verify::<Signer>(&keys), "non-canonical committee order must be rejected");
+
+	let mut duplicated = cert;
+	duplicated.new_committee = vec![0u32, 0u32];
+	let dup_hash = compute_accept_hash(
+		&ssid,
+		&duplicated.transcript_hash,
+		&duplicated.active_set,
+		&duplicated.new_committee,
+	);
+	duplicated.accepts = BTreeMap::from([(0u32, Signer { id: 0 }.sign(&dup_hash))]);
+	let dup_keys: BTreeMap<u32, u32> = BTreeMap::from([(0u32, 0u32), (1u32, 1u32)]);
+	assert!(!duplicated.verify::<Signer>(&dup_keys), "duplicated committee must be rejected");
 }
 
 /// A certificate's `active_set` must be authenticated by the acceptance
@@ -4239,17 +4368,24 @@ fn test_certificate_rejects_forged_active_set() {
 	let transcript_hash = [9u8; 32];
 	// The active set the new committee actually attested to.
 	let real_active_set = vec![0u32, 1u32, 2u32];
-	let accept_hash = compute_accept_hash(&ssid, &transcript_hash, &real_active_set);
+	let new_committee = vec![0u32, 1u32];
+	let accept_hash =
+		compute_accept_hash(&ssid, &transcript_hash, &real_active_set, &new_committee);
 
-	let new_participants = vec![0u32, 1u32];
-	let keys: BTreeMap<u32, u32> = new_participants.iter().map(|&p| (p, p)).collect();
+	let keys: BTreeMap<u32, u32> = new_committee.iter().map(|&p| (p, p)).collect();
 
 	let mut accepts: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
 	accepts.insert(0, Signer { id: 0 }.sign(&accept_hash));
 	accepts.insert(1, Signer { id: 1 }.sign(&accept_hash));
 
-	let cert = ResharingCertificate { ssid, active_set: real_active_set, transcript_hash, accepts };
-	assert!(cert.verify::<Signer>(&new_participants, &keys), "honest certificate must verify");
+	let cert = ResharingCertificate {
+		ssid,
+		active_set: real_active_set,
+		new_committee,
+		transcript_hash,
+		accepts,
+	};
+	assert!(cert.verify::<Signer>(&keys), "honest certificate must verify");
 
 	// Attacker rewrites active_set (drops party 2 / claims a different handoff
 	// set) but keeps ssid, transcript_hash, and the collected signatures. With
@@ -4257,7 +4393,7 @@ fn test_certificate_rejects_forged_active_set() {
 	let mut forged = cert.clone();
 	forged.active_set = vec![0u32, 1u32];
 	assert!(
-		!forged.verify::<Signer>(&new_participants, &keys),
+		!forged.verify::<Signer>(&keys),
 		"certificate with a forged active_set must not verify"
 	);
 
@@ -4265,7 +4401,7 @@ fn test_certificate_rejects_forged_active_set() {
 	let mut reordered = cert;
 	reordered.active_set = vec![2u32, 1u32, 0u32];
 	assert!(
-		!reordered.verify::<Signer>(&new_participants, &keys),
+		!reordered.verify::<Signer>(&keys),
 		"certificate with a reordered active_set must not verify"
 	);
 }

--- a/threshold/tests/signer_state_tests.rs
+++ b/threshold/tests/signer_state_tests.rs
@@ -302,7 +302,6 @@ mod party_management_tests {
 			b"test message".to_vec(),
 			b"context".to_vec(),
 			vec![0, 1], // exactly threshold participants
-			0,          // my_id
 			0,          // leader_id
 			[0xAA; 32], // round1_seed
 			[0xBB; 32], // attempt_nonce


### PR DESCRIPTION
# Security review remediations: hdwallet, dilithium, threshold

This PR addresses a batch of security review findings across the `hdwallet`, `dilithium`, and `threshold` crates. Each finding was handled the same way: verify the reported behavior against the code, reproduce it with a test that fails on the unfixed code (where the finding is a code defect), fix it, and land the fix with its regression test in a dedicated commit.

## Protocol fixes (threshold)

### Excluded old members could abort resharing (`95cf4f9`)

Round 5 of the resharing protocol used inconsistent trust boundaries: completion (`have_all_round5`) and the transcript hash only consider the required senders (active set ∪ new committee), but the Combining failure scan honored `success = false` broadcasts from *any* participant. A single old member excluded from the active set — exactly the party the protocol promises to proceed without — could abort every resharing session with one forged failure report, and parties could diverge based on whether they received it before combining.

The required Round 5 sender set is now computed by a single helper used by all three consumers. No legitimate signal is lost: honest failure reports only ever originate from new committee members, which are always required. Covered by a unit test pair (excluded member's failure ignored / active member's failure still aborts) and an end-to-end test where an excluded member withholds its Ready signal and injects a forged failure.

### Signing protocol identity could diverge from the share position (`6f3c94d`)

`DilithiumSignProtocol::new` took a caller-supplied `my_participant_id` but never checked it against `signer.party_id()`. The state machine keyed self-broadcasts under the caller's id while payloads and self-exclusion filters used the share's id; a divergent pair made every peer silently drop the party's messages (payload `party_id` ≠ envelope sender), stalling the session, and desynchronized the RSS share position used by `combine`.

**Breaking change:** the `my_participant_id` parameter is removed entirely. The party's protocol identity is now `signer.party_id()` by construction, making the mismatch unrepresentable. Construction still rejects a signer share whose id is outside the agreed signing set.

### Resharing certificate was not self-describing (`6260bce`)

`ResharingCertificate::verify` treated the caller-supplied `new_participants` slice as the complete set of required acceptors, so an empty or truncated list vacuously verified an unsigned certificate. The new committee is now stored in the certificate and bound into the acceptance hash (domain bumped to `resharing-accept-v3`), and verification demands the trusted key map equal the committee exactly — empty, truncated, superset, and rewritten committees all fail closed.

### Transcript signer zeroization was implicit (`ff3f0fd`)

`DkgState::zeroize()` and `ResharingProtocol::zeroize_session_secrets` relied on drop side effects to erase the signer's long-term key, but `ZeroizeOnDrop` is only a marker trait — a bare-marker impl satisfies the bounds without wiping anything. The signer's `zeroize()` is now called directly, making key erasure a state-machine invariant instead of downstream implementer discipline.

## Cryptographic API hardening (dilithium)

### `Poly` coefficient access sealed behind a validated API (`27c7055`)

The public `poly` module exposed raw `i32` coefficients with comment-only range preconditions. Safe callers could trigger `i32` overflow in `reduce`/`ntt`/`invntt_tomont` (panic in checked builds, silent wraparound in release), and `check_norm` returned a *wrong result* for out-of-range inputs like `i32::MIN`.

- `check_norm` is now total for all `i32` (branchless `i64` absolute value).
- `Poly.coeffs` is `pub(crate)`; external construction goes through the validated `Poly::from_coeffs`, with `coeffs()`/`coeffs_mut()` accessors carrying a documented low-level contract.
- Per-function coefficient bounds are documented and enforced with `debug_assert!` in `reduce`, `ntt`, `invntt_tomont`, and `shiftl`.
- The new assertions surfaced a real latent bug: `compute_partial_pk_t` in `threshold` (and the NTT roundtrip tests) fed `8·Q`-bounded forward-NTT output into an inverse transform that requires `|c| < Q`. A `reduce` step now sits between them, matching the reference implementation.

**Breaking change:** downstream code that accessed `Poly.coeffs` directly must migrate to `from_coeffs`/`coeffs()`/`coeffs_mut()` (the `threshold` crate and examples are migrated in this PR).

### `SecretKey::from_bytes` now validates key invariants (`f2da599`)

`SecretKey::from_bytes` accepted any length-correct byte string, while `Keypair::from_bytes` validated `t0`/`tr` consistency. A corrupted standalone secret key could silently produce signatures that fail verification. Both import paths now enforce the same invariants.

## Wallet input validation (hdwallet)

### Removed aliasing `ChildNumber::hardened_from_u32` (`c98139b`)

The numeric constructor OR-ed the hardened bit into the caller-supplied index without rejecting indexes that already had it set, so `hardened_from_u32(1 << 31)` and `hardened_from_u32(0)` encoded identically — and child derivation feeds only those bytes into the HMAC, deriving the same wallet key for two distinct advertised indexes. Distinct account/address indexes could therefore collapse onto one private key.

**Breaking change:** the constructor is removed (nothing in the workspace used it). The string parser, which already enforces `index < 2^31`, is the sole validated construction path; a test pins rejection of hardened-bit aliases at the boundary (`2147483648'` must not alias `0'`).

### Input bounds before expensive work (`0fe405e`, `8607447`)

- Mnemonic and passphrase sizes are capped (1 KiB each) before NFKD normalization and PBKDF2, mirroring the existing derivation-path bounds, so oversized inputs can no longer drive unbounded allocation and CPU work before rejection.
- Derivation-path (and wormhole chain-ID) validation now runs *before* BIP39 seed stretching, so requests guaranteed to fail no longer cost full PBKDF2 work.

## Documentation corrections

### False determinism claim in key derivation (`412622f`)

The `derivation` module claimed "the derived public key is deterministic for the same (master_key, tweak)". It is not: every DKG run mixes a mandatory fresh `session_nonce` into Round 1 randomness (a deliberate anti-grinding property), so re-running the DKG yields a different key. An integrator trusting the stated determinism during re-provisioning or disaster recovery would silently lose the canonical key and everything bound to it.

The docs now state the actual guarantee — one canonical *stored* key per `(master_key, tweak)`, never recomputable — and a new test pins the nonce dependence of the DKG output so docs and code cannot drift apart again. This finding was fixed doc-side because making the key nonce-independent would reintroduce the randomness-grinding attack the nonce binding exists to prevent.

### Misc (`99c72e3`, `feb36ca`, `5e4cf6a`)

`SendMany` transport-requirement docs, rustfmt fixups.

## Compatibility notes

Three public API breaking changes, all of which convert silent misuse into compile errors or remove the unsafe surface outright:

| Crate | Change | Migration |
|---|---|---|
| `threshold` | `DilithiumSignProtocol::new` loses `my_participant_id` | Delete the argument; identity comes from the signer share |
| `dilithium` | `Poly.coeffs` no longer public | Use `Poly::from_coeffs` / `coeffs()` / `coeffs_mut()` |
| `hdwallet` | `ChildNumber::hardened_from_u32` removed | Parse the canonical string form, e.g. `"44'".parse::<ChildNumber>()` |

`ResharingCertificate` from `6260bce` bumps the acceptance-hash domain to `resharing-accept-v3`; certificates produced by older code will not verify against the new format (and vice versa).

## Testing

- Every code fix ships with a regression test that was verified to fail against the unfixed code.
- Full workspace test suite passes (`dilithium`, `hdwallet`, `threshold` unit + integration suites, including the ~5-minute resharing suite).
- `cargo clippy --all-targets` clean; formatted with the project's nightly `rustfmt` configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches threshold resharing/signing liveness, certificate verification, and secret-key import paths, plus breaking public API changes in dilithium and hdwallet that integrators must migrate.
> 
> **Overview**
> Security review remediations across **hdwallet**, **dilithium**, and **threshold**: protocol liveness/auth fixes, stricter key and polynomial APIs, wallet input bounds, and corrected derivation docs.
> 
> **Threshold:** Resharing Round 5 now uses one `required_round5_senders` set for completion, transcript hashing, and failure aborts, so an old member excluded from the active set cannot stall every session with a forged `success = false`. `ResharingCertificate` stores `new_committee`, bumps acceptance to `resharing-accept-v3`, and verifies against an exact key map (no vacuous empty-committee pass). `DilithiumSignProtocol::new` drops `my_participant_id`; identity is `signer.party_id()`. DKG/resharing state machines call `TranscriptSigner::zeroize()` explicitly instead of relying on `Drop`.
> 
> **Dilithium:** `Poly.coeffs` is sealed behind `from_coeffs` / `coeffs()` / `coeffs_mut()` with documented bounds and `debug_assert!`; `check_norm` is fixed for all `i32`. `SecretKey::from_bytes` validates `tr`/`t0` like `Keypair::from_bytes`. Threshold partial-PK / NTT paths add `reduce` before inverse NTT where forward output can reach `8·Q`.
> 
> **hdwallet:** Removes aliasing `ChildNumber::hardened_from_u32`; caps mnemonic/passphrase at 1 KiB before NFKD/PBKDF2; validates derivation (and wormhole) paths before seed stretching.
> 
> **Breaking:** `DilithiumSignProtocol::new` arity, `Poly.coeffs` visibility, `hardened_from_u32` removal, older resharing certificates vs v3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f3c94d8a5c33ad24c008c4200b226fd2d35940f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->