### PR TITLE
ci: Automate dilithium version bump to dilithium-v3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ checksum = "55e32db7b3a5d70086f82f198ecfc021f17cb7ec70a416512dba3488f4a116c1"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ hex-literal = { version = "=0.4.1", default-features = false }
 libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
-qp-rusty-crystals-dilithium = { path = "./dilithium", version = "=3.0.0", default-features = false }
+qp-rusty-crystals-dilithium = { path = "./dilithium", version = "3.0.1", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "3.0.0", default-features = false }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=1.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-dilithium"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of CRYSTALS-Dilithium digital signature scheme"


### PR DESCRIPTION
Automated dilithium version bump for release dilithium-v3.0.1.

https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/29721182455

Triggered by workflow run: patch

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile metadata only; no cryptographic or behavioral code changes in this PR.
> 
> **Overview**
> **Automated dilithium patch release (`dilithium-v3.0.1`)** — no library or API source changes in the diff.
> 
> The `qp-rusty-crystals-dilithium` package version moves **3.0.0 → 3.0.1** in `dilithium/Cargo.toml`. The workspace pins that crate at **3.0.1** in the root `Cargo.toml` (the dependency version constraint is updated from `=3.0.0` to `3.0.1`). **`Cargo.lock`** is refreshed so the locked `qp-rusty-crystals-dilithium` entry matches **3.0.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08597e27dc8336e726b49caaac00182bfbc0cb21. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->