### PR TITLE
ci: Automate hdwallet version bump to hdwallet-v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "2.4.0"
+version = "3.0.0"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "=3.0.0", default-features = false }
-qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "=2.4.0", default-features = false }
+qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "3.0.0", default-features = false }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=1.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-hdwallet"
-version = "2.4.0"
+version = "3.0.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of HD wallet functionality with post-quantum cryptography"


### PR DESCRIPTION
Automated hdwallet version bump for release hdwallet-v3.0.0.

Triggered by workflow run: https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/29630115591

Type: major

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release bump with no functional code changes; consumers must pin the new major version explicitly.
> 
> **Overview**
> **Automated major release** for `qp-rusty-crystals-hdwallet`: version **2.4.0 → 3.0.0** in `hdwallet/Cargo.toml`, the workspace dependency in root `Cargo.toml`, and `Cargo.lock`.
> 
> No library source or API changes in this diff—only crate metadata and lockfile alignment for tag `hdwallet-v3.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef8f587a3539c32435b85c126c3ccd70a6e22486. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->