### PR TITLE
ci: Automate threshold version bump to threshold-v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "qp-rusty-crystals-threshold"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "borsh",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "=3.0.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "=2.4.0", default-features = false }
-qp-rusty-crystals-threshold = { path = "./threshold", version = "=1.0.0", default-features = false }
+qp-rusty-crystals-threshold = { path = "./threshold", version = "1.1.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }
 rusty-crystals-integration-tests = { path = "./tests" }

--- a/threshold/Cargo.toml
+++ b/threshold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-threshold"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Quantus Network"]
 license = "GPL-3.0"


### PR DESCRIPTION
Automated threshold version bump for release threshold-v1.1.0.

Triggered by workflow run: https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/29630209736

Type: minor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no cryptographic or behavioral code modifications.
> 
> **Overview**
> **Automated minor release** for `qp-rusty-crystals-threshold`, aligning the crate and workspace to **1.1.0** (from 1.0.0) for tag `threshold-v1.1.0`.
> 
> Updates `threshold/Cargo.toml` package version, the workspace `qp-rusty-crystals-threshold` dependency in root `Cargo.toml`, and the corresponding entry in `Cargo.lock`. No library or API source changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fafd8f26a43744f6a8d079db07089710479d8c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->