### PR TITLE
Illuzen/bump serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "3.0.1"
+version = "3.0.0"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "=3.0.0", default-features = false }
-qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "3.0.0", default-features = false }
+qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "=3.0.1", default-features = false }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=1.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }
 rusty-crystals-integration-tests = { path = "./tests" }
 serde = { version = "=1.0.228", default-features = false, features = ["alloc", "derive"] }
-serde_json = { version = "=1.0.149", default-features = false, features = ["alloc"] }
+serde_json = { version = "=1.0.150", default-features = false, features = ["alloc"] }
 thiserror = { version = "=2.0.18", default-features = false }
 unicode-normalization = { version = "=0.1.25", default-features = false }
 zeroize = { version = "=1.8.2", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "=3.0.0", default-features = false }
-qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "=3.0.1", default-features = false }
+qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "3.0.0", default-features = false }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=1.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-hdwallet"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of HD wallet functionality with post-quantum cryptography"

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-hdwallet"
-version = "3.0.1"
+version = "3.0.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of HD wallet functionality with post-quantum cryptography"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with no application code changes; typical low-risk maintenance.
> 
> **Overview**
> Bumps the workspace **`serde_json`** pin from **1.0.149** to **1.0.150** in the root `Cargo.toml` and refreshes **`Cargo.lock`** (updated crate checksum).
> 
> The lockfile also records **`qp-rusty-crystals-hdwallet`** as **3.0.1**; the workspace manifest still references hdwallet **3.0.0**, so that entry may be incidental lockfile drift from resolving dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9af7afb332595f3cb02fc01f9dfcb5c3f66a800. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->