### PR TITLE
Security audit fixes: input validation, DoS hardening, and API contract enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "hex-conservative",
 ]

--- a/dilithium/src/fips202.rs
+++ b/dilithium/src/fips202.rs
@@ -408,12 +408,16 @@ fn keccak_absorb_once(s: &mut [u64; 25], r: usize, input: &[u8], p: u8) {
 	s[(r - 1) / 8] ^= 1u64 << 63;
 }
 
-/// Squeeze step of Keccak. Squeezes full blocks of r bytes each.
+/// Squeeze step of Keccak. Squeezes one full rate-sized block per entry of `out`.
 /// Modifies the state. Can be called multiple times to keep squeezing, i.e., is incremental.
 /// Assumes zero bytes of current block have already been squeezed.
-fn keccak_squeezeblocks(out: &mut [u8], nblocks: usize, s: &mut [u64; 25], r: usize) {
-	// Process exactly nblocks blocks using chunks_exact_mut for safe iteration
-	for block in out.chunks_exact_mut(r).take(nblocks) {
+///
+/// The output is typed as whole blocks (`[[u8; R]]`) rather than a flat slice
+/// plus a separate block count, so a count/capacity mismatch — which would
+/// silently underfill the buffer and desynchronize the state — is
+/// unrepresentable at the type level.
+fn keccak_squeezeblocks<const R: usize>(out: &mut [[u8; R]], s: &mut [u64; 25]) {
+	for block in out.iter_mut() {
 		keccakf1600_statepermute(s);
 		for (i, chunk) in block.chunks_exact_mut(8).enumerate() {
 			// chunks_exact_mut(8) guarantees exactly 8 bytes
@@ -434,11 +438,17 @@ pub fn shake128_finalize(state: &mut KeccakState) {
 	state.pos = SHAKE128_RATE;
 }
 
-/// Squeeze step of SHAKE128 XOF. Squeezes full blocks of SHAKE128_RATE bytes each.
+/// Squeeze step of SHAKE128 XOF. Squeezes one full block of SHAKE128_RATE bytes
+/// per entry of `output`.
 /// Can be called multiple times to keep squeezing.
 /// Assumes new block has not yet been started (state->pos = SHAKE128_RATE).
-pub fn shake128_squeezeblocks(output: &mut [u8], nblocks: usize, s: &mut KeccakState) {
-	keccak_squeezeblocks(output, nblocks, &mut s.s, SHAKE128_RATE);
+///
+/// Taking whole blocks (`[[u8; SHAKE128_RATE]]`) instead of a flat slice plus a
+/// block count makes an inconsistent count/capacity pair unrepresentable: the
+/// old shape silently underfilled a short slice, leaving stale bytes that the
+/// caller would treat as XOF output.
+pub fn shake128_squeezeblocks(output: &mut [[u8; SHAKE128_RATE]], s: &mut KeccakState) {
+	keccak_squeezeblocks(output, &mut s.s);
 }
 
 /// Absorb step of the SHAKE256 XOF; incremental.
@@ -464,23 +474,32 @@ pub fn shake256_absorb_once(state: &mut KeccakState, input: &[u8]) {
 	state.pos = SHAKE256_RATE;
 }
 
-/// Squeeze step of SHAKE256 XOF. Squeezes full blocks of SHAKE256_RATE bytes each.
+/// Squeeze step of SHAKE256 XOF. Squeezes one full block of SHAKE256_RATE bytes
+/// per entry of `out`.
 /// Can be called multiple times to keep squeezing.
 /// Assumes next block has not yet been started (state.pos = SHAKE256_RATE).
-pub fn shake256_squeezeblocks(out: &mut [u8], nblocks: usize, state: &mut KeccakState) {
-	keccak_squeezeblocks(out, nblocks, &mut state.s, SHAKE256_RATE);
+///
+/// Taking whole blocks (`[[u8; SHAKE256_RATE]]`) instead of a flat slice plus a
+/// block count makes an inconsistent count/capacity pair unrepresentable: the
+/// old shape silently underfilled a short slice, leaving stale bytes that the
+/// caller would treat as XOF output.
+pub fn shake256_squeezeblocks(out: &mut [[u8; SHAKE256_RATE]], state: &mut KeccakState) {
+	keccak_squeezeblocks(out, &mut state.s);
 }
 
 /// SHAKE256 XOF with non-incremental API
 pub fn shake256(output: &mut [u8], input: &[u8]) {
 	let mut state = KeccakState::default();
-	let outlen = output.len();
 
 	shake256_absorb_once(&mut state, input);
-	let nblocks = outlen / SHAKE256_RATE;
-	shake256_squeezeblocks(output, nblocks, &mut state);
-	let idx = nblocks * SHAKE256_RATE;
-	shake256_squeeze(&mut output[idx..], &mut state);
+	// Squeeze whole blocks first, then the sub-block tail.
+	let mut blocks = output.chunks_exact_mut(SHAKE256_RATE);
+	for block in blocks.by_ref() {
+		let block: &mut [u8; SHAKE256_RATE] =
+			block.try_into().expect("chunks_exact yields full blocks");
+		shake256_squeezeblocks(core::slice::from_mut(block), &mut state);
+	}
+	shake256_squeeze(blocks.into_remainder(), &mut state);
 }
 
 /// Initialize SHAKE128 stream with a fixed-size seed and nonce.
@@ -626,6 +645,46 @@ mod tests {
 		let mut out = [0u8; 64];
 		shake256_squeeze(&mut out, &mut state);
 		assert!(state.pos <= SHAKE256_RATE, "state position must be back in range");
+	}
+
+	#[test]
+	fn squeezeblocks_matches_incremental_squeeze() {
+		// Audit regression companion: the old API took a flat `&mut [u8]` plus
+		// a separate `nblocks`, and a short slice was silently underfilled
+		// (stale tail bytes treated as XOF output, Keccak state permuted fewer
+		// times than requested). The API now takes whole blocks
+		// (`&mut [[u8; RATE]]`), so that mismatch cannot be expressed at all —
+		// this test pins down that the block-squeeze still produces exactly
+		// the same stream as the byte-wise squeeze.
+		let mut block_state = KeccakState::default();
+		shake256_absorb(&mut block_state, b"equivalence");
+		shake256_finalize(&mut block_state);
+		let mut blocks = [[0u8; SHAKE256_RATE]; 2];
+		shake256_squeezeblocks(&mut blocks, &mut block_state);
+
+		let mut byte_state = KeccakState::default();
+		shake256_absorb(&mut byte_state, b"equivalence");
+		shake256_finalize(&mut byte_state);
+		let mut bytes = [0u8; 2 * SHAKE256_RATE];
+		shake256_squeeze(&mut bytes, &mut byte_state);
+
+		assert_eq!(blocks.as_flattened(), bytes);
+
+		// Same equivalence for SHAKE128.
+		let mut block_state = KeccakState::default();
+		shake128_absorb(&mut block_state, b"equivalence");
+		shake128_finalize(&mut block_state);
+		let mut blocks128 = [[0u8; SHAKE128_RATE]; 2];
+		shake128_squeezeblocks(&mut blocks128, &mut block_state);
+
+		let mut byte_state = KeccakState::default();
+		shake128_absorb(&mut byte_state, b"equivalence");
+		shake128_finalize(&mut byte_state);
+		let mut bytes128 = [0u8; 2 * SHAKE128_RATE];
+		let pos = keccak_squeeze(&mut bytes128, &mut byte_state.s, SHAKE128_RATE, SHAKE128_RATE);
+		assert!(pos <= SHAKE128_RATE);
+
+		assert_eq!(blocks128.as_flattened(), bytes128);
 	}
 
 	#[test]

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -497,6 +497,41 @@ mod tests {
 		);
 	}
 
+	// The standalone SecretKey import path must reject a secret key whose
+	// derived public key has all-zero t1, matching PublicKey::from_bytes and
+	// sign::verify. Such a blob (s1 = s2 = 0, hence t1 = t0 = 0) passes the
+	// tr/t0 consistency checks by construction, so without an explicit t1
+	// check it imports cleanly and then produces signatures that can never
+	// verify — while the degenerate public key it corresponds to is exactly
+	// the malicious-key forgery class the verifier rejects.
+	#[test]
+	fn secret_key_from_bytes_rejects_zero_t1() {
+		use super::{KeyParsingError, SecretKey, SECRETKEYBYTES};
+		use crate::{packing, params, polyvec};
+
+		// Craft a fully self-consistent secret key with s1 = s2 = 0:
+		// t = A·0 + 0 = 0, so t1 = 0 and t0 = 0, and tr = SHAKE256(pk).
+		let rho = [0x42u8; params::SEEDBYTES];
+		let key = [0x17u8; params::SEEDBYTES];
+		let s1 = polyvec::Polyvecl::default();
+		let s2 = polyvec::Polyveck::default();
+		let t0 = polyvec::Polyveck::default();
+		let t1 = polyvec::Polyveck::default();
+
+		let mut pk = [0u8; super::PUBLICKEYBYTES];
+		packing::pack_pk(&mut pk, &rho, &t1);
+		let mut tr = [0u8; params::TR_BYTES];
+		crate::fips202::shake256(&mut tr, &pk);
+
+		let mut sk = [0u8; SECRETKEYBYTES];
+		packing::pack_sk(&mut sk, &rho, &tr, &key, &t0, &s1, &s2);
+
+		assert!(
+			matches!(SecretKey::from_bytes(&sk), Err(KeyParsingError::BadSecretKey)),
+			"secret key deriving an all-zero t1 public key must be rejected"
+		);
+	}
+
 	// Malicious-key forgery defense: a public key with an all-zero t1 makes verification
 	// independent of the challenge, enabling signature forgery without a secret key.
 	// `from_bytes` must reject such a key so it can never be constructed or stored.

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -312,20 +312,17 @@ pub fn uniform(a: &mut Poly, seed: &[u8; params::SEEDBYTES], nonce: u16) {
 	let mut state = fips202::KeccakState::default();
 	fips202::shake128_stream_init(&mut state, seed, nonce);
 
-	let mut buf = [0u8; UNIFORM_NBLOCKS * fips202::SHAKE128_RATE + 2];
-	fips202::shake128_squeezeblocks(&mut buf, UNIFORM_NBLOCKS, &mut state);
+	let mut buf = [[0u8; fips202::SHAKE128_RATE]; UNIFORM_NBLOCKS];
+	fips202::shake128_squeezeblocks(&mut buf, &mut state);
 
-	let mut buflen: usize = UNIFORM_NBLOCKS * fips202::SHAKE128_RATE;
-	let mut ctr = rej_uniform(&mut a.coeffs, &buf[..buflen]);
+	let mut ctr = rej_uniform(&mut a.coeffs, buf.as_flattened());
 
+	// SHAKE128_RATE is a multiple of 3, so every block holds a whole number of
+	// 3-byte coefficient candidates and refills can be scanned block by block.
+	// (The C reference's `off` carry-over bytes are always zero here.)
 	while ctr < N {
-		let off = buflen % 3;
-		for i in 0..off {
-			buf[i] = buf[buflen - off + i];
-		}
-		fips202::shake128_squeezeblocks(&mut buf[off..], 1, &mut state);
-		buflen = fips202::SHAKE128_RATE + off;
-		ctr += rej_uniform(&mut a.coeffs[ctr..], &buf[..buflen]);
+		fips202::shake128_squeezeblocks(&mut buf[..1], &mut state);
+		ctr += rej_uniform(&mut a.coeffs[ctr..], &buf[0]);
 	}
 }
 
@@ -544,7 +541,7 @@ pub fn uniform_eta(output_polynomial: &mut Poly, seed: &[u8; params::CRHBYTES], 
 
 	// Fixed number of rounds to reduce timing variations
 	const FIXED_ROUNDS: usize = 2;
-	let mut shake_output_buffer = [0u8; fips202::SHAKE256_RATE];
+	let mut shake_output_buffer = [[0u8; fips202::SHAKE256_RATE]; 1];
 	let mut temporary_coefficient_storage = [0i32; 1000]; // Temp storage for all extracted coeffs
 	let mut total_coefficients_collected = 0usize;
 
@@ -554,12 +551,12 @@ pub fn uniform_eta(output_polynomial: &mut Poly, seed: &[u8; params::CRHBYTES], 
 		// Always run exactly FIXED_ROUNDS iterations
 		for _round_number in 0..FIXED_ROUNDS {
 			// Squeeze one block at a time and collect
-			fips202::shake256_squeezeblocks(&mut shake_output_buffer, 1, &mut state);
+			fips202::shake256_squeezeblocks(&mut shake_output_buffer, &mut state);
 
 			// Always call rej_eta with same parameters regardless of how many coeffs we have
 			let coefficients_extracted_this_round = rej_eta(
 				&mut temporary_coefficient_storage[total_coefficients_collected..],
-				&shake_output_buffer,
+				&shake_output_buffer[0],
 			);
 			total_coefficients_collected += coefficients_extracted_this_round;
 		}
@@ -575,11 +572,12 @@ pub fn uniform_gamma1(a: &mut Poly, seed: &[u8; params::CRHBYTES], nonce: u16) {
 	let mut state = fips202::KeccakState::default();
 	fips202::shake256_stream_init(&mut state, seed, nonce);
 
-	let mut buf = [0u8; UNIFORM_GAMMA1_NBLOCKS * fips202::SHAKE256_RATE];
-	fips202::shake256_squeezeblocks(&mut buf, UNIFORM_GAMMA1_NBLOCKS, &mut state);
+	let mut buf = [[0u8; fips202::SHAKE256_RATE]; UNIFORM_GAMMA1_NBLOCKS];
+	fips202::shake256_squeezeblocks(&mut buf, &mut state);
 	// The squeeze buffer is a multiple of the rate and always >= POLYZ_PACKEDBYTES,
 	// so `first_chunk` yields the exact prefix the codec consumes.
 	let z_bytes = buf
+		.as_flattened()
 		.first_chunk::<{ params::POLYZ_PACKEDBYTES }>()
 		.expect("gamma1 buffer covers POLYZ_PACKEDBYTES");
 	z_unpack(a, z_bytes);
@@ -597,11 +595,11 @@ pub fn challenge(c: &mut Poly, seed: &[u8]) {
 	fips202::shake256_absorb(&mut state, seed);
 	fips202::shake256_finalize(&mut state);
 
-	let mut buf = [0u8; fips202::SHAKE256_RATE];
-	fips202::shake256_squeezeblocks(&mut buf, 1, &mut state);
+	let mut buf = [[0u8; fips202::SHAKE256_RATE]; 1];
+	fips202::shake256_squeezeblocks(&mut buf, &mut state);
 
 	let mut signs: u64 = 0;
-	for (i, &byte) in buf.iter().enumerate().take(8) {
+	for (i, &byte) in buf[0].iter().enumerate().take(8) {
 		signs |= (byte as u64) << 8 * i;
 	}
 
@@ -612,10 +610,10 @@ pub fn challenge(c: &mut Poly, seed: &[u8]) {
 	for i in (N - params::TAU)..N {
 		let b = loop {
 			if pos >= fips202::SHAKE256_RATE {
-				fips202::shake256_squeezeblocks(&mut buf, 1, &mut state);
+				fips202::shake256_squeezeblocks(&mut buf, &mut state);
 				pos = 0;
 			}
-			let candidate = buf[pos] as usize;
+			let candidate = buf[0][pos] as usize;
 			pos += 1;
 			if candidate <= i {
 				break candidate;
@@ -1324,14 +1322,14 @@ mod tests {
 			let mut state = fips202::KeccakState::default();
 			fips202::shake256_stream_init(&mut state, &seed, nonce);
 
-			let mut shake_output_buffer = [0u8; fips202::SHAKE256_RATE];
+			let mut shake_output_buffer = [[0u8; fips202::SHAKE256_RATE]; 1];
 
 			for _round_number in 0..FIXED_ROUNDS_FOR_CONSTANT_TIME {
-				fips202::shake256_squeezeblocks(&mut shake_output_buffer, 1, &mut state);
+				fips202::shake256_squeezeblocks(&mut shake_output_buffer, &mut state);
 
 				let coefficients_extracted_this_round = rej_eta(
 					&mut temporary_coefficient_storage[total_coefficients_collected..],
-					&shake_output_buffer,
+					&shake_output_buffer[0],
 				);
 				total_coefficients_collected += coefficients_extracted_this_round;
 			}

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -56,12 +56,15 @@ pub fn keypair(
 	let mut seed_bytes = seed.into_bytes();
 	const SEEDBUF_LEN: usize = 2 * params::SEEDBYTES + params::CRHBYTES;
 	let mut seedbuf = [0u8; SEEDBUF_LEN];
-	// Build preimage = seed || K || L (accept any seed length when provided)
-	let mut preimage: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
-	preimage.extend_from_slice(&seed_bytes);
-
-	preimage.push(params::K as u8);
-	preimage.push(params::L as u8);
+	// Build preimage = seed || K || L in a fixed stack buffer. A growable
+	// Vec would reallocate while holding the seed (Vec::new +
+	// extend_from_slice sizes capacity exactly, so the pushes force a
+	// realloc), freeing a seed-bearing heap block that zeroize() can no
+	// longer reach.
+	let mut preimage = [0u8; params::SEEDBYTES + 2];
+	preimage[..params::SEEDBYTES].copy_from_slice(&seed_bytes);
+	preimage[params::SEEDBYTES] = params::K as u8;
+	preimage[params::SEEDBYTES + 1] = params::L as u8;
 	fips202::shake256(&mut seedbuf, &preimage);
 
 	let mut rho = [0u8; params::SEEDBYTES];

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -113,8 +113,12 @@ pub fn keypair(
 /// [`keypair`] does, and packs `pk = (rho, t1)`. In addition to re-deriving
 /// the public key, this checks the two remaining packed-SK invariants:
 ///
-/// - the stored `t0` must equal the re-derived low bits of `A·s1 + s2`, and
-/// - the stored `tr` must equal `SHAKE256(pk)`.
+/// - the stored `t0` must equal the re-derived low bits of `A·s1 + s2`,
+/// - the stored `tr` must equal `SHAKE256(pk)`, and
+/// - the derived `t1` must not be all-zero, matching the degenerate-key rejection in [`verify`] and
+///   `ml_dsa_87::PublicKey::from_bytes`. A blob with `s1 = s2 = 0` derives `t1 = t0 = 0` and passes
+///   the two consistency checks by construction, but its public key is exactly the forgeable class
+///   the verifier rejects, so signing with it can only produce unverifiable signatures.
 ///
 /// Signing uses the stored `tr` (bound into the message digest) and `t0`
 /// (hint computation), so a blob with a corrupted `tr`/`t0` region would
@@ -142,6 +146,10 @@ pub(crate) fn public_key_from_secret(
 	// Same derivation as key generation.
 	let (t1, mut t0_derived) = derive_public_components(&rho, &s1, &s2);
 
+	// Invariant: the derived public key must not be the degenerate all-zero
+	// t1 key that verify() rejects (see the doc comment above).
+	let t1_nonzero = !t1.vec.iter().all(|p| p.coeffs().iter().all(|&c| c == 0));
+
 	let mut pk = [0u8; params::PUBLICKEYBYTES];
 	packing::pack_pk(&mut pk, &rho, &t1);
 
@@ -164,7 +172,7 @@ pub(crate) fn public_key_from_secret(
 	t0.zeroize();
 	t0_derived.zeroize();
 
-	if t0_consistent && tr_consistent {
+	if t0_consistent && tr_consistent && t1_nonzero {
 		Some(pk)
 	} else {
 		None

--- a/dilithium/tests/keygen_zeroization.rs
+++ b/dilithium/tests/keygen_zeroization.rs
@@ -1,0 +1,71 @@
+//! Regression test (security review): key generation must never free heap
+//! memory that still contains the input seed.
+//!
+//! `keypair` used to assemble the SHAKE preimage `seed || K || L` in a
+//! growable `Vec` starting from `Vec::new()`: `extend_from_slice` allocated
+//! exactly 32 bytes of capacity, so the two subsequent `push` calls forced a
+//! reallocation that copied the seed to a new block and freed the original
+//! without clearing it. The final `preimage.zeroize()` only wiped the
+//! surviving allocation, leaving the raw seed — which deterministically
+//! derives the entire keypair — recoverable from freed heap memory.
+//!
+//! The test installs a global allocator that scans every block for the seed
+//! pattern at `dealloc` time (the block is still valid inside the hook, so
+//! the scan is sound) and asserts that no seed-bearing block is ever freed
+//! while key generation runs. This file contains exactly one test so no
+//! unrelated concurrent allocations can race the scanner.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::alloc::{GlobalAlloc, Layout, System};
+
+use qp_rusty_crystals_dilithium::{ml_dsa_87::Keypair, SensitiveBytes32};
+
+/// Distinctive 32-byte pattern; a repeated single byte could false-positive
+/// against unrelated allocator noise.
+const SEED_PATTERN: [u8; 32] = *b"zeroize-regression-seed-pattern!";
+
+static SCANNING: AtomicBool = AtomicBool::new(false);
+static SEED_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+
+struct SeedScanningAllocator;
+
+unsafe impl GlobalAlloc for SeedScanningAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		if SCANNING.load(Ordering::SeqCst) && layout.size() >= SEED_PATTERN.len() {
+			let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+			if block.windows(SEED_PATTERN.len()).any(|w| w == SEED_PATTERN) {
+				SEED_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+			}
+		}
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: SeedScanningAllocator = SeedScanningAllocator;
+
+#[test]
+fn keypair_never_frees_heap_memory_containing_the_seed() {
+	let mut seed = SEED_PATTERN;
+	let sensitive = SensitiveBytes32::new(&mut seed);
+
+	SCANNING.store(true, Ordering::SeqCst);
+	let keypair = Keypair::generate(sensitive);
+	SCANNING.store(false, Ordering::SeqCst);
+
+	assert!(
+		!SEED_FREED_UNCLEARED.load(Ordering::SeqCst),
+		"key generation freed a heap block still containing the raw seed; \
+		 the seed deterministically derives the private key, so it must be \
+		 zeroized before its memory is released"
+	);
+
+	// Sanity: generation still produces a working keypair.
+	let message = b"zeroization regression";
+	let signature = keypair.sign(message, None, None).expect("signing succeeds");
+	assert!(keypair.public.verify(message, &signature, None));
+}

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -200,12 +200,38 @@ impl BorshDeserialize for PrivateKeyShare {
 ///
 /// Uses fixed-size arrays to guarantee exact dimensions at compile time,
 /// preventing malformed deserialized data from causing issues downstream.
-#[derive(Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, PartialEq, Eq, BorshSerialize, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct SecretShareData {
 	/// Share of s1 polynomial vector (exactly L polynomials of 256 coefficients).
 	pub(crate) s1: [[i32; 256]; L],
 	/// Share of s2 polynomial vector (exactly K polynomials of 256 coefficients).
 	pub(crate) s2: [[i32; 256]; K],
+}
+
+impl BorshDeserialize for SecretShareData {
+	/// Deserialize with coefficient-range validation.
+	///
+	/// Every producer of share data emits coefficients in (-Q, Q): the
+	/// dealer's shares are η-bounded, and DKG/resharing shares are reduced
+	/// mod Q before storage. Signing copies these raw arrays into `Poly`
+	/// values and runs `poly::ntt` on them, whose coefficient bound is a
+	/// caller-enforced contract — so a malformed blob with out-of-range
+	/// coefficients must be rejected at import, not discovered as a panic
+	/// (overflow checks on) or silent wraparound (release) mid-signing.
+	fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+		const Q: i32 = qp_rusty_crystals_dilithium::params::Q;
+		let s1 = <[[i32; 256]; L]>::deserialize_reader(reader)?;
+		let s2 = <[[i32; 256]; K]>::deserialize_reader(reader)?;
+		let in_range =
+			|polys: &[[i32; 256]]| polys.iter().all(|poly| poly.iter().all(|&c| c > -Q && c < Q));
+		if !in_range(&s1) || !in_range(&s2) {
+			return Err(borsh::io::Error::new(
+				borsh::io::ErrorKind::InvalidData,
+				"SecretShareData coefficient outside (-Q, Q)",
+			));
+		}
+		Ok(Self { s1, s2 })
+	}
 }
 
 impl PrivateKeyShare {
@@ -381,6 +407,64 @@ mod tests {
 		assert_eq!(pk_share.key, [0u8; 32]);
 		assert_eq!(pk_share.rho, [0u8; 32]);
 		assert_eq!(pk_share.tr, [0u8; TR_SIZE]);
+	}
+
+	/// Security review: PrivateKeyShare deserialization must validate share
+	/// coefficient ranges, not just the share-map length. Signing copies the
+	/// raw arrays into Poly values and runs poly::ntt on them, whose
+	/// coefficient-bound contract is caller-enforced — a malformed blob would
+	/// import cleanly and only blow up (panic with overflow checks, silent
+	/// wrap in release) once the signer tries to use it.
+	#[test]
+	fn test_private_key_share_borsh_rejects_out_of_range_coefficients() {
+		use qp_rusty_crystals_dilithium::params::Q;
+
+		let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
+		let mut shares = BTreeMap::new();
+		let mut bad = SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] };
+		bad.s1[0][0] = i32::MAX;
+		shares.insert(0b011u16, bad);
+
+		let share = PrivateKeyShare::new(
+			0,
+			3,
+			2,
+			[0x11u8; 32],
+			[0x22u8; 32],
+			[0x33u8; TR_SIZE],
+			shares,
+			dkg_participants.clone(),
+		);
+		let bytes = borsh::to_vec(&share).unwrap();
+		let result: Result<PrivateKeyShare, _> = borsh::from_slice(&bytes);
+		assert!(result.is_err(), "share coefficient outside (-Q, Q) must be rejected at import");
+
+		// Boundary: exactly Q and -Q are invalid, Q-1 and -(Q-1) are valid.
+		for (value, valid) in [(Q, false), (-Q, false), (Q - 1, true), (-(Q - 1), true)] {
+			let mut shares = BTreeMap::new();
+			let mut data = SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] };
+			data.s2[K - 1][255] = value;
+			shares.insert(0b011u16, data);
+			let share = PrivateKeyShare::new(
+				0,
+				3,
+				2,
+				[0x11u8; 32],
+				[0x22u8; 32],
+				[0x33u8; TR_SIZE],
+				shares,
+				dkg_participants.clone(),
+			);
+			let bytes = borsh::to_vec(&share).unwrap();
+			let result: Result<PrivateKeyShare, _> = borsh::from_slice(&bytes);
+			assert_eq!(
+				result.is_ok(),
+				valid,
+				"coefficient {} should be {}",
+				value,
+				if valid { "accepted" } else { "rejected" }
+			);
+		}
 	}
 
 	#[test]

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -32,6 +32,20 @@ fn compute_tr(bytes: &[u8; PUBLIC_KEY_SIZE]) -> [u8; TR_SIZE] {
 	tr
 }
 
+/// Validate public key bytes through the canonical ML-DSA parser.
+///
+/// Every import boundary (`from_bytes`, Borsh deserialization) must apply
+/// the same key-validity rules as `ml_dsa_87::PublicKey::from_bytes` and the
+/// verifier — in particular the rejection of the degenerate all-zero t1 key,
+/// which removes challenge binding and makes signatures forgeable. Accepting
+/// such bytes here would hand downstream code a trusted-looking `PublicKey`
+/// that the core implementation itself treats as invalid.
+fn validate_pk_bytes(bytes: &[u8; PUBLIC_KEY_SIZE]) -> Result<(), &'static str> {
+	qp_rusty_crystals_dilithium::ml_dsa_87::PublicKey::from_bytes(bytes)
+		.map(|_| ())
+		.map_err(|_| "invalid ML-DSA public key")
+}
+
 /// Public key for threshold ML-DSA-87.
 ///
 /// This key is shared among all parties and is used for signature verification.
@@ -63,6 +77,8 @@ impl BorshSerialize for PublicKey {
 impl BorshDeserialize for PublicKey {
 	fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
 		let bytes = <[u8; PUBLIC_KEY_SIZE]>::deserialize_reader(reader)?;
+		validate_pk_bytes(&bytes)
+			.map_err(|e| borsh::io::Error::new(borsh::io::ErrorKind::InvalidData, e))?;
 		let tr = compute_tr(&bytes);
 		Ok(Self { bytes, tr })
 	}
@@ -92,7 +108,9 @@ impl PublicKey {
 
 	/// Create a public key from bytes.
 	///
-	/// This computes the TR hash from the public key bytes.
+	/// The bytes are validated through the canonical ML-DSA parser (rejecting
+	/// e.g. the forgeable all-zero t1 key), and the TR hash is computed from
+	/// them.
 	pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
 		if bytes.len() != PUBLIC_KEY_SIZE {
 			return Err("invalid public key length");
@@ -100,6 +118,7 @@ impl PublicKey {
 
 		let mut pk_bytes = [0u8; PUBLIC_KEY_SIZE];
 		pk_bytes.copy_from_slice(bytes);
+		validate_pk_bytes(&pk_bytes)?;
 
 		let tr = compute_tr(&pk_bytes);
 		Ok(Self { bytes: pk_bytes, tr })
@@ -297,6 +316,34 @@ mod tests {
 	fn test_public_key_invalid_length() {
 		let bytes = [0u8; 100];
 		assert!(PublicKey::from_bytes(&bytes).is_err());
+	}
+
+	/// Security review: the threshold public key import paths must apply the
+	/// same degenerate-key check as the canonical ML-DSA parser
+	/// (`ml_dsa_87::PublicKey::from_bytes`) and the verifier, both of which
+	/// reject an all-zero t1 because it removes challenge binding and makes
+	/// signatures forgeable for that key. Accepting it here would let
+	/// downstream code trust a forgeable PublicKey object (or its
+	/// `as_bytes()` output) without ever re-parsing through the safe wrapper.
+	#[test]
+	fn test_public_key_from_bytes_rejects_zero_t1() {
+		// rho nonzero, t1 region all zero — the forgeable class.
+		let mut bytes = [0u8; PUBLIC_KEY_SIZE];
+		bytes[..32].copy_from_slice(&[0x42u8; 32]);
+		assert!(
+			PublicKey::from_bytes(&bytes).is_err(),
+			"all-zero t1 public key must be rejected by from_bytes"
+		);
+	}
+
+	/// Borsh deserialization is an import boundary too (broadcast messages,
+	/// stored state) and must enforce the same check as `from_bytes`.
+	#[test]
+	fn test_public_key_borsh_rejects_zero_t1() {
+		let mut bytes = [0u8; PUBLIC_KEY_SIZE];
+		bytes[..32].copy_from_slice(&[0x42u8; 32]);
+		let result: Result<PublicKey, _> = borsh::from_slice(&bytes);
+		assert!(result.is_err(), "all-zero t1 public key must be rejected by Borsh deserialize");
 	}
 
 	#[test]

--- a/threshold/src/protocol/primitives.rs
+++ b/threshold/src/protocol/primitives.rs
@@ -646,9 +646,15 @@ pub(crate) fn poly_unpack_w(buf: &[u8]) -> Result<poly::Poly, &'static str> {
 
 /// Unpack a Polyveck from 23-bit encoding.
 ///
-/// Returns an error if any coefficient is >= Q.
+/// Returns an error if the buffer is shorter than `K * 736` bytes or if any
+/// coefficient is >= Q. The length is validated up front so an undersized
+/// buffer is a recoverable `Err` rather than an out-of-bounds slice panic
+/// (which would abort the process in panic=abort deployments).
 pub(crate) fn unpack_polyveck_w(buf: &[u8]) -> Result<polyvec::Polyveck, &'static str> {
 	const POLY_W_SIZE: usize = 736;
+	if buf.len() < K * POLY_W_SIZE {
+		return Err("buffer too short for unpack_polyveck_w");
+	}
 	let mut w = polyvec::Polyveck::default();
 	for i in 0..K {
 		let offset = i * POLY_W_SIZE;
@@ -752,6 +758,29 @@ mod tests {
 		for i in 0..N as usize {
 			assert_eq!(p.coeffs()[i], p2.coeffs()[i], "Mismatch at index {}", i);
 		}
+	}
+
+	#[test]
+	fn test_unpack_polyveck_w_rejects_short_buffer() {
+		// Audit regression: an undersized buffer must be a recoverable Err,
+		// not an out-of-bounds slice panic. The function already returns
+		// Result for coefficient-range errors; a length violation must take
+		// the same path (a panic would abort the process in panic=abort
+		// deployments before the caller's error handling runs).
+		for len in [0usize, 100, 736, 8 * 736 - 1] {
+			let buf = vec![0u8; len];
+			let result = unpack_polyveck_w(&buf);
+			assert!(
+				matches!(result, Err("buffer too short for unpack_polyveck_w")),
+				"len {} must be rejected with an error, got {:?}",
+				len,
+				result.is_ok()
+			);
+		}
+
+		// A correctly sized buffer still unpacks (all-zero coefficients are valid).
+		let buf = vec![0u8; 8 * 736];
+		assert!(unpack_polyveck_w(&buf).is_ok());
 	}
 
 	#[test]

--- a/threshold/src/protocol/signing.rs
+++ b/threshold/src/protocol/signing.rs
@@ -59,6 +59,17 @@ pub(crate) struct Round2Data {
 	/// Stores the actual participant IDs (which can be arbitrary u32 values).
 	/// The ParticipantList provides index mapping for internal bitmask operations.
 	pub(crate) active_participants: ParticipantList,
+	/// Round 1 commitment hashes captured from the peers' Round 1 broadcasts,
+	/// keyed by party ID, frozen at the moment this party revealed its own
+	/// Round 2 commitment.
+	///
+	/// Round 3 verifies every peer's Round 2 reveal against *this* map rather
+	/// than a caller-supplied Round 1 set. That preserves the commit-reveal
+	/// anti-rushing property: a peer cannot swap in a Round 1 hash chosen
+	/// after observing honest reveals. These hashes are public broadcast
+	/// material, so they are excluded from zeroization.
+	#[zeroize(skip)]
+	pub(crate) round1_commitments: BTreeMap<ParticipantId, [u8; 32]>,
 }
 
 // ============================================================================
@@ -526,7 +537,9 @@ pub(crate) fn process_round2(
 	tr.copy_from_slice(public_key.tr());
 	let mu = compute_mu(&tr, message, context);
 
-	Ok(Round2Data { mu, w_aggregated, active_participants })
+	// The caller (ThresholdSigner::round2_reveal) fills in the frozen Round 1
+	// commitment hashes; process_round2 only sees the participant IDs.
+	Ok(Round2Data { mu, w_aggregated, active_participants, round1_commitments: BTreeMap::new() })
 }
 
 // ============================================================================

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -172,8 +172,8 @@ pub use types::{
 	ResharingRole, ResharingRound1EntropyCommitment, ResharingRound2EntropyReveal,
 	ResharingRound3Broadcast, ResharingRound4Message, ResharingRound5Broadcast,
 	ResharingSignerConfig, SubsetMask, SubsetPair, ENTROPY_SIZE, MAX_ACCEPT_SIGNATURE_LEN,
-	RESHARING_PROTOCOL_VERSION, RESHARING_SSID_SIZE, RESHARING_SUITE_ML_DSA_87,
-	SUBSHARE_COEFF_BOUND,
+	MAX_ERROR_MESSAGE_LEN, RESHARING_PROTOCOL_VERSION, RESHARING_SSID_SIZE,
+	RESHARING_SUITE_ML_DSA_87, SUBSHARE_COEFF_BOUND,
 };
 
 // Re-export the long-term-key signing trait used for Round 6 acceptance, so

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -189,6 +189,21 @@ impl ResharingConfig {
 				return Err(ResharingConfigError::SharePartyNotInOldCommittee { party_id });
 			}
 
+			// The share's stored subset masks are defined relative to its
+			// embedded DKG participant list, but the protocol maps mask bits
+			// to parties through `old_participants` (dealer assignment,
+			// subset enumeration, share lookup). The two lists must be
+			// identical, or this party would deal sub-share material derived
+			// from its real share under a different identity mapping than
+			// the one the shares were created with. The party-count check
+			// additionally rejects shares whose stored `total_parties` is
+			// inconsistent with their own participant list.
+			if share.dkg_participants() != &old_participant_list ||
+				share.total_parties() as usize != old_participant_list.len()
+			{
+				return Err(ResharingConfigError::OldCommitteeMismatch);
+			}
+
 			// Validate share's threshold matches old_threshold parameter
 			if threshold != old_threshold {
 				return Err(ResharingConfigError::ThresholdMismatch {
@@ -371,6 +386,11 @@ pub enum ResharingConfigError {
 	OldMemberMustProvideShare { party_id: ParticipantId },
 	/// Share's party_id is not in the old committee.
 	SharePartyNotInOldCommittee { party_id: ParticipantId },
+	/// Old committee does not exactly match the share's embedded DKG
+	/// participant list, so the share's subset masks would be interpreted
+	/// under a different identity mapping than the one they were created
+	/// with.
+	OldCommitteeMismatch,
 	/// Share's public key (TR) doesn't match the provided public key.
 	PublicKeyMismatch,
 	/// Share's threshold doesn't match the old_threshold parameter.
@@ -416,6 +436,9 @@ impl fmt::Display for ResharingConfigError {
 					"Share's party_id ({}) is not in the old committee participant list",
 					party_id
 				)
+			},
+			ResharingConfigError::OldCommitteeMismatch => {
+				write!(f, "Old committee does not match the share's embedded DKG participant list")
 			},
 			ResharingConfigError::PublicKeyMismatch => {
 				write!(f, "Share's public key hash (TR) does not match the provided public key")
@@ -1560,6 +1583,68 @@ mod tests {
 		assert_eq!(resharing_config.role, ResharingRole::Both);
 		assert!(resharing_config.role.is_old_committee());
 		assert!(resharing_config.role.is_new_committee());
+	}
+
+	/// Security review: the caller-supplied old committee must exactly match
+	/// the share's embedded DKG participant list. The share's subset masks
+	/// are defined relative to that embedded list, but the protocol maps
+	/// mask bits to parties through `config.old_participants()` (dealer
+	/// assignment, subset enumeration, share lookup). If the two lists
+	/// differ, an old member deals Round 4 sub-share material derived from
+	/// its real share under the wrong identity mapping before any later
+	/// consistency check can fire.
+	#[test]
+	fn test_config_rejects_old_committee_not_matching_share_dkg_list() {
+		use crate::{generate_with_dealer, ThresholdConfig};
+
+		let config = ThresholdConfig::new(2, 3).expect("valid config");
+		let seed = [42u8; 32];
+		// Dealer keygen embeds dkg_participants = [0, 1, 2] in every share.
+		let (public_key, shares) = generate_with_dealer(&seed, config).expect("keygen");
+
+		// Same size, victim's ID present, threshold and TR match — but two
+		// committee members are swapped for attacker-chosen IDs.
+		let result = ResharingConfig::new(
+			Some(shares[1].clone()),
+			2,
+			vec![1, 5, 6],
+			2,
+			vec![1, 5, 6],
+			1,
+			public_key.clone(),
+		);
+		assert!(
+			matches!(result, Err(ResharingConfigError::OldCommitteeMismatch)),
+			"old committee differing from the share's DKG list must be rejected, got {:?}",
+			result.map(|_| ())
+		);
+
+		// A superset also shifts the mask-bit-to-party mapping.
+		let result = ResharingConfig::new(
+			Some(shares[1].clone()),
+			2,
+			vec![0, 1, 2, 3],
+			2,
+			vec![0, 1, 2, 3],
+			1,
+			public_key.clone(),
+		);
+		assert!(
+			matches!(result, Err(ResharingConfigError::OldCommitteeMismatch)),
+			"old committee superset of the share's DKG list must be rejected"
+		);
+
+		// The exact DKG committee still works.
+		let result = ResharingConfig::new(
+			Some(shares[1].clone()),
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 2],
+			1,
+			public_key.clone(),
+		);
+		assert!(result.is_ok(), "matching old committee must be accepted");
 	}
 
 	#[test]

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -1279,15 +1279,14 @@ impl BorshDeserialize for ResharingRound5Broadcast {
 					)
 				})?)
 			},
-			flag => {
+			flag =>
 				return Err(borsh::io::Error::new(
 					borsh::io::ErrorKind::InvalidData,
 					alloc::format!(
 						"Invalid Option representation: {}. The first byte must be 0 or 1",
 						flag
 					),
-				))
-			},
+				)),
 		};
 
 		Ok(Self { ssid, party_id, share_commitments, partial_pks, success, error_message })

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -1367,8 +1367,9 @@ mod tests {
 	const TEST_SSID: [u8; RESHARING_SSID_SIZE] = [0xABu8; RESHARING_SSID_SIZE];
 
 	fn make_test_public_key() -> PublicKey {
-		// Create a dummy public key for testing
-		let bytes = [0u8; 2592];
+		// Dummy public key for testing. Must have a nonzero t1 region:
+		// import paths reject the degenerate all-zero t1 key.
+		let bytes = [0x42u8; 2592];
 		PublicKey::from_bytes(&bytes).unwrap()
 	}
 

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -1173,6 +1173,17 @@ impl Default for NewShareData {
 // Round 5: Verification
 // ============================================================================
 
+/// Maximum accepted `error_message` length in bytes (bounds deserialization).
+///
+/// Genuine Round 5 error messages are short, locally generated
+/// `Display`-formatted protocol errors; 1 KiB is generous headroom. Without a
+/// bound, the `Option<String>` field is the one variable-length resharing
+/// field whose length prefix an attacker controls without limit: a ~90-byte
+/// broadcast claiming a huge length forces every recipient to allocate up to
+/// borsh's internal 1 MiB first chunk before detecting truncation, and a
+/// fully-delivered payload of up to 4 GiB would be accepted and retained.
+pub const MAX_ERROR_MESSAGE_LEN: usize = 1024;
+
 /// Round 5 broadcast.
 ///
 /// Round 5 has three purposes:
@@ -1242,7 +1253,42 @@ impl BorshDeserialize for ResharingRound5Broadcast {
 		}
 
 		let success = bool::deserialize_reader(reader)?;
-		let error_message = Option::<String>::deserialize_reader(reader)?;
+
+		// Read error_message with a bound check. Borsh's default Option<String>
+		// path would trust the attacker-controlled u32 length prefix (allocating
+		// up to its internal 1 MiB chunk on a truncated payload, or accepting a
+		// fully-delivered string of up to 4 GiB), so mirror the Option flag
+		// encoding manually and bound the length before reading, using the
+		// chunked read_length_prefixed path like every other variable-length
+		// resharing field.
+		let error_message = match u8::deserialize_reader(reader)? {
+			0 => None,
+			1 => {
+				let msg_len = u32::deserialize_reader(reader)? as usize;
+				if msg_len > MAX_ERROR_MESSAGE_LEN {
+					return Err(borsh::io::Error::new(
+						borsh::io::ErrorKind::InvalidData,
+						"ResharingRound5Broadcast.error_message exceeds MAX_ERROR_MESSAGE_LEN",
+					));
+				}
+				let bytes = crate::broadcast::read_length_prefixed(reader, msg_len)?;
+				Some(String::from_utf8(bytes).map_err(|_| {
+					borsh::io::Error::new(
+						borsh::io::ErrorKind::InvalidData,
+						"ResharingRound5Broadcast.error_message is not valid UTF-8",
+					)
+				})?)
+			},
+			flag => {
+				return Err(borsh::io::Error::new(
+					borsh::io::ErrorKind::InvalidData,
+					alloc::format!(
+						"Invalid Option representation: {}. The first byte must be 0 or 1",
+						flag
+					),
+				))
+			},
+		};
 
 		Ok(Self { ssid, party_id, share_commitments, partial_pks, success, error_message })
 	}

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -871,11 +871,12 @@ mod tests {
 		);
 
 		// Create a public key - from_bytes computes TR = SHAKE256(bytes),
-		// which will NOT match our private key's TR (0x42 repeated)
-		let pk_bytes = [0u8; PUBLIC_KEY_SIZE];
+		// which will NOT match our private key's TR (0x42 repeated). The
+		// bytes must have a nonzero t1 region to pass import validation.
+		let pk_bytes = [0x37u8; PUBLIC_KEY_SIZE];
 		let public_key = PublicKey::from_bytes(&pk_bytes).unwrap();
 
-		// The public key's TR is SHAKE256([0u8; PUBLIC_KEY_SIZE]), not [0x42; TR_SIZE]
+		// The public key's TR is SHAKE256(pk_bytes), not [0x42; TR_SIZE]
 		assert_ne!(public_key.tr(), &private_tr);
 
 		// ThresholdSigner::new should reject this mismatched key pair

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -36,7 +36,12 @@
 //! let signature = signer.combine(&all_r2_broadcasts, &all_r3_broadcasts)?;
 //! ```
 
-use alloc::{collections::BTreeSet, format, string::ToString, vec::Vec};
+use alloc::{
+	collections::{BTreeMap, BTreeSet},
+	format,
+	string::ToString,
+	vec::Vec,
+};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use qp_rusty_crystals_dilithium::polyvec;
@@ -46,6 +51,7 @@ use crate::{
 	config::ThresholdConfig,
 	error::{ThresholdError, ThresholdResult},
 	keys::{PrivateKeyShare, PublicKey},
+	participants::ParticipantId,
 	protocol::signing::{
 		aggregate_commitments_dilithium, combine_signature, generate_round1,
 		generate_round3_response, pack_responses, pack_round1_commitment, process_round2,
@@ -401,7 +407,7 @@ impl ThresholdSigner {
 		let other_party_ids: Vec<u32> = other_round1.iter().map(|r1| r1.party_id).collect();
 
 		// Process Round 2 - sets up our own commitments
-		let round2_data = process_round2(
+		let mut round2_data = process_round2(
 			&self.private_key,
 			&self.public_key,
 			&self.config,
@@ -410,6 +416,15 @@ impl ThresholdSigner {
 			context,
 			&other_party_ids,
 		)?;
+
+		// Freeze the peers' Round 1 commitment hashes now, at the moment we
+		// reveal our own Round 2 commitment. Round 3 verifies reveals against
+		// this map instead of a caller-supplied Round 1 set, so a peer cannot
+		// substitute a Round 1 hash chosen after observing honest reveals
+		// (the commit-reveal anti-rushing property). A duplicate peer party ID
+		// is already rejected while building `active_participants` above.
+		round2_data.round1_commitments =
+			other_round1.iter().map(|r1| (r1.party_id, r1.commitment_hash)).collect();
 
 		let broadcast = Round2Broadcast::new(*ssid, self.private_key.party_id(), commitment_data);
 
@@ -469,18 +484,37 @@ impl ThresholdSigner {
 	) -> ThresholdResult<Round3Broadcast> {
 		let k = self.config.k_iterations() as usize;
 
-		// Validate all reveals against their Round 1 commitments before touching
-		// any state (duplicates, sizes, hash binding).
-		let seen_parties =
-			Self::validate_reveals_against_commitments(ssid, other_round1, other_round2, k)?;
-
-		// Check state
+		// The peers' Round 1 commitment hashes were frozen when we revealed our
+		// own Round 2 commitment (see `round2_reveal`). Verifying reveals
+		// against that stored map — rather than the caller-supplied
+		// `other_round1` — is what preserves the commit-reveal anti-rushing
+		// property: a peer cannot substitute a Round 1 hash chosen after
+		// observing honest reveals. This requires AfterRound2, so grab the
+		// frozen map first.
 		if self.state.phase != SigningPhase::AfterRound2 {
 			return Err(ThresholdError::InvalidState {
 				current: self.state.phase_name(),
 				expected: "AfterRound2",
 			});
 		}
+		let stored_commitments = {
+			let round2_data =
+				self.state.round2_data.as_ref().ok_or(ThresholdError::InvalidState {
+					current: "AfterRound2", // phase already validated above
+					expected: "AfterRound2",
+				})?;
+			round2_data.round1_commitments.clone()
+		};
+
+		// Validate all reveals against the frozen Round 1 commitments before
+		// touching any state (duplicates, sizes, hash binding).
+		let seen_parties = Self::validate_reveals_against_commitments(
+			ssid,
+			&stored_commitments,
+			other_round1,
+			other_round2,
+			k,
+		)?;
 
 		// Aggregate commitments without mutating persistent state until every reveal
 		// is validated and unpacked. Two properties are enforced here:
@@ -537,11 +571,20 @@ impl ThresholdSigner {
 		Ok(broadcast)
 	}
 
-	/// Validate Round 2 reveals against their Round 1 commitments: reject
-	/// duplicate reveals, empty or mis-sized commitment data, reveals without a
-	/// matching Round 1 broadcast, and reveals whose data does not hash to the
+	/// Validate Round 2 reveals against the Round 1 commitment hashes that were
+	/// frozen during `round2_reveal`: reject duplicate reveals, empty or
+	/// mis-sized commitment data, reveals from a party we recorded no Round 1
+	/// commitment for, and reveals whose data does not hash to the frozen
 	/// Round 1 commitment. Touches no state; returns the set of revealing
 	/// party IDs for the exact-set check.
+	///
+	/// `stored_commitments` is the authoritative source (captured before this
+	/// party revealed its own commitment). The caller-supplied `other_round1`
+	/// is accepted only as defense in depth: if it carries a Round 1 hash for a
+	/// revealing party, that hash must equal the frozen one, otherwise the
+	/// caller is attempting to substitute a post-hoc commitment and the reveal
+	/// is rejected. This is what stops a rushing peer from choosing its
+	/// commitment after seeing honest reveals.
 	///
 	/// Rejecting duplicates up front matters because replaying one party's
 	/// Round 2 broadcast must never be counted twice, or the aggregate (and
@@ -549,6 +592,7 @@ impl ThresholdSigner {
 	/// corrupted.
 	fn validate_reveals_against_commitments(
 		ssid: &[u8; 32],
+		stored_commitments: &BTreeMap<ParticipantId, [u8; 32]>,
 		other_round1: &[Round1Broadcast],
 		other_round2: &[Round2Broadcast],
 		k: usize,
@@ -572,15 +616,31 @@ impl ThresholdSigner {
 				});
 			}
 
-			// Find matching Round 1 broadcast
-			let r1 = other_round1
-				.iter()
-				.find(|r1| r1.party_id == r2.party_id)
+			// The Round 1 hash frozen during round2_reveal is authoritative.
+			// A reveal from a party we recorded no Round 1 commitment for
+			// cannot be bound and is rejected.
+			let committed_hash = stored_commitments
+				.get(&r2.party_id)
 				.ok_or(ThresholdError::MissingBroadcast { party_id: r2.party_id })?;
 
-			// Verify commitment hash (using SSID instead of tr)
-			if !verify_commitment_hash(ssid, r2.party_id, &r2.commitment_data, &r1.commitment_hash)
-			{
+			// Defense in depth: a Round 1 broadcast supplied to Round 3 for a
+			// revealing party must agree with the frozen hash. A mismatch is a
+			// rushing attempt (a commitment hash chosen after observing honest
+			// reveals) and is rejected outright.
+			if let Some(supplied) = other_round1.iter().find(|r1| r1.party_id == r2.party_id) {
+				if &supplied.commitment_hash != committed_hash {
+					return Err(ThresholdError::CommitmentMismatch {
+						party_id: r2.party_id,
+						message: "Round 1 commitment hash supplied to round 3 does not match \
+						          the hash committed during round 2"
+							.to_string(),
+					});
+				}
+			}
+
+			// Verify commitment hash against the frozen Round 1 hash (using
+			// SSID instead of tr).
+			if !verify_commitment_hash(ssid, r2.party_id, &r2.commitment_data, committed_hash) {
 				return Err(ThresholdError::CommitmentMismatch {
 					party_id: r2.party_id,
 					message: "Round 2 commitment data does not match Round 1 commitment hash"
@@ -928,12 +988,78 @@ mod tests {
 		assert!(ok.is_ok(), "in-bounds message must still be accepted: {ok:?}");
 	}
 
+	/// Security review: `round3_respond` must bind each peer's Round 2 reveal
+	/// to the Round 1 commitment hash that was frozen when *this* party
+	/// revealed in Round 2, not to a caller-supplied Round 1 set. Otherwise a
+	/// rushing peer can send a placeholder Round 1 hash, observe the honest
+	/// party's revealed commitment, then hand `round3_respond` a fresh,
+	/// mutually-consistent (Round 1 hash, Round 2 data) pair chosen after the
+	/// fact — defeating the commit-reveal anti-rushing property.
+	#[test]
+	fn test_round3_binds_reveal_to_round1_hash_seen_in_round2() {
+		use crate::{
+			broadcast::Round1Broadcast, generate_with_dealer,
+			protocol::signing::compute_commitment_hash,
+		};
+
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[11u8; 32], config).unwrap();
+
+		let mut s0 = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
+		let mut s1 = ThresholdSigner::new(shares[1].clone(), pk.clone(), config).unwrap();
+
+		let ssid = [0x7Cu8; 32];
+		let msg = b"anti-rushing";
+		let ctx = b"";
+
+		let r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+
+		// The genuine party-1 commitment: a valid, well-formed Round 1/Round 2
+		// pair the attacker will present to s0 only in Round 3.
+		let r1_1_genuine = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
+		let r2_1_genuine = s1.round2_reveal(&ssid, msg, ctx, core::slice::from_ref(&r1_0)).unwrap();
+
+		// In Round 1, the attacker instead sent s0 a *placeholder* commitment
+		// hash for party 1 — distinct from the genuine one it later reveals.
+		let placeholder_hash = compute_commitment_hash(&ssid, 1, b"placeholder-commitment");
+		assert_ne!(
+			placeholder_hash, r1_1_genuine.commitment_hash,
+			"placeholder must differ from the genuine commitment"
+		);
+		let r1_1_placeholder = Round1Broadcast::new(ssid, 1, placeholder_hash);
+
+		// s0 reveals its Round 2 commitment having seen only the placeholder.
+		s0.round2_reveal(&ssid, msg, ctx, core::slice::from_ref(&r1_1_placeholder))
+			.unwrap();
+
+		// The attack: hand Round 3 the genuine, self-consistent pair. Because
+		// s0 froze the placeholder hash in Round 2, the genuine reveal no
+		// longer matches, so the rushing attempt is rejected.
+		let err = s0
+			.round3_respond(
+				&ssid,
+				core::slice::from_ref(&r1_1_genuine),
+				core::slice::from_ref(&r2_1_genuine),
+			)
+			.expect_err("reveal not matching the round-2-frozen commitment must be rejected");
+		assert!(
+			matches!(err, ThresholdError::CommitmentMismatch { party_id: 1, .. }),
+			"expected CommitmentMismatch for party 1, got {err:?}"
+		);
+	}
+
 	/// Regression test for the validate-then-commit property of
 	/// `round3_respond` (preserved across the removal of the full aggregate
 	/// clone): a reveal that passes the commitment-hash check but fails to
-	/// unpack must be rejected *without* mutating `w_aggregated`, so a
-	/// corrected retry produces exactly the same response as a signer that
-	/// never saw the malformed attempt.
+	/// unpack must be rejected *without* poisoning the session, so the signer
+	/// stays in a clean `AfterRound2` state and a repeated attempt is rejected
+	/// identically rather than double-counting or resetting.
+	///
+	/// Under the commit-reveal binding fix, the only way to reach the
+	/// unpack-failure path with a hash-bound reveal is for the malformed
+	/// commitment to be the one frozen in Round 2 — a peer that committed to
+	/// garbage in Round 1. (A peer that committed to valid data but reveals
+	/// different data is caught earlier as a `CommitmentMismatch`.)
 	#[test]
 	fn test_round3_malformed_reveal_leaves_state_clean_for_retry() {
 		use crate::{
@@ -946,52 +1072,49 @@ mod tests {
 		let (pk, shares) = generate_with_dealer(&[9u8; 32], config).unwrap();
 
 		let mut s0 = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
-		let mut s1 = ThresholdSigner::new(shares[1].clone(), pk.clone(), config).unwrap();
-		// Control signer: identical to s0 (same share, same seeds) but never
-		// fed the malformed reveal.
-		let mut c0 = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
 
 		let ssid = [0x5Au8; 32];
-		let r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
-		let r1_1 = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
-		let r1_c = c0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
-		assert_eq!(r1_0, r1_c, "control signer must mirror s0 exactly");
+		let _r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+
+		// Party 1 commits (in Round 1) to malformed data: correct length, but
+		// every 23-bit coefficient is 2^23 - 1 >= Q, so unpacking fails. The
+		// commitment hash is over that same garbage, so the later reveal is
+		// genuinely hash-bound to what s0 freezes in Round 2.
+		let k = config.k_iterations() as usize;
+		let garbage = alloc::vec![0xFFu8; k * 8 * 736];
+		let garbage_hash = compute_commitment_hash(&ssid, 1, &garbage);
+		let r1_1 = Round1Broadcast::new(ssid, 1, garbage_hash);
+		let r2_1 = Round2Broadcast::new(ssid, 1, garbage);
 
 		let msg = b"atomicity";
 		let ctx = b"";
 		s0.round2_reveal(&ssid, msg, ctx, core::slice::from_ref(&r1_1)).unwrap();
-		c0.round2_reveal(&ssid, msg, ctx, core::slice::from_ref(&r1_1)).unwrap();
-		let r2_1 = s1.round2_reveal(&ssid, msg, ctx, core::slice::from_ref(&r1_0)).unwrap();
 
-		// Forge a malformed-but-hash-bound reveal from party 1: correct length,
-		// bound to a matching (forged) Round 1 hash, but every 23-bit
-		// coefficient is 2^23 - 1 >= Q, so unpacking fails.
-		let k = config.k_iterations() as usize;
-		let garbage = alloc::vec![0xFFu8; k * 8 * 736];
-		let forged_hash = compute_commitment_hash(&ssid, 1, &garbage);
-		let fake_r1 = Round1Broadcast::new(ssid, 1, forged_hash);
-		let fake_r2 = Round2Broadcast::new(ssid, 1, garbage);
-
+		// The reveal passes the hash check (it matches the frozen commitment)
+		// but fails to unpack, and is rejected in the validation pass before
+		// the aggregate is touched.
 		let err = s0
-			.round3_respond(&ssid, core::slice::from_ref(&fake_r1), core::slice::from_ref(&fake_r2))
+			.round3_respond(&ssid, core::slice::from_ref(&r1_1), core::slice::from_ref(&r2_1))
 			.expect_err("hash-bound but malformed reveal must be rejected");
 		assert!(
 			matches!(err, ThresholdError::InvalidCommitmentData { party_id: 1, .. }),
 			"expected InvalidCommitmentData for party 1, got {err:?}"
 		);
 
-		// The corrected retry must succeed and match the control signer's
-		// response byte-for-byte: any residue from the failed attempt (e.g. a
-		// partially-applied aggregate) would change the challenge material.
-		let r3_retry = s0
-			.round3_respond(&ssid, core::slice::from_ref(&r1_1), core::slice::from_ref(&r2_1))
-			.expect("corrected retry must succeed after a rejected reveal");
-		let r3_control = c0
-			.round3_respond(&ssid, core::slice::from_ref(&r1_1), core::slice::from_ref(&r2_1))
-			.expect("control signer round 3");
+		// The failed attempt neither advanced nor reset the session: the signer
+		// stays in AfterRound2 and rejects a repeated attempt identically,
+		// proving the aggregate was not partially mutated.
 		assert_eq!(
-			r3_retry, r3_control,
-			"retry after rejected reveal must match a signer that never saw it"
+			s0.state.phase,
+			SigningPhase::AfterRound2,
+			"a rejected reveal must leave the session in a clean AfterRound2 state"
+		);
+		let err_again = s0
+			.round3_respond(&ssid, core::slice::from_ref(&r1_1), core::slice::from_ref(&r2_1))
+			.expect_err("repeated malformed reveal must be rejected identically");
+		assert!(
+			matches!(err_again, ThresholdError::InvalidCommitmentData { party_id: 1, .. }),
+			"expected InvalidCommitmentData for party 1 on retry, got {err_again:?}"
 		);
 	}
 }

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -385,7 +385,17 @@ impl ThresholdSigner {
 		context: &[u8],
 		other_round1: &[Round1Broadcast],
 	) -> ThresholdResult<Round2Broadcast> {
-		// Validate inputs first (before state check to give better errors)
+		// Validate inputs first (before state check to give better errors).
+		//
+		// The ML-DSA message/context bounds must be enforced *before*
+		// `pack_round1_commitment` below: packing allocates and serializes
+		// k_iterations * SINGLE_COMMITMENT_SIZE bytes (~9.4 MB for 4-of-6),
+		// and a request that can never yield a verifiable signature must not
+		// be able to force that work. `process_round2` re-checks these bounds
+		// as defense in depth.
+		crate::error::validate_message(message)?;
+		crate::error::validate_context(context)?;
+
 		// The scheme requires EXACTLY threshold parties (not more, not fewer).
 		// See signing_protocol.rs documentation for details.
 		let total_parties = other_round1.len() + 1; // +1 for ourselves

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -991,9 +991,13 @@ impl DilithiumSignProtocol {
 						// Combination failed (most commonly: ML-DSA rejection sampling
 						// did not produce a valid signature this attempt). Terminate
 						// this instance; the caller will retry with a fresh one.
+						// ProtocolFailed is the documented retry signal (see the module
+						// docs and trust model): callers dispatch fresh-instance retries
+						// on this variant, and every subsequent poke of this dead
+						// instance reports ProtocolFailed already.
 						let msg = format!("Signature combination failed: {}", e);
 						self.state = SignProtocolState::Failed(msg.clone());
-						Err(SignProtocolError::SigningError(msg))
+						Err(SignProtocolError::ProtocolFailed(msg))
 					},
 				}
 			},
@@ -1342,7 +1346,7 @@ fn derive_attempt_nonce(session_seed: &[u8; 32]) -> [u8; 32] {
 /// # Returns
 ///
 /// The produced signature on success. If the underlying ML-DSA rejection sampling
-/// happens to abort on this attempt, returns `Err(SignProtocolError::SigningError)`
+/// happens to abort on this attempt, returns `Err(SignProtocolError::ProtocolFailed)`
 /// — callers should retry with a different `session_seed`.
 pub fn run_local_signing(
 	signers: Vec<ThresholdSigner>,
@@ -2343,6 +2347,43 @@ mod tests {
 		// Subsequent pokes must continue to fail (the instance is dead).
 		let again = protocol.poke();
 		assert!(matches!(again, Err(SignProtocolError::ProtocolFailed(_))));
+	}
+
+	/// Audit regression: the module docs promise that a Round 4 combination
+	/// failure (normal under ML-DSA rejection sampling) ends the instance
+	/// with `SignProtocolError::ProtocolFailed`, the variant callers use to
+	/// dispatch a retry with a fresh instance. Returning any other variant
+	/// makes an integration that implements the documented recovery policy
+	/// treat routine rejection-sampling failures as permanent, and is also
+	/// self-inconsistent: the same dead instance already reports
+	/// `ProtocolFailed` on every subsequent poke.
+	#[test]
+	fn test_combination_failure_returns_protocol_failed() {
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[42u8; 32], config).unwrap();
+
+		let signer = ThresholdSigner::new(shares[0].clone(), pk, config).unwrap();
+		let mut protocol = DilithiumSignProtocol::new(
+			signer,
+			b"test".to_vec(),
+			b"ctx".to_vec(),
+			vec![0, 1],
+			0,
+			[0xAA; 32],
+			[0xBB; 32], // attempt_nonce
+		)
+		.unwrap();
+
+		// Force the protocol into Round4Deciding with empty broadcasts so that
+		// combination cannot succeed.
+		protocol.state = SignProtocolState::Round4Deciding;
+
+		let result = protocol.poke();
+		assert!(
+			matches!(result, Err(SignProtocolError::ProtocolFailed(_))),
+			"combination failure must surface as the documented ProtocolFailed variant \
+			 (the caller's retry signal), got: {result:?}"
+		);
 	}
 
 	#[test]

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -384,14 +384,21 @@ pub enum SignProtocolState {
 ///
 /// # Security
 ///
-/// The buffer uses `BTreeMap` keyed by party_id to:
-/// 1. **Deduplicate**: Only one message per party is stored (later messages ignored)
-/// 2. **Bound memory**: At most MAX_PARTIES entries per round
+/// The buffer enforces its memory bound itself, rather than relying on the
+/// caller to pre-filter senders:
+/// 1. **Membership**: Messages whose `party_id` is not in the session's participant list are
+///    dropped. This is what actually bounds memory — legitimate Round 2/3 payloads are megabytes,
+///    so without it a peer could force unbounded storage by varying `party_id`.
+/// 2. **Deduplicate**: Only one message per party is stored (later messages ignored)
+/// 3. **Bound memory**: At most the participant count (≤ MAX_PARTIES) entries per round
 ///
 /// Round4Complete is buffered separately since only the leader sends it and followers
 /// may receive it before transitioning to `WaitingForLeaderDecision` state.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SignMessageBuffer {
+	/// Participants of this signing session; messages from any other
+	/// party_id are dropped instead of buffered.
+	participants: ParticipantList,
 	/// Buffered Round 2 messages, keyed by party_id.
 	round2: BTreeMap<ParticipantId, Round2Broadcast>,
 	/// Buffered Round 3 messages, keyed by party_id.
@@ -402,20 +409,36 @@ pub struct SignMessageBuffer {
 }
 
 impl SignMessageBuffer {
-	/// Create a new empty message buffer.
-	pub fn new() -> Self {
-		Self { round2: BTreeMap::new(), round3: BTreeMap::new(), round4_complete: None }
+	/// Create a new empty message buffer for a signing session.
+	///
+	/// Only messages from parties in `participants` will be buffered; this is
+	/// what enforces the documented memory bound at the buffer boundary.
+	pub fn new(participants: ParticipantList) -> Self {
+		Self {
+			participants,
+			round2: BTreeMap::new(),
+			round3: BTreeMap::new(),
+			round4_complete: None,
+		}
 	}
 
 	/// Buffer a Round 2 message for later processing.
-	/// Only the first message from each party is stored; duplicates are ignored.
+	/// Messages from parties outside the session's participant list are dropped;
+	/// only the first message from each participant is stored (duplicates ignored).
 	pub fn buffer_round2(&mut self, msg: Round2Broadcast) {
+		if !self.participants.contains(msg.party_id) {
+			return;
+		}
 		self.round2.entry(msg.party_id).or_insert(msg);
 	}
 
 	/// Buffer a Round 3 message for later processing.
-	/// Only the first message from each party is stored; duplicates are ignored.
+	/// Messages from parties outside the session's participant list are dropped;
+	/// only the first message from each participant is stored (duplicates ignored).
 	pub fn buffer_round3(&mut self, msg: Round3Broadcast) {
+		if !self.participants.contains(msg.party_id) {
+			return;
+		}
 		self.round3.entry(msg.party_id).or_insert(msg);
 	}
 
@@ -654,6 +677,7 @@ impl DilithiumSignProtocol {
 		Ok(Self {
 			signer,
 			state: SignProtocolState::Round1Generate,
+			message_buffer: SignMessageBuffer::new(participant_list.clone()),
 			participants: participant_list,
 			my_participant_id,
 			leader_id,
@@ -667,7 +691,6 @@ impl DilithiumSignProtocol {
 			my_r1: None,
 			my_r2: None,
 			my_r3: None,
-			message_buffer: SignMessageBuffer::new(),
 			received_signature: None,
 		})
 	}
@@ -1745,15 +1768,20 @@ mod tests {
 		assert_eq!(protocol.r1_broadcasts.len(), initial_count);
 	}
 
+	/// Participant list used by the standalone buffer tests.
+	fn test_participants() -> ParticipantList {
+		ParticipantList::new(&[0, 1, 2]).unwrap()
+	}
+
 	#[test]
 	fn test_message_buffer_creation() {
-		let buffer = SignMessageBuffer::new();
+		let buffer = SignMessageBuffer::new(test_participants());
 		assert!(buffer.is_empty());
 	}
 
 	#[test]
 	fn test_message_buffer_round2() {
-		let mut buffer = SignMessageBuffer::new();
+		let mut buffer = SignMessageBuffer::new(test_participants());
 		assert!(buffer.is_empty());
 
 		let ssid = [0xCC; SSID_SIZE];
@@ -1770,7 +1798,7 @@ mod tests {
 
 	#[test]
 	fn test_message_buffer_deduplication() {
-		let mut buffer = SignMessageBuffer::new();
+		let mut buffer = SignMessageBuffer::new(test_participants());
 		let ssid = [0xCC; SSID_SIZE];
 
 		// Buffer first message from party 1
@@ -1794,7 +1822,7 @@ mod tests {
 
 	#[test]
 	fn test_message_buffer_round3() {
-		let mut buffer = SignMessageBuffer::new();
+		let mut buffer = SignMessageBuffer::new(test_participants());
 		let ssid = [0xCC; SSID_SIZE];
 
 		let msg = Round3Broadcast::new(ssid, 2, vec![5, 6, 7, 8]);

--- a/threshold/tests/resharing_round5_error_message_dos.rs
+++ b/threshold/tests/resharing_round5_error_message_dos.rs
@@ -6,15 +6,13 @@
 //! default path with an attacker-controlled, unbounded u32 length prefix.
 //! Two consequences, both checked here:
 //!
-//! 1. A ~90-byte truncated broadcast claiming a near-`u32::MAX` length forces
-//!    every recipient to allocate borsh's internal 1 MiB first chunk before
-//!    the truncation is detected — a >10,000x memory amplification per
-//!    message. (borsh 1.6.1 caps the eager allocation at 1 MiB, so the
-//!    original audit's 4 GiB-per-message OOM does not reproduce at this
-//!    version, but the amplification and the missing bound are real.)
-//! 2. A fully-delivered oversized `error_message` (up to 4 GiB) would be
-//!    accepted and retained, unlike every other variable-length resharing
-//!    field, which is explicitly bounded.
+//! 1. A ~90-byte truncated broadcast claiming a near-`u32::MAX` length forces every recipient to
+//!    allocate borsh's internal 1 MiB first chunk before the truncation is detected — a >10,000x
+//!    memory amplification per message. (borsh 1.6.1 caps the eager allocation at 1 MiB, so the
+//!    original audit's 4 GiB-per-message OOM does not reproduce at this version, but the
+//!    amplification and the missing bound are real.)
+//! 2. A fully-delivered oversized `error_message` (up to 4 GiB) would be accepted and retained,
+//!    unlike every other variable-length resharing field, which is explicitly bounded.
 //!
 //! This test lives in its own integration-test binary because it installs a
 //! tracking global allocator; sharing the binary with unrelated tests would

--- a/threshold/tests/resharing_round5_error_message_dos.rs
+++ b/threshold/tests/resharing_round5_error_message_dos.rs
@@ -1,0 +1,145 @@
+//! Audit regression test: `ResharingRound5Broadcast` deserialization must
+//! bound the `error_message: Option<String>` field.
+//!
+//! The custom deserializer bounds `share_commitments` and `partial_pks`
+//! against `MAX_SUBSETS`, but `error_message` was read through borsh's
+//! default path with an attacker-controlled, unbounded u32 length prefix.
+//! Two consequences, both checked here:
+//!
+//! 1. A ~90-byte truncated broadcast claiming a near-`u32::MAX` length forces
+//!    every recipient to allocate borsh's internal 1 MiB first chunk before
+//!    the truncation is detected — a >10,000x memory amplification per
+//!    message. (borsh 1.6.1 caps the eager allocation at 1 MiB, so the
+//!    original audit's 4 GiB-per-message OOM does not reproduce at this
+//!    version, but the amplification and the missing bound are real.)
+//! 2. A fully-delivered oversized `error_message` (up to 4 GiB) would be
+//!    accepted and retained, unlike every other variable-length resharing
+//!    field, which is explicitly bounded.
+//!
+//! This test lives in its own integration-test binary because it installs a
+//! tracking global allocator; sharing the binary with unrelated tests would
+//! add allocation noise from parallel test threads.
+
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use qp_rusty_crystals_threshold::resharing::{
+	ResharingRound5Broadcast, MAX_ERROR_MESSAGE_LEN, RESHARING_SSID_SIZE,
+};
+
+static TRACKING: AtomicBool = AtomicBool::new(false);
+static MAX_ALLOC: AtomicUsize = AtomicUsize::new(0);
+
+/// Wraps the system allocator, recording the largest single allocation made
+/// while `TRACKING` is enabled.
+struct MaxAllocTracker;
+
+unsafe impl GlobalAlloc for MaxAllocTracker {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		if TRACKING.load(Ordering::Relaxed) {
+			MAX_ALLOC.fetch_max(layout.size(), Ordering::Relaxed);
+		}
+		System.alloc(layout)
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		System.dealloc(ptr, layout)
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: MaxAllocTracker = MaxAllocTracker;
+
+/// Run `f` with allocation tracking enabled and return the largest single
+/// allocation observed during the call.
+fn max_alloc_during<T>(f: impl FnOnce() -> T) -> (T, usize) {
+	MAX_ALLOC.store(0, Ordering::Relaxed);
+	TRACKING.store(true, Ordering::Relaxed);
+	let result = f();
+	TRACKING.store(false, Ordering::Relaxed);
+	(result, MAX_ALLOC.load(Ordering::Relaxed))
+}
+
+/// Serialize the fixed prefix of a Round 5 broadcast: ssid, party_id, empty
+/// `share_commitments`, empty `partial_pks`, `success = false`.
+fn round5_prefix() -> Vec<u8> {
+	let mut buf = Vec::new();
+	buf.extend_from_slice(&[0xABu8; RESHARING_SSID_SIZE]);
+	buf.extend_from_slice(&1u32.to_le_bytes()); // party_id
+	buf.extend_from_slice(&0u32.to_le_bytes()); // share_commitments: 0 entries
+	buf.extend_from_slice(&0u32.to_le_bytes()); // partial_pks: 0 entries
+	buf.push(0); // success = false
+	buf
+}
+
+#[test]
+fn round5_error_message_length_is_bounded() {
+	// A tiny broadcast whose error_message length prefix claims ~4 GiB, with
+	// only a few payload bytes actually delivered. Deserialization must
+	// reject the claimed length up front instead of allocating a large
+	// buffer and then discovering the truncation.
+	let mut malicious = round5_prefix();
+	malicious.push(1); // Option::Some flag
+	malicious.extend_from_slice(&u32::MAX.to_le_bytes()); // claimed String length
+	malicious.extend_from_slice(b"tiny"); // actual payload: 4 bytes
+
+	let (result, max_alloc) =
+		max_alloc_during(|| ResharingRound5Broadcast::try_from_slice(&malicious));
+	assert!(result.is_err(), "truncated huge-length broadcast must be rejected");
+	assert!(
+		max_alloc < 64 * 1024,
+		"a ~90-byte broadcast claiming a 4 GiB error_message forced a {max_alloc}-byte \
+		 allocation before the length was rejected"
+	);
+
+	// A fully-delivered error_message one byte over the bound must also be
+	// rejected: the serializer is unbounded, so build the bytes directly.
+	let oversized = ResharingRound5Broadcast {
+		ssid: [0xABu8; RESHARING_SSID_SIZE],
+		party_id: 1,
+		share_commitments: Default::default(),
+		partial_pks: Default::default(),
+		success: false,
+		error_message: Some("x".repeat(MAX_ERROR_MESSAGE_LEN + 1)),
+	};
+	let mut bytes = Vec::new();
+	oversized.serialize(&mut bytes).unwrap();
+	assert!(
+		ResharingRound5Broadcast::try_from_slice(&bytes).is_err(),
+		"error_message longer than MAX_ERROR_MESSAGE_LEN must be rejected"
+	);
+
+	// A legitimate failure broadcast with a short message still round-trips.
+	let legit = ResharingRound5Broadcast {
+		ssid: [0xABu8; RESHARING_SSID_SIZE],
+		party_id: 1,
+		share_commitments: Default::default(),
+		partial_pks: Default::default(),
+		success: false,
+		error_message: Some("Share verification failed".to_string()),
+	};
+	let mut bytes = Vec::new();
+	legit.serialize(&mut bytes).unwrap();
+	let decoded = ResharingRound5Broadcast::try_from_slice(&bytes)
+		.expect("legitimate error_message must round-trip");
+	assert_eq!(decoded.error_message.as_deref(), Some("Share verification failed"));
+	assert!(!decoded.success);
+
+	// And a success broadcast with no message still round-trips.
+	let none = ResharingRound5Broadcast {
+		ssid: [0xABu8; RESHARING_SSID_SIZE],
+		party_id: 2,
+		share_commitments: Default::default(),
+		partial_pks: Default::default(),
+		success: true,
+		error_message: None,
+	};
+	let mut bytes = Vec::new();
+	none.serialize(&mut bytes).unwrap();
+	let decoded = ResharingRound5Broadcast::try_from_slice(&bytes)
+		.expect("None error_message must round-trip");
+	assert_eq!(decoded.error_message, None);
+}

--- a/threshold/tests/round2_input_validation_dos.rs
+++ b/threshold/tests/round2_input_validation_dos.rs
@@ -90,8 +90,7 @@ fn round2_reveal_rejects_bad_inputs_before_commitment_packing() {
 	);
 
 	// Same for an oversized message.
-	let oversized_message =
-		vec![0u8; qp_rusty_crystals_dilithium::ml_dsa_87::MAX_MESSAGE_SIZE + 1];
+	let oversized_message = vec![0u8; qp_rusty_crystals_dilithium::ml_dsa_87::MAX_MESSAGE_SIZE + 1];
 	let (result, max_alloc) =
 		max_alloc_during(|| s0.round2_reveal(&ssid, &oversized_message, b"", others));
 	assert!(

--- a/threshold/tests/round2_input_validation_dos.rs
+++ b/threshold/tests/round2_input_validation_dos.rs
@@ -1,0 +1,112 @@
+//! Audit regression test: `round2_reveal` must validate the caller-controlled
+//! message and context bounds *before* packing Round 1 commitment data.
+//!
+//! Packing allocates and serializes `k_iterations * SINGLE_COMMITMENT_SIZE`
+//! bytes (about 9.4 MB for the 4-of-6 configuration). If the ML-DSA size
+//! bounds are only enforced afterwards (inside `process_round2`), an attacker
+//! can force that CPU and memory cost with a guaranteed-to-fail request, e.g.
+//! a 256-byte context. This test observes the wasted work directly: it tracks
+//! the largest single heap allocation made during the failing call and
+//! requires it to stay below one packed commitment (5888 bytes).
+//!
+//! This test lives in its own integration-test binary because it installs a
+//! tracking global allocator; sharing the binary with unrelated tests would
+//! add allocation noise from parallel test threads.
+
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use qp_rusty_crystals_threshold::{
+	generate_with_dealer, ThresholdConfig, ThresholdError, ThresholdSigner,
+};
+
+/// Packed size of one commitment: K (8) polynomials of 736 bytes each.
+/// Round 2 packing allocates `k_iterations` of these in a single buffer
+/// (29,440 bytes for the 2-of-3 configuration used here).
+const SINGLE_COMMITMENT_SIZE: usize = 8 * 736;
+
+static TRACKING: AtomicBool = AtomicBool::new(false);
+static MAX_ALLOC: AtomicUsize = AtomicUsize::new(0);
+
+/// Wraps the system allocator, recording the largest single allocation made
+/// while `TRACKING` is enabled.
+struct MaxAllocTracker;
+
+unsafe impl GlobalAlloc for MaxAllocTracker {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		if TRACKING.load(Ordering::Relaxed) {
+			MAX_ALLOC.fetch_max(layout.size(), Ordering::Relaxed);
+		}
+		System.alloc(layout)
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		System.dealloc(ptr, layout)
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: MaxAllocTracker = MaxAllocTracker;
+
+/// Run `f` with allocation tracking enabled and return the largest single
+/// allocation observed during the call.
+fn max_alloc_during<T>(f: impl FnOnce() -> T) -> (T, usize) {
+	MAX_ALLOC.store(0, Ordering::Relaxed);
+	TRACKING.store(true, Ordering::Relaxed);
+	let result = f();
+	TRACKING.store(false, Ordering::Relaxed);
+	(result, MAX_ALLOC.load(Ordering::Relaxed))
+}
+
+#[test]
+fn round2_reveal_rejects_bad_inputs_before_commitment_packing() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let (public_key, shares) = generate_with_dealer(&[3u8; 32], config).expect("keygen");
+
+	let mut s0 = ThresholdSigner::new(shares[0].clone(), public_key.clone(), config).unwrap();
+	let mut s1 = ThresholdSigner::new(shares[1].clone(), public_key.clone(), config).unwrap();
+
+	let ssid = [0xA5u8; 32];
+	let _r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+	let r1_1 = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
+	let others = core::slice::from_ref(&r1_1);
+
+	// A context one byte over the 255-byte ML-DSA limit must be rejected
+	// before the k * SINGLE_COMMITMENT_SIZE packing buffer is allocated.
+	let oversized_context = vec![0u8; 256];
+	let (result, max_alloc) =
+		max_alloc_during(|| s0.round2_reveal(&ssid, b"message", &oversized_context, others));
+	assert!(
+		matches!(result, Err(ThresholdError::ContextTooLong { length: 256 })),
+		"expected ContextTooLong, got {result:?}"
+	);
+	assert!(
+		max_alloc < SINGLE_COMMITMENT_SIZE,
+		"oversized context still triggered commitment packing: \
+		 largest allocation during the rejected call was {max_alloc} bytes \
+		 (>= one packed commitment of {SINGLE_COMMITMENT_SIZE} bytes)"
+	);
+
+	// Same for an oversized message.
+	let oversized_message =
+		vec![0u8; qp_rusty_crystals_dilithium::ml_dsa_87::MAX_MESSAGE_SIZE + 1];
+	let (result, max_alloc) =
+		max_alloc_during(|| s0.round2_reveal(&ssid, &oversized_message, b"", others));
+	assert!(
+		matches!(result, Err(ThresholdError::MessageTooLong { .. })),
+		"expected MessageTooLong, got {result:?}"
+	);
+	assert!(
+		max_alloc < SINGLE_COMMITMENT_SIZE,
+		"oversized message still triggered commitment packing: \
+		 largest allocation during the rejected call was {max_alloc} bytes \
+		 (>= one packed commitment of {SINGLE_COMMITMENT_SIZE} bytes)"
+	);
+
+	// The rejected attempts must not have consumed the session: a well-formed
+	// request still succeeds.
+	s0.round2_reveal(&ssid, b"message", b"context", others)
+		.expect("valid inputs must still be accepted after rejected attempts");
+}

--- a/threshold/tests/sign_message_buffer_bounds.rs
+++ b/threshold/tests/sign_message_buffer_bounds.rs
@@ -1,0 +1,54 @@
+//! Audit regression test: the public `SignMessageBuffer` must enforce the
+//! memory bound its documentation advertises.
+//!
+//! The type's docs promise "at most MAX_PARTIES entries per round", but that
+//! invariant was only enforced upstream by `DilithiumSignProtocol::message`
+//! (which filters non-participants before buffering). The standalone public
+//! API accepted any caller-supplied `party_id`, so a consumer using the
+//! buffer directly for out-of-order network buffering could be driven to
+//! store an unbounded number of entries — each potentially megabytes, since
+//! legitimate Round 2/3 payloads are that large — by varying `party_id`.
+
+use qp_rusty_crystals_threshold::{
+	broadcast::{Round2Broadcast, Round3Broadcast, SSID_SIZE},
+	signing_protocol::SignMessageBuffer,
+	ParticipantList,
+};
+
+/// The protocol-wide maximum party count (MAX_PARTIES in `error.rs`).
+const MAX_PARTIES: usize = 6;
+
+#[test]
+fn sign_message_buffer_bounds_entries_to_participants() {
+	let ssid = [0xB7u8; SSID_SIZE];
+	let participants = ParticipantList::new(&[0, 1, 2]).unwrap();
+	let mut buffer = SignMessageBuffer::new(participants);
+
+	// A remote peer varies party_id across 1000 broadcasts. A real Round 2
+	// payload can be ~9.4 MB; a small stand-in keeps the test fast without
+	// changing the counting behavior.
+	let payload = vec![0xEEu8; 4096];
+	for party_id in 0..1000u32 {
+		buffer.buffer_round2(Round2Broadcast::new(ssid, party_id, payload.clone()));
+		buffer.buffer_round3(Round3Broadcast::new(ssid, party_id, payload.clone()));
+	}
+
+	let round2 = buffer.take_round2();
+	let round3 = buffer.take_round3();
+	assert!(
+		round2.len() <= MAX_PARTIES,
+		"documented bound violated: {} Round 2 entries buffered (max {MAX_PARTIES})",
+		round2.len()
+	);
+	assert!(
+		round3.len() <= MAX_PARTIES,
+		"documented bound violated: {} Round 3 entries buffered (max {MAX_PARTIES})",
+		round3.len()
+	);
+
+	// Messages from actual session participants are retained, non-members dropped.
+	let round2_ids: Vec<u32> = round2.iter().map(|m| m.party_id).collect();
+	assert_eq!(round2_ids, vec![0, 1, 2], "participant messages must be kept");
+	let round3_ids: Vec<u32> = round3.iter().map(|m| m.party_id).collect();
+	assert_eq!(round3_ids, vec![0, 1, 2], "participant messages must be kept");
+}


### PR DESCRIPTION
This PR addresses a batch of security-audit review items across the `dilithium` and `threshold` crates. Every fix follows the same discipline: the issue was first reproduced with a failing regression test, then fixed, and the test now passes. All fixes ship with their regression tests.

## Fixes

### Key material and share validation

- **Keypair seed preimage built in a fixed buffer** (`dilithium`): the keygen seed preimage is assembled in a fixed-size stack buffer instead of a heap allocation, so no copy of the seed material is left behind for the allocator to recycle un-zeroized.
- **All-zero `t1` rejected on every key-import path** (`dilithium`/`threshold`): the all-zero public-key rejection is now enforced consistently across every import path, not just some of them.
- **Share coefficient ranges validated at deserialization** (`threshold`): private key shares deserialized from untrusted bytes now have their coefficient ranges checked up front, rejecting corrupt or malicious share data at the trust boundary.
- **Resharing old committee must match the share's DKG list** (`threshold`): the resharing protocol rejects an old-committee list that does not match the participant set recorded in the share at DKG time.

### Protocol correctness

- **Round 3 reveals bound to the Round 1 hashes seen in Round 2** (`threshold`): `round3_respond` verifies reveals against the commitment hashes frozen at Round 2 reveal time rather than a caller-supplied Round 1 set, preserving the commit-reveal anti-rushing property. A rushing peer can no longer substitute a Round 1 hash chosen after observing honest reveals.
- **Round 4 combination failure returns `ProtocolFailed`** (`threshold`): the leader's combination-failure branch returned `SigningError` while the module docs (and the `Failed`-state behavior of the same instance) promise `ProtocolFailed` — the variant integrations use to dispatch fresh-instance retries. Normal ML-DSA rejection-sampling failures are no longer misreported as permanent signing errors.

### Denial-of-service hardening

- **Message/context validated before Round 2 commitment packing** (`threshold`): `round2_reveal` now enforces the ML-DSA message and context bounds *before* packing `k_iterations × 5888` bytes of commitment data (~9.4 MB for 4-of-6). Previously a guaranteed-to-fail request (e.g. a 256-byte context) still forced the full allocation and serialization. Verified by a regression test using a tracking allocator.
- **Resharing Round 5 `error_message` bounded during deserialization** (`threshold`): the one variable-length resharing field without a length bound. A ~90-byte broadcast claiming a near-`u32::MAX` string length forced a 1 MiB allocation on every recipient (borsh 1.6.1 caps the eager allocation there — the audit's 4 GiB figure does not reproduce at this version), and a fully-delivered payload of up to 4 GiB would have been accepted and retained. Now bounded by `MAX_ERROR_MESSAGE_LEN` (1 KiB) using the same chunked-read path as every other variable-length field, with UTF-8 validation.
- **`SignMessageBuffer` enforces its own participant bound** (`threshold`, breaking): the public out-of-order message buffer documented "at most MAX_PARTIES entries per round" but accepted arbitrary `party_id`s, making it an unbounded storage sink for megabyte-scale payloads when used directly. `SignMessageBuffer::new` now takes the session's `ParticipantList` and drops messages from non-participants; the `Default` impl is removed.

### API contract enforcement (breaking)

- **XOF block-squeeze made type-safe** (`dilithium`, breaking): `shake128_squeezeblocks`/`shake256_squeezeblocks` previously took `(&mut [u8], nblocks)` and silently underfilled a short slice (`chunks_exact_mut(r).take(nblocks)`), leaving stale bytes the caller would treat as XOF output and desynchronizing the Keccak state. The functions now take whole blocks (`&mut [[u8; RATE]]`), so a count/capacity mismatch is unrepresentable. All samplers were migrated; the `off` carry-over logic inherited from the C reference in `poly::uniform` was removed as dead code (SHAKE128's rate is divisible by 3, so it never fired). NIST ACVP known-answer tests confirm byte-identical output.
- **`unpack_polyveck_w` validates buffer length** (`threshold`): an undersized buffer is now a recoverable `Err` instead of an out-of-bounds slice panic (which would abort the process in `panic=abort` deployments).

## Breaking changes

- `qp-rusty-crystals-dilithium`: `shake128_squeezeblocks` / `shake256_squeezeblocks` signatures changed from `(out: &mut [u8], nblocks: usize, state)` to `(out: &mut [[u8; RATE]], state)`. Requires a version bump on next publish.
- `qp-rusty-crystals-threshold`: `SignMessageBuffer::new()` now requires the session `ParticipantList`; `Default` removed.

## Test plan

- [x] Each fix has a dedicated regression test that failed before the fix and passes after (allocation-tracking tests for the two DoS items; equivalence and boundary tests elsewhere)
- [x] Full workspace suite green in release mode: 572 tests, 0 failures
- [x] Dilithium NIST ACVP known-answer vectors pass (confirms the XOF/sampler refactor is byte-identical)
- [x] `no_std` compatibility preserved (no new `std` dependencies outside test code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches cryptographic key handling, XOF output correctness, threshold commit-reveal security, and multiple untrusted deserialization boundaries; breaking public API changes require coordinated version bumps.
> 
> **Overview**
> This PR batches **security-audit** fixes in `dilithium` and `threshold`, each paired with a regression test.
> 
> **Dilithium:** `keypair` now builds the SHAKE preimage in a **fixed stack buffer** instead of a `Vec` that could free an uncleared seed copy. **SHAKE block squeeze** APIs take `&mut [[u8; RATE]]` so slice length vs. block count cannot silently desync Keccak state; samplers were updated. **`public_key_from_secret`** and standalone **`SecretKey::from_bytes`** now reject secret keys whose derived public key has **all-zero `t1`**, aligned with verifier/`PublicKey::from_bytes`.
> 
> **Threshold signing:** Round 1 commitment hashes are **frozen at Round 2 reveal**; Round 3 checks reveals against that map (not caller-supplied Round 1), blocking post-hoc commitment substitution. **`round2_reveal`** validates message/context **before** large commitment packing. Round 4 combination failures return **`ProtocolFailed`** for documented retries. **`SignMessageBuffer`** only buffers messages from the session **`ParticipantList`** (breaking: `new(participants)`, no `Default`).
> 
> **Import / protocol hardening:** Threshold **`PublicKey`** paths call canonical ML-DSA parse (forgeable zero-`t1` rejected). **`SecretShareData`** Borsh deserialize checks coefficients in `(-Q, Q)`. Resharing config requires **old committee == share’s embedded DKG list**. Round 5 **`error_message`** bounded at deserialize; **`unpack_polyveck_w`** returns `Err` on short buffers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b54db0ebd51f4cfd20fbfe089ca70bcddf0dab0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->