### PR TITLE
Security review round 4: secret hygiene, bounded deserialization, and protocol atomicity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,23 @@ jobs:
         run: cargo build --workspace --locked
       - name: Test workspace
         run: cargo test --workspace --locked
+      # The stack-zeroization guard is gated to optimized builds
+      # (#![cfg(not(debug_assertions))]): debug codegen materializes compiler
+      # temporaries of the secret key that no source-level fix can wipe, so the
+      # debug `cargo test` above compiles this file to zero tests. The property
+      # it guards is entirely a function of codegen, making it the test most
+      # likely to silently regress on a toolchain bump — run it in release, and
+      # fail if zero tests ran so a gating/rename change can't turn the guard
+      # back into documentation.
+      - name: Optimized-build regression tests (stack zeroization)
+        run: |
+          set -o pipefail
+          cargo test --release --locked -p qp-rusty-crystals-dilithium \
+            --test import_stack_zeroization 2>&1 | tee stack-zeroization.log
+          grep -Eq "test result: ok\. [1-9][0-9]* passed" stack-zeroization.log || {
+            echo "::error::stack-zeroization tests were filtered out (0 tests ran)"
+            exit 1
+          }
 
   no-std-build:
     name: 📦 no_std Build (wasm32v1-none)

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -11,7 +11,9 @@ This PR addresses the fourth round of security review findings across the `dilit
 - DKG K_S relocation out of Copy-typed containers: `transition_to_round2` freed the `received_shared_secrets` map nodes with the secrets still in them (the state zeroizer runs too late — the field is already `None`), `pending_privates.pop()` left queued `Round1Private` bytes beyond the `Vec`'s shrunken length, and the buffered-privates drain consumed its map the same way (`4e6cb6d`);
 - the wormhole Poseidon preimage (`preimage_felts`) was `clear()`ed but never wiped; covered by a dedicated allocator-instrumented test in `hdwallet/tests/wormhole_zeroization.rs` (`7d63cf9`).
 
-**Stack copies of the ML-DSA-87 secret key are wiped in import/serialize paths.** `Keypair::from_bytes`, `SecretKey::from_bytes`, and `Keypair::to_bytes` left plaintext `[u8; SECRETKEYBYTES]` copies in dead stack frames because `[u8; N]` is `Copy`. All three now stage the secret in `Zeroizing` locals. A painted-stack probe test (`dilithium/tests/import_stack_zeroization.rs`, release-mode only — debug builds create compiler temporaries no source fix can wipe) verifies no copy survives (`2197133`).
+**Stack copies of the ML-DSA-87 secret key are wiped in import/serialize paths.** `Keypair::from_bytes`, `SecretKey::from_bytes`, and `Keypair::to_bytes` left plaintext `[u8; SECRETKEYBYTES]` copies in dead stack frames because `[u8; N]` is `Copy`. All three now stage the secret in `Zeroizing` locals, and the secret-bearing `to_bytes` methods return `Zeroizing<[u8; N]>` so the caller's copy self-wipes too (semver-breaking; a caller who simply drops the result leaks nothing). A painted-stack probe test (`dilithium/tests/import_stack_zeroization.rs`, release-mode only — debug builds create compiler temporaries no source fix can wipe) verifies no copy survives, and CI runs it in release mode with a zero-tests-ran guard.
+
+Known residual: the DKG private-send path (`pop_pending_private` → `poke` → `serialize_round1_private`) moves a `Round1Private` by value, and intermediate move temporaries holding K_S in dead stack frames are compiler-managed — the same class the dilithium probe pins. Heap copies on that path are covered; the stack side is noted in the code as follow-up.
 
 **Debug output no longer leaks key material.** The resharing `Action::SendPrivate` payload (serialized sub-shares) is redacted from the manual `Debug` impl (`df8dee3`).
 
@@ -32,7 +34,7 @@ This PR addresses the fourth round of security review findings across the `dilit
 ## Protocol state-machine correctness
 
 - Aborted resharing sessions no longer strand the old share: recovery restores it so the party can rejoin a retried session (`5e5c7ef`).
-- `round3_respond` failures **after** the peers' reveals were folded into the commitment aggregate (e.g. `recover_share` rejecting an active party outside the DKG set — only detectable at that point) now reset the session instead of leaving a poisoned aggregate in the "cleanly retryable" `AfterRound2` state, where a retry would double-count every peer's commitment. Pre-commit-point failures still leave the session clean for corrected retries (`243bb0d`).
+- `round3_respond` failures **after** the peers' reveals were folded into the commitment aggregate now reset the session instead of leaving a poisoned aggregate in the "cleanly retryable" `AfterRound2` state, where a retry would double-count every peer's commitment. Pre-commit-point failures still leave the session clean for corrected retries (`243bb0d`). The trigger for the reset — a Round 1 broadcast from a party outside the DKG participant set, previously only detected inside `recover_share` — is now rejected by `round2_reveal` before the commit point, so the failure is early and recoverable and the round-3 reset is defense in depth.
 - `DerivedKeyId` is bound to the DKG output public key, preventing cross-key derivation-ID collisions (`5599c69`).
 
 ## API contract enforcement
@@ -46,8 +48,8 @@ This PR addresses the fourth round of security review findings across the `dilit
 Behavioral tightenings downstream consumers may notice:
 
 - `hdwallet`: seeds outside 16..=64 bytes are now rejected by `ExtendedPrivKey::derive` (new `Error::InvalidSeedLength` variant). The Quantus SDK's `derive_hd_path` passes 64-byte BIP39 seeds and is unaffected.
-- `threshold`: resharing `Action::SendPrivate` now carries `Zeroizing<Vec<u8>>`; `DkgConfig` fields are private (use the accessors); `SubsetContribution` and secret-key/share imports reject blobs that previously deserialized.
-- `dilithium`: `packing::unpack_sk` returns a `bool` canonicality flag; `poly::shiftl` is crate-private.
+- `threshold`: resharing `Action::SendPrivate` now carries `Zeroizing<Vec<u8>>`; `DkgConfig` fields are private (use the accessors); `SubsetContribution` and secret-key/share imports reject blobs that previously deserialized; `ThresholdSigner::round2_reveal` rejects Round 1 broadcasts from parties outside the DKG set (previously deferred to Round 3); `ResharingProtocol::take_existing_share` is renamed `abort_and_take_existing_share` (the name now carries its abort side effect); `all_broadcasts_received` is no longer exported.
+- `dilithium`: `packing::unpack_sk` returns a `bool` canonicality flag; `poly::shiftl` is crate-private; `Keypair::to_bytes` and `SecretKey::to_bytes` return `Zeroizing` buffers (deref or `as_slice()` for access).
 
 ## Test plan
 

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,57 @@
+# Security review round 4: secret hygiene, bounded deserialization, and protocol atomicity
+
+This PR addresses the fourth round of security review findings across the `dilithium`, `hdwallet`, and `threshold` crates. Every fix follows the same discipline: the finding was first reproduced with a failing regression test, then fixed, then re-verified (test red on the old code, green with the fix). 19 commits, 28 files, ~2600 insertions.
+
+## Secret hygiene (zeroization)
+
+**Heap intermediates are wiped before their memory is freed.** A new `threshold/tests/heap_zeroization.rs` suite installs a scanning global allocator that inspects every freed block for the scenario's secret pattern at `dealloc` time. It caught, and now guards, six scenarios:
+
+- `derive_dkg_contribution`'s share-digest linearization buffer, incoming DKG Round 1 private frames carrying K_S, and the hyperball sampling scratch buffer (`7d63cf9`);
+- the resharing protocol's `party_key` derivation buffer, Round 4 transport frames (both directions — `Action::SendPrivate` now carries `Zeroizing<Vec<u8>>`), sub-share derivation output, and per-polynomial hashing scratch buffers (`ce8175f`);
+- DKG K_S relocation out of Copy-typed containers: `transition_to_round2` freed the `received_shared_secrets` map nodes with the secrets still in them (the state zeroizer runs too late — the field is already `None`), `pending_privates.pop()` left queued `Round1Private` bytes beyond the `Vec`'s shrunken length, and the buffered-privates drain consumed its map the same way (`4e6cb6d`);
+- the wormhole Poseidon preimage (`preimage_felts`) was `clear()`ed but never wiped; covered by a dedicated allocator-instrumented test in `hdwallet/tests/wormhole_zeroization.rs` (`7d63cf9`).
+
+**Stack copies of the ML-DSA-87 secret key are wiped in import/serialize paths.** `Keypair::from_bytes`, `SecretKey::from_bytes`, and `Keypair::to_bytes` left plaintext `[u8; SECRETKEYBYTES]` copies in dead stack frames because `[u8; N]` is `Copy`. All three now stage the secret in `Zeroizing` locals. A painted-stack probe test (`dilithium/tests/import_stack_zeroization.rs`, release-mode only — debug builds create compiler temporaries no source fix can wipe) verifies no copy survives (`2197133`).
+
+**Debug output no longer leaks key material.** The resharing `Action::SendPrivate` payload (serialized sub-shares) is redacted from the manual `Debug` impl (`df8dee3`).
+
+## Bounded, validating deserialization
+
+- `ResharingActProposal::active_set` length is bounded at deserialize; a hostile length prefix can no longer drive unbounded allocation (`62f736e`).
+- `PrivateKeyShare` metadata (threshold, party counts, participant list, share-map shape) is cross-checked at Borsh import and at `ThresholdSigner` construction (`345c7aa`).
+- ML-DSA-87 secret keys whose `s1`/`s2` coefficients decode outside `[-ETA, ETA]` are rejected at import: `eta_unpack` and `unpack_sk` now return a canonicality flag (`#[must_use]`) that `public_key_from_secret` enforces, so non-canonical 3-bit slots (5–7) can no longer cross the boundary (`19e2bf0`).
+- `SubsetContribution` (exported, previously derive-deserialized into unbounded `Vec<[i32; N]>`) now has a manual deserializer enforcing exactly `L`/`K` polynomials — length prefix checked before any allocation — and η-bounded coefficients, mirroring `SecretShareData` (`3ec5b15`).
+- Invalid `DkgConfig` values are unconstructible: fields are private with accessors, and `all_broadcasts_received` uses total quorum arithmetic that cannot underflow on an empty participant list (`e1df0ca`). The predicate is now `pub(crate)` (no longer re-exported): its empty-list-is-complete reading is only sound for config-validated participant lists, so raw external inputs can no longer reach it — pinned by a `compile_fail` doctest on `DkgConfig`.
+
+## DoS hardening (no work before validation)
+
+- The signing protocol checks the fixed-header SSID and a **per-config** frame budget (`k_iterations`-derived, ~23 KB for a (2,2) session instead of the global 12 MiB) before deserializing anything (`0428526`).
+- `ExtendedPrivKey::derive` parses and validates the derivation path first and bounds the seed to the BIP32 master-seed range (16..=64 bytes, new `Error::InvalidSeedLength`) before doing any HMAC work (`bf9b646`).
+- Round 2 reveals are rejected on the exact per-config length **before** the SHAKE256 commitment hash runs, so a peer who pre-committed to an oversized blob (up to the 10.5 MB global deserializer bound) cannot force megabytes of hashing in a session whose legitimate reveal is kilobytes; protocol intake drops hash-bound but mis-sized reveals in O(1) (`36e1079`).
+
+## Protocol state-machine correctness
+
+- Aborted resharing sessions no longer strand the old share: recovery restores it so the party can rejoin a retried session (`5e5c7ef`).
+- `round3_respond` failures **after** the peers' reveals were folded into the commitment aggregate (e.g. `recover_share` rejecting an active party outside the DKG set — only detectable at that point) now reset the session instead of leaving a poisoned aggregate in the "cleanly retryable" `AfterRound2` state, where a retry would double-count every peer's commitment. Pre-commit-point failures still leave the session clean for corrected retries (`243bb0d`).
+- `DerivedKeyId` is bound to the DKG output public key, preventing cross-key derivation-ID collisions (`5599c69`).
+
+## API contract enforcement
+
+- `poly::shiftl`'s unchecked left shift is no longer reachable through public API with out-of-contract coefficients: it is crate-private and the `k_shiftl` docs state the real `2^(31-D)` bound (`6fe967c`).
+- `KeccakState` encodes the SHAKE rate as a const-generic parameter, making the absorb/squeeze phase-and-rate mismatches flagged by review unrepresentable, and squeeze chunking canonical (`225e629`).
+- `uniform_eta`'s rejection-sampling retry loop is documented as not a timing channel: two fixed blocks yield 544 nibbles at 15/16 acceptance, so a third block is a < 2^-600 event, and rejection counts are independent of the accepted values under standard XOF assumptions (`ec388fe`).
+
+## Compatibility notes
+
+Behavioral tightenings downstream consumers may notice:
+
+- `hdwallet`: seeds outside 16..=64 bytes are now rejected by `ExtendedPrivKey::derive` (new `Error::InvalidSeedLength` variant). The Quantus SDK's `derive_hd_path` passes 64-byte BIP39 seeds and is unaffected.
+- `threshold`: resharing `Action::SendPrivate` now carries `Zeroizing<Vec<u8>>`; `DkgConfig` fields are private (use the accessors); `SubsetContribution` and secret-key/share imports reject blobs that previously deserialized.
+- `dilithium`: `packing::unpack_sk` returns a `bool` canonicality flag; `poly::shiftl` is crate-private.
+
+## Test plan
+
+- [x] Each finding reproduced red before the fix and green after (error-variant or allocator/stack-probe assertions pin the mechanism, not just the outcome)
+- [x] `cargo test --workspace` green (dilithium, hdwallet, threshold; unit + integration + e2e suites)
+- [x] New regression suites: `threshold/tests/heap_zeroization.rs` (scanning allocator, 6 scenarios), `dilithium/tests/import_stack_zeroization.rs` (painted-stack probe, release builds), `hdwallet/tests/wormhole_zeroization.rs`
+- [x] Release-mode runs for the stack-zeroization suite

--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -208,7 +208,7 @@ fn sign_sk_expansion(runner: &mut CtRunner, rng: &mut BenchRng) {
 			let mut t0 = Polyveck::default();
 			let mut s1 = Polyvecl::default();
 			let mut s2 = Polyveck::default();
-			packing::unpack_sk(
+			let canonical = packing::unpack_sk(
 				&mut rho,
 				&mut tr,
 				&mut key,
@@ -217,6 +217,7 @@ fn sign_sk_expansion(runner: &mut CtRunner, rng: &mut BenchRng) {
 				&mut s2,
 				black_box(&sk),
 			);
+			black_box(canonical);
 			polyvec::l_ntt(&mut s1);
 			polyvec::k_ntt(&mut s2);
 			polyvec::k_ntt(&mut t0);

--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -189,7 +189,8 @@ fn sign_sk_expansion(runner: &mut CtRunner, rng: &mut BenchRng) {
 		let mut entropy = [0u8; 32];
 		rng.fill_bytes(&mut entropy);
 		let keypair = Keypair::generate((&mut entropy).into());
-		keypair.secret.to_bytes()
+		// Bench-only throwaway keys: copy out of the self-wiping buffer.
+		*keypair.secret.to_bytes()
 	};
 
 	let fixed = gen_sk(rng);

--- a/dilithium/examples/stack_probe.rs
+++ b/dilithium/examples/stack_probe.rs
@@ -54,13 +54,16 @@ fn main() {
 		let _ = ml_dsa_87::Keypair::generate((&mut [1u8; 32]).into());
 	});
 
+	// `to_bytes` now returns a self-wiping `Zeroizing` buffer, which is not
+	// `Copy`; clone a copy into each closure.
+	let sign_bytes = kp_bytes.clone();
 	let sign = peak_stack(move || {
-		let kp = ml_dsa_87::Keypair::from_bytes(&kp_bytes).expect("from_bytes");
+		let kp = ml_dsa_87::Keypair::from_bytes(sign_bytes.as_slice()).expect("from_bytes");
 		let _ = kp.sign(msg, None, None);
 	});
 
 	let verify = peak_stack(move || {
-		let kp = ml_dsa_87::Keypair::from_bytes(&kp_bytes).expect("from_bytes");
+		let kp = ml_dsa_87::Keypair::from_bytes(kp_bytes.as_slice()).expect("from_bytes");
 		let _ = kp.verify(msg, &sig, None);
 	});
 

--- a/dilithium/examples/stack_usage_demo.rs
+++ b/dilithium/examples/stack_usage_demo.rs
@@ -170,16 +170,20 @@ fn main() {
 			true
 		});
 
+		// `to_bytes` now returns a self-wiping `Zeroizing` buffer, which is
+		// not `Copy`; clone a copy into each spawned-thread closure.
+		let sign_bytes = ml87_keypair_bytes.clone();
 		let ml87_sign = test_sign_with_stack_size(size_kb, "ml-dsa-87", move || {
-			let kp = ml_dsa_87::Keypair::from_bytes(&ml87_keypair_bytes)
+			let kp = ml_dsa_87::Keypair::from_bytes(sign_bytes.as_slice())
 				.expect("from_bytes must succeed for known-good bytes");
 			let _sig = kp.sign(test_msg, None, None);
 			true
 		});
 
 		let ml87_sig_clone = ml87_sig;
+		let verify_bytes = ml87_keypair_bytes.clone();
 		let ml87_verify = test_verify_with_stack_size(size_kb, "ml-dsa-87", move || {
-			let kp = ml_dsa_87::Keypair::from_bytes(&ml87_keypair_bytes)
+			let kp = ml_dsa_87::Keypair::from_bytes(verify_bytes.as_slice())
 				.expect("from_bytes must succeed for known-good bytes");
 			kp.verify(test_msg, &ml87_sig_clone, None)
 		});

--- a/dilithium/src/fips202.rs
+++ b/dilithium/src/fips202.rs
@@ -6,10 +6,9 @@
 //! both. This module enforces the rate at compile time and the phase at
 //! runtime:
 //!
-//! - [`KeccakState`] carries its rate as a const generic parameter
-//!   ([`Shake128State`] vs [`Shake256State`]), so a state built by SHAKE128
-//!   operations cannot reach a SHAKE256 function at all. Mixing rates used to
-//!   underflow `rate - pos` and panic; now it does not compile:
+//! - [`KeccakState`] carries its rate as a const generic parameter ([`Shake128State`] vs
+//!   [`Shake256State`]), so a state built by SHAKE128 operations cannot reach a SHAKE256 function
+//!   at all. Mixing rates used to underflow `rate - pos` and panic; now it does not compile:
 //!
 //! ```compile_fail
 //! use qp_rusty_crystals_dilithium::fips202::*;
@@ -21,11 +20,10 @@
 //! shake256_absorb(&mut state, b"more");
 //! ```
 //!
-//! - The absorb→squeeze phase is tracked in the state and checked with debug
-//!   assertions: absorbing into a finalized state or squeezing an unfinalized
-//!   one is a caller bug that panics in debug builds. In release builds these
-//!   misuses stay deterministic and panic-free (they yield a well-defined but
-//!   non-standard stream), matching the crate's policy of not panicking in
+//! - The absorb→squeeze phase is tracked in the state and checked with debug assertions: absorbing
+//!   into a finalized state or squeezing an unfinalized one is a caller bug that panics in debug
+//!   builds. In release builds these misuses stay deterministic and panic-free (they yield a
+//!   well-defined but non-standard stream), matching the crate's policy of not panicking in
 //!   production for domain violations.
 //!
 //! Squeezing (both [`shake256_squeeze`] and the block-sized
@@ -771,10 +769,7 @@ mod tests {
 		chunked[17..17 + SHAKE256_RATE].copy_from_slice(&block[0]);
 		shake256_squeeze(&mut chunked[17 + SHAKE256_RATE..], &mut state);
 
-		assert_eq!(
-			reference, chunked,
-			"SHAKE256 output stream depends on how reads are chunked"
-		);
+		assert_eq!(reference, chunked, "SHAKE256 output stream depends on how reads are chunked");
 	}
 
 	/// The debug-mode phase check: absorbing into a finalized state is a caller

--- a/dilithium/src/fips202.rs
+++ b/dilithium/src/fips202.rs
@@ -1,3 +1,37 @@
+//! SHAKE128/SHAKE256 XOFs with the sponge rate encoded in the type.
+//!
+//! A Keccak sponge is only well-defined when every operation agrees on the
+//! rate (168 for SHAKE128, 136 for SHAKE256) and on the phase (absorbing vs
+//! squeezing): the byte position stored in the state is meaningless without
+//! both. This module enforces the rate at compile time and the phase at
+//! runtime:
+//!
+//! - [`KeccakState`] carries its rate as a const generic parameter
+//!   ([`Shake128State`] vs [`Shake256State`]), so a state built by SHAKE128
+//!   operations cannot reach a SHAKE256 function at all. Mixing rates used to
+//!   underflow `rate - pos` and panic; now it does not compile:
+//!
+//! ```compile_fail
+//! use qp_rusty_crystals_dilithium::fips202::*;
+//!
+//! let mut state = KeccakState::default();
+//! shake128_absorb(&mut state, b"seed");
+//! shake128_finalize(&mut state);
+//! // error[E0308]: `state` is a SHAKE128-rate state, not a SHAKE256 one
+//! shake256_absorb(&mut state, b"more");
+//! ```
+//!
+//! - The absorb→squeeze phase is tracked in the state and checked with debug
+//!   assertions: absorbing into a finalized state or squeezing an unfinalized
+//!   one is a caller bug that panics in debug builds. In release builds these
+//!   misuses stay deterministic and panic-free (they yield a well-defined but
+//!   non-standard stream), matching the crate's policy of not panicking in
+//!   production for domain violations.
+//!
+//! Squeezing (both [`shake256_squeeze`] and the block-sized
+//! `shake{128,256}_squeezeblocks`) reads one canonical output stream: the
+//! result is the same no matter how reads are chunked.
+
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub const SHAKE128_RATE: usize = 168;
@@ -5,7 +39,12 @@ pub const SHAKE256_RATE: usize = 136;
 
 const NROUNDS: usize = 24;
 
-/// 1600-bit state of the Keccak algorithm, with an index of current position.
+/// 1600-bit state of the Keccak algorithm for sponge rate `R`, with an index
+/// of the current position and the absorb/squeeze phase (see module docs).
+///
+/// `KeccakState::default()` is the initialized empty (absorbing) state; the
+/// rate parameter is normally inferred from the first `shake128_*` /
+/// `shake256_*` call.
 ///
 /// # Security
 ///
@@ -14,24 +53,30 @@ const NROUNDS: usize = 24;
 /// intentionally NOT implemented to prevent accidental copies that could
 /// leave sensitive data in memory (HQ8).
 ///
-/// The `s` (sponge lanes) and `pos` (offset within the current block) fields
-/// are private. This is deliberate: `pos` must satisfy the invariant
-/// `pos <= rate`, and the squeeze/absorb routines rely on it to make forward
-/// progress. Exposing the fields would let a caller (for example one that
-/// restores a state from untrusted bytes) construct a state with `pos > rate`,
-/// which previously caused `keccak_squeeze` to loop forever. Keeping the
-/// fields private makes that state unrepresentable from outside this module.
+/// The fields are private. This is deliberate: `pos` must satisfy the
+/// invariant `pos <= R`, and the squeeze/absorb routines rely on it to make
+/// forward progress; `squeezing` must only flip on finalize. Exposing the
+/// fields would let a caller (for example one that restores a state from
+/// untrusted bytes) construct a state with `pos > R`, which previously caused
+/// `keccak_squeeze` to loop forever.
 #[derive(Clone, Default, Zeroize, ZeroizeOnDrop)]
-pub struct KeccakState {
+pub struct KeccakState<const R: usize> {
 	s: [u64; 25],
 	pos: usize,
+	squeezing: bool,
 }
 
-impl KeccakState {
-	/// Set the state to the initial form.
+/// A SHAKE128 sponge state (rate 168).
+pub type Shake128State = KeccakState<SHAKE128_RATE>;
+/// A SHAKE256 sponge state (rate 136).
+pub type Shake256State = KeccakState<SHAKE256_RATE>;
+
+impl<const R: usize> KeccakState<R> {
+	/// Set the state to the initial (absorbing) form.
 	pub fn init(&mut self) {
 		self.s.fill(0);
 		self.pos = 0;
+		self.squeezing = false;
 	}
 }
 
@@ -324,17 +369,19 @@ fn keccakf1600_statepermute(state: &mut [u64; 25]) {
 	state[24] = asu;
 }
 
-/// Absorb step of Keccak; incremental.
-fn keccak_absorb(state: &mut KeccakState, r: usize, input: &[u8]) {
+/// Absorb step of Keccak; incremental. The rate comes from the state's type,
+/// so `pos` can never be interpreted against the wrong block size.
+fn keccak_absorb<const R: usize>(state: &mut KeccakState<R>, input: &[u8]) {
+	debug_assert!(!state.squeezing, "fips202: absorb called on a finalized (squeezing) state");
 	let mut inlen = input.len();
 	let mut idx = 0;
 	let mut pos = state.pos;
-	while pos + inlen >= r {
-		for i in pos..r {
+	while pos + inlen >= R {
+		for i in pos..R {
 			state.s[i / 8] ^= (input[idx] as u64) << 8 * (i % 8);
 			idx += 1;
 		}
-		inlen -= r - pos;
+		inlen -= R - pos;
 		keccakf1600_statepermute(&mut state.s);
 		pos = 0;
 	}
@@ -347,31 +394,37 @@ fn keccak_absorb(state: &mut KeccakState, r: usize, input: &[u8]) {
 	state.pos = i;
 }
 
-/// Finalize absorb step.
-fn keccak_finalize(s: &mut [u64; 25], pos: usize, r: usize, p: u8) {
-	s[pos / 8] ^= (p as u64) << 8 * (pos % 8);
-	s[r / 8 - 1] ^= 1u64 << 63;
+/// Finalize absorb step: apply domain-separation/padding and transition the
+/// state to the squeezing phase. `pos = R` marks the current block as
+/// exhausted, so the first squeeze permutes.
+fn keccak_finalize<const R: usize>(state: &mut KeccakState<R>, p: u8) {
+	debug_assert!(!state.squeezing, "fips202: finalize called twice on the same state");
+	state.s[state.pos / 8] ^= (p as u64) << 8 * (state.pos % 8);
+	state.s[R / 8 - 1] ^= 1u64 << 63;
+	state.pos = R;
+	state.squeezing = true;
 }
 
-/// Squeeze step of Keccak. Squeezes arbitratrily many bytes.
-/// Modifies the state. Can be called multiple times to keep squeezing, i.e., is incremental.
-///
-/// Returns new position pos in current block
-fn keccak_squeeze(out: &mut [u8], s: &mut [u64; 25], mut pos: usize, r: usize) -> usize {
+/// Squeeze step of Keccak. Squeezes arbitrarily many bytes from the canonical
+/// output stream. Can be called multiple times to keep squeezing, i.e., is
+/// incremental.
+fn keccak_squeeze<const R: usize>(out: &mut [u8], state: &mut KeccakState<R>) {
+	debug_assert!(state.squeezing, "fips202: squeeze called before finalize");
+	let mut pos = state.pos;
 	let mut outlen = out.len();
 	let mut out_idx = 0;
 	while outlen != 0 {
 		// `>=` (rather than `==`) is a defensive guard: a well-formed state always
-		// has `pos <= r`, but if an out-of-range `pos` ever reaches here we must
+		// has `pos <= R`, but if an out-of-range `pos` ever reaches here we must
 		// still permute and reset so the loop makes progress. Without this, a
-		// `pos > r` would emit zero bytes per iteration and spin forever.
-		if pos >= r {
-			keccakf1600_statepermute(s);
+		// `pos > R` would emit zero bytes per iteration and spin forever.
+		if pos >= R {
+			keccakf1600_statepermute(&mut state.s);
 			pos = 0;
 		}
 		let mut i = pos;
-		while i < r && i < pos + outlen {
-			out[out_idx] = (s[i / 8] >> 8 * (i % 8)) as u8;
+		while i < R && i < pos + outlen {
+			out[out_idx] = (state.s[i / 8] >> 8 * (i % 8)) as u8;
 			out_idx += 1;
 			i += 1;
 		}
@@ -379,15 +432,15 @@ fn keccak_squeeze(out: &mut [u8], s: &mut [u64; 25], mut pos: usize, r: usize) -
 		pos = i;
 	}
 
-	pos
+	state.pos = pos;
 }
 
 /// Absorb step of Keccak; non-incremental, starts by zeroeing the state.
-fn keccak_absorb_once(s: &mut [u64; 25], r: usize, input: &[u8], p: u8) {
+fn keccak_absorb_once<const R: usize>(s: &mut [u64; 25], input: &[u8], p: u8) {
 	s.fill(0);
 
 	// Process full blocks using chunks_exact for safe iteration
-	let mut chunks = input.chunks_exact(r);
+	let mut chunks = input.chunks_exact(R);
 	for block in chunks.by_ref() {
 		for (i, chunk) in block.chunks_exact(8).enumerate() {
 			// SAFETY: chunks_exact(8) guarantees exactly 8 bytes, so this indexing is safe
@@ -405,106 +458,107 @@ fn keccak_absorb_once(s: &mut [u64; 25], r: usize, input: &[u8], p: u8) {
 	}
 
 	s[remainder.len() / 8] ^= (p as u64) << (8 * (remainder.len() % 8));
-	s[(r - 1) / 8] ^= 1u64 << 63;
+	s[(R - 1) / 8] ^= 1u64 << 63;
 }
 
-/// Squeeze step of Keccak. Squeezes one full rate-sized block per entry of `out`.
-/// Modifies the state. Can be called multiple times to keep squeezing, i.e., is incremental.
-/// Assumes zero bytes of current block have already been squeezed.
+/// Squeeze step of Keccak. Squeezes one full rate-sized block per entry of `out`,
+/// reading from the same canonical output stream as [`keccak_squeeze`]: if the
+/// current block is partially consumed, the stream continues from that offset
+/// rather than skipping the unconsumed bytes.
 ///
 /// The output is typed as whole blocks (`[[u8; R]]`) rather than a flat slice
 /// plus a separate block count, so a count/capacity mismatch — which would
 /// silently underfill the buffer and desynchronize the state — is
 /// unrepresentable at the type level.
-fn keccak_squeezeblocks<const R: usize>(out: &mut [[u8; R]], s: &mut [u64; 25]) {
+fn keccak_squeezeblocks<const R: usize>(out: &mut [[u8; R]], state: &mut KeccakState<R>) {
+	debug_assert!(state.squeezing, "fips202: squeezeblocks called before finalize");
+	if state.pos < R {
+		// Mid-block: stay on the canonical stream via the byte-wise squeeze.
+		keccak_squeeze(out.as_flattened_mut(), state);
+		return;
+	}
+	// Block-aligned fast path: whole-lane copies.
 	for block in out.iter_mut() {
-		keccakf1600_statepermute(s);
+		keccakf1600_statepermute(&mut state.s);
 		for (i, chunk) in block.chunks_exact_mut(8).enumerate() {
 			// chunks_exact_mut(8) guarantees exactly 8 bytes
-			let bytes = s[i].to_le_bytes();
+			let bytes = state.s[i].to_le_bytes();
 			chunk.copy_from_slice(&bytes);
 		}
 	}
+	state.pos = R;
 }
 
 /// Absorb step of the SHAKE128 XOF; incremental.
-pub fn shake128_absorb(state: &mut KeccakState, input: &[u8]) {
-	keccak_absorb(state, SHAKE128_RATE, input);
+pub fn shake128_absorb(state: &mut Shake128State, input: &[u8]) {
+	keccak_absorb(state, input);
 }
 
-/// Finalize absorb step of the SHAKE128 XOF.
-pub fn shake128_finalize(state: &mut KeccakState) {
-	keccak_finalize(&mut state.s, state.pos as usize, SHAKE128_RATE, 0x1F);
-	state.pos = SHAKE128_RATE;
+/// Finalize absorb step of the SHAKE128 XOF, transitioning the state to the
+/// squeezing phase. Absorbing after this point is a caller bug (debug panic).
+pub fn shake128_finalize(state: &mut Shake128State) {
+	keccak_finalize(state, 0x1F);
 }
 
 /// Squeeze step of SHAKE128 XOF. Squeezes one full block of SHAKE128_RATE bytes
-/// per entry of `output`.
+/// per entry of `output`, continuing the canonical output stream.
 /// Can be called multiple times to keep squeezing.
-/// Assumes new block has not yet been started (state->pos = SHAKE128_RATE).
 ///
 /// Taking whole blocks (`[[u8; SHAKE128_RATE]]`) instead of a flat slice plus a
 /// block count makes an inconsistent count/capacity pair unrepresentable: the
 /// old shape silently underfilled a short slice, leaving stale bytes that the
 /// caller would treat as XOF output.
-pub fn shake128_squeezeblocks(output: &mut [[u8; SHAKE128_RATE]], s: &mut KeccakState) {
-	keccak_squeezeblocks(output, &mut s.s);
+pub fn shake128_squeezeblocks(output: &mut [[u8; SHAKE128_RATE]], state: &mut Shake128State) {
+	keccak_squeezeblocks(output, state);
 }
 
 /// Absorb step of the SHAKE256 XOF; incremental.
-pub fn shake256_absorb(state: &mut KeccakState, input: &[u8]) {
-	keccak_absorb(state, SHAKE256_RATE, input);
+pub fn shake256_absorb(state: &mut Shake256State, input: &[u8]) {
+	keccak_absorb(state, input);
 }
 
-/// Finalize absorb step of the SHAKE256 XOF.
-pub fn shake256_finalize(state: &mut KeccakState) {
-	keccak_finalize(&mut state.s, state.pos, SHAKE256_RATE, 0x1F);
-	state.pos = SHAKE256_RATE;
+/// Finalize absorb step of the SHAKE256 XOF, transitioning the state to the
+/// squeezing phase. Absorbing after this point is a caller bug (debug panic).
+pub fn shake256_finalize(state: &mut Shake256State) {
+	keccak_finalize(state, 0x1F);
 }
 
-/// Squeeze step of SHAKE256 XOF. Squeezes arbitraily many bytes.
+/// Squeeze step of SHAKE256 XOF. Squeezes arbitrarily many bytes.
 /// Can be called multiple times to keep squeezing.
-pub fn shake256_squeeze(out: &mut [u8], state: &mut KeccakState) {
-	state.pos = keccak_squeeze(out, &mut state.s, state.pos, SHAKE256_RATE);
+pub fn shake256_squeeze(out: &mut [u8], state: &mut Shake256State) {
+	keccak_squeeze(out, state);
 }
 
 /// Initialize, absorb into and finalize SHAKE256 XOF; non-incremental.
-pub fn shake256_absorb_once(state: &mut KeccakState, input: &[u8]) {
-	keccak_absorb_once(&mut state.s, SHAKE256_RATE, input, 0x1F);
+pub fn shake256_absorb_once(state: &mut Shake256State, input: &[u8]) {
+	keccak_absorb_once::<SHAKE256_RATE>(&mut state.s, input, 0x1F);
 	state.pos = SHAKE256_RATE;
+	state.squeezing = true;
 }
 
 /// Squeeze step of SHAKE256 XOF. Squeezes one full block of SHAKE256_RATE bytes
-/// per entry of `out`.
+/// per entry of `out`, continuing the canonical output stream.
 /// Can be called multiple times to keep squeezing.
-/// Assumes next block has not yet been started (state.pos = SHAKE256_RATE).
 ///
 /// Taking whole blocks (`[[u8; SHAKE256_RATE]]`) instead of a flat slice plus a
 /// block count makes an inconsistent count/capacity pair unrepresentable: the
 /// old shape silently underfilled a short slice, leaving stale bytes that the
 /// caller would treat as XOF output.
-pub fn shake256_squeezeblocks(out: &mut [[u8; SHAKE256_RATE]], state: &mut KeccakState) {
-	keccak_squeezeblocks(out, &mut state.s);
+pub fn shake256_squeezeblocks(out: &mut [[u8; SHAKE256_RATE]], state: &mut Shake256State) {
+	keccak_squeezeblocks(out, state);
 }
 
 /// SHAKE256 XOF with non-incremental API
 pub fn shake256(output: &mut [u8], input: &[u8]) {
-	let mut state = KeccakState::default();
-
+	let mut state = Shake256State::default();
 	shake256_absorb_once(&mut state, input);
-	// Squeeze whole blocks first, then the sub-block tail.
-	let mut blocks = output.chunks_exact_mut(SHAKE256_RATE);
-	for block in blocks.by_ref() {
-		let block: &mut [u8; SHAKE256_RATE] =
-			block.try_into().expect("chunks_exact yields full blocks");
-		shake256_squeezeblocks(core::slice::from_mut(block), &mut state);
-	}
-	shake256_squeeze(blocks.into_remainder(), &mut state);
+	shake256_squeeze(output, &mut state);
 }
 
-/// Initialize SHAKE128 stream with a fixed-size seed and nonce.
+/// Initialize SHAKE128 stream with a fixed-size seed and nonce, leaving the
+/// state finalized (ready to squeeze).
 pub fn shake128_stream_init(
-	state: &mut KeccakState,
+	state: &mut Shake128State,
 	seed: &[u8; crate::params::SEEDBYTES],
 	nonce: u16,
 ) {
@@ -515,9 +569,10 @@ pub fn shake128_stream_init(
 	shake128_finalize(state);
 }
 
-/// Initialize SHAKE256 stream with a fixed-size seed and nonce.
+/// Initialize SHAKE256 stream with a fixed-size seed and nonce, leaving the
+/// state finalized (ready to squeeze).
 pub fn shake256_stream_init(
-	state: &mut KeccakState,
+	state: &mut Shake256State,
 	seed: &[u8; crate::params::CRHBYTES],
 	nonce: u16,
 ) {
@@ -622,13 +677,13 @@ mod tests {
 		// keccak_squeeze loop forever. Before hardening, `pos > r` meant the inner
 		// `while i < r` loop emitted zero bytes, so `outlen` was never decremented
 		// and the outer `while outlen != 0` spun indefinitely. This test wedges an
-		// out-of-range position (as an untrusted/corrupted state could) and requires
-		// the call to return with a valid in-range position.
-		let mut s = [0u64; 25];
+		// out-of-range position (as a corrupted state could) and requires the call
+		// to leave a valid in-range position.
+		let mut state: Shake256State =
+			KeccakState { s: [0u64; 25], pos: SHAKE256_RATE + 1, squeezing: true };
 		let mut out = [0u8; 32];
-		let bad_pos = SHAKE256_RATE + 1;
-		let new_pos = keccak_squeeze(&mut out, &mut s, bad_pos, SHAKE256_RATE);
-		assert!(new_pos <= SHAKE256_RATE, "squeeze must return an in-range position");
+		keccak_squeeze(&mut out, &mut state);
+		assert!(state.pos <= SHAKE256_RATE, "squeeze must leave an in-range position");
 	}
 
 	#[test]
@@ -681,10 +736,58 @@ mod tests {
 		shake128_absorb(&mut byte_state, b"equivalence");
 		shake128_finalize(&mut byte_state);
 		let mut bytes128 = [0u8; 2 * SHAKE128_RATE];
-		let pos = keccak_squeeze(&mut bytes128, &mut byte_state.s, SHAKE128_RATE, SHAKE128_RATE);
-		assert!(pos <= SHAKE128_RATE);
+		keccak_squeeze(&mut bytes128, &mut byte_state);
 
 		assert_eq!(blocks128.as_flattened(), bytes128);
+	}
+
+	/// The SHAKE256 output stream must be one canonical byte sequence no matter
+	/// how reads are chunked. Mixing `shake256_squeeze` with
+	/// `shake256_squeezeblocks` (which used to ignore `pos` and always permute)
+	/// must not skip unconsumed bytes or re-emit bytes from an earlier block.
+	#[test]
+	fn squeeze_chunking_does_not_change_stream() {
+		const TAIL: usize = 32;
+		const TOTAL: usize = 17 + SHAKE256_RATE + TAIL;
+
+		fn absorb() -> Shake256State {
+			let mut state = KeccakState::default();
+			shake256_absorb(&mut state, b"canonical-stream");
+			shake256_finalize(&mut state);
+			state
+		}
+
+		// Reference stream: one straight squeeze.
+		let mut reference = [0u8; TOTAL];
+		shake256_squeeze(&mut reference, &mut absorb());
+
+		// Same transcript, chunked reads: partial squeeze, then a whole block
+		// via the block API, then the tail.
+		let mut chunked = [0u8; TOTAL];
+		let mut state = absorb();
+		shake256_squeeze(&mut chunked[..17], &mut state);
+		let mut block = [[0u8; SHAKE256_RATE]; 1];
+		shake256_squeezeblocks(&mut block, &mut state);
+		chunked[17..17 + SHAKE256_RATE].copy_from_slice(&block[0]);
+		shake256_squeeze(&mut chunked[17 + SHAKE256_RATE..], &mut state);
+
+		assert_eq!(
+			reference, chunked,
+			"SHAKE256 output stream depends on how reads are chunked"
+		);
+	}
+
+	/// The debug-mode phase check: absorbing into a finalized state is a caller
+	/// bug and must be caught loudly in debug builds. (Cross-*rate* misuse is
+	/// caught at compile time; see the module-level `compile_fail` doctest.)
+	#[test]
+	#[cfg(debug_assertions)]
+	#[should_panic(expected = "absorb called on a finalized")]
+	fn absorb_after_finalize_debug_asserts() {
+		let mut state = KeccakState::default();
+		shake256_absorb(&mut state, b"seed");
+		shake256_finalize(&mut state);
+		shake256_absorb(&mut state, b"more");
 	}
 
 	#[test]

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -551,6 +551,78 @@ mod tests {
 		);
 	}
 
+	// The packed s1/s2 regions use 3 bits per coefficient, decoded as
+	// `ETA - slot`. With ETA = 2, slots 5..7 decode to coefficients -3..-5 —
+	// outside the [-ETA, ETA] key distribution the parameters advertise and
+	// the BETA rejection margin is sized for. An attacker can recompute
+	// t0/tr/pk *from* the oversized coefficients, so every algebraic
+	// consistency check passes; the import paths must therefore enforce the
+	// coefficient range explicitly.
+	#[test]
+	fn from_bytes_rejects_out_of_range_secret_coefficients() {
+		use super::{
+			KeyParsingError, Keypair, SecretKey, KEYPAIRBYTES, PUBLICKEYBYTES, SECRETKEYBYTES,
+		};
+		use crate::{fips202, packing, params, polyvec};
+
+		// Start from an honest key and re-derive everything after planting
+		// the out-of-range coefficient, so the forged blob is fully
+		// self-consistent (valid t0, tr, and matching public key).
+		let keys = Keypair::generate(get_random_bytes());
+		let sk_bytes = keys.secret.to_bytes();
+
+		let mut rho = [0u8; params::SEEDBYTES];
+		let mut tr = [0u8; params::TR_BYTES];
+		let mut key = [0u8; params::SEEDBYTES];
+		let mut t0 = polyvec::Polyveck::default();
+		let mut s1 = polyvec::Polyvecl::default();
+		let mut s2 = polyvec::Polyveck::default();
+		assert!(
+			packing::unpack_sk(&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, &sk_bytes),
+			"honest key unpacks canonically"
+		);
+
+		// -3 packs as the 3-bit slot 5 (eta_pack stores ETA - coeff), so the
+		// forged coefficient survives the pack/unpack round trip.
+		s1.vec[0].coeffs_mut()[0] = -(params::ETA as i32) - 1;
+
+		// Same derivation as keygen: t = A·s1 + s2, split into (t1, t0).
+		let mut s1hat = s1.clone();
+		polyvec::l_ntt(&mut s1hat);
+		let mut t1 = polyvec::Polyveck::default();
+		polyvec::matrix_pointwise_montgomery_streamed(&mut t1, &rho, &s1hat);
+		polyvec::k_reduce(&mut t1);
+		polyvec::k_invntt_tomont(&mut t1);
+		polyvec::k_add(&mut t1, &s2);
+		polyvec::k_caddq(&mut t1);
+		let mut t0_forged = polyvec::Polyveck::default();
+		polyvec::k_power2round(&mut t1, &mut t0_forged);
+
+		let mut pk = [0u8; PUBLICKEYBYTES];
+		packing::pack_pk(&mut pk, &rho, &t1);
+		let mut tr_forged = [0u8; params::TR_BYTES];
+		fips202::shake256(&mut tr_forged, &pk);
+
+		let mut forged_sk = [0u8; SECRETKEYBYTES];
+		packing::pack_sk(&mut forged_sk, &rho, &tr_forged, &key, &t0_forged, &s1, &s2);
+
+		assert!(
+			matches!(SecretKey::from_bytes(&forged_sk), Err(KeyParsingError::BadSecretKey)),
+			"secret key with a coefficient outside [-ETA, ETA] must be rejected"
+		);
+
+		let mut forged_kp = [0u8; KEYPAIRBYTES];
+		forged_kp[..SECRETKEYBYTES].copy_from_slice(&forged_sk);
+		forged_kp[SECRETKEYBYTES..].copy_from_slice(&pk);
+		assert!(
+			matches!(Keypair::from_bytes(&forged_kp), Err(KeyParsingError::BadKeypair)),
+			"keypair with a secret coefficient outside [-ETA, ETA] must be rejected"
+		);
+
+		// Honest keys must still round-trip.
+		assert!(SecretKey::from_bytes(&sk_bytes).is_ok(), "honest secret key must be accepted");
+	}
+
 	// Malicious-key forgery defense: a public key with an all-zero t1 makes verification
 	// independent of the challenge, enabling signature forgery without a secret key.
 	// `from_bytes` must reject such a key so it can never be constructed or stored.

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -1,4 +1,4 @@
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::{
 	errors::{KeyParsingError, KeyParsingError::BadSecretKey, SignatureError},
@@ -58,10 +58,17 @@ impl Keypair {
 	///
 	/// Returns an array containing private and public keys bytes
 	pub fn to_bytes(&self) -> [u8; KEYPAIRBYTES] {
-		let mut result = [0u8; KEYPAIRBYTES];
-		result[..SECRETKEYBYTES].copy_from_slice(&self.secret.to_bytes());
+		// Copy the secret half directly from the stored key rather than via
+		// `self.secret.to_bytes()`: that would materialize a `Copy` temporary
+		// of the whole secret key on the stack, dropped without zeroization.
+		// The working buffer is itself zeroizing: it is not always elided
+		// into the return slot, and an unwiped local would leave the secret
+		// key readable in this frame's dead stack memory after return. The
+		// returned (caller-owned) copy is the caller's responsibility.
+		let mut result = Zeroizing::new([0u8; KEYPAIRBYTES]);
+		result[..SECRETKEYBYTES].copy_from_slice(&self.secret.bytes);
 		result[SECRETKEYBYTES..].copy_from_slice(&self.public.to_bytes());
-		result
+		*result
 	}
 
 	/// Create a Keypair from bytes.
@@ -94,9 +101,14 @@ impl Keypair {
 		if bytes.len() != SECRETKEYBYTES + PUBLICKEYBYTES {
 			return Err(KeyParsingError::BadKeypair);
 		}
-		let (secret_bytes, public_bytes) = bytes.split_at(SECRETKEYBYTES);
-		let secret_bytes: [u8; SECRETKEYBYTES] =
-			secret_bytes.try_into().map_err(|_| KeyParsingError::BadKeypair)?;
+		let (secret_slice, public_bytes) = bytes.split_at(SECRETKEYBYTES);
+		// Copy the secret half into a zeroizing local (filled in place, so no
+		// intermediate `Copy` array is created). A plain `[u8; N]` local would
+		// survive the "move" into the returned struct — arrays are `Copy` —
+		// and leave a plaintext secret key in dead stack memory; `Zeroizing`
+		// wipes the local on every exit path, including the error returns.
+		let mut secret_bytes = Zeroizing::new([0u8; SECRETKEYBYTES]);
+		secret_bytes.copy_from_slice(secret_slice);
 		let public =
 			PublicKey::from_bytes(public_bytes).map_err(|_| KeyParsingError::BadKeypair)?;
 
@@ -112,7 +124,7 @@ impl Keypair {
 			return Err(KeyParsingError::BadKeypair);
 		}
 
-		Ok(Keypair { secret: SecretKey { bytes: secret_bytes }, public })
+		Ok(Keypair { secret: SecretKey { bytes: *secret_bytes }, public })
 	}
 
 	/// Compute a signature for a given message.
@@ -199,11 +211,18 @@ impl SecretKey {
 	/// serialized secret material has the same guarantees whether it is
 	/// imported as a `Keypair` or as a standalone `SecretKey`.
 	pub fn from_bytes(bytes: &[u8]) -> Result<SecretKey, KeyParsingError> {
-		let bytes: [u8; SECRETKEYBYTES] = bytes.try_into().map_err(|_| BadSecretKey)?;
+		if bytes.len() != SECRETKEYBYTES {
+			return Err(BadSecretKey);
+		}
+		// Zeroizing local filled in place: see `Keypair::from_bytes` — a bare
+		// `[u8; N]` local is `Copy` and would survive the move into the
+		// returned struct as an unwiped plaintext copy of the secret key.
+		let mut sk = Zeroizing::new([0u8; SECRETKEYBYTES]);
+		sk.copy_from_slice(bytes);
 		// Re-derives the public components and checks the stored tr/t0 against
 		// them; the derived pk itself is not needed here.
-		crate::sign::public_key_from_secret(&bytes).ok_or(BadSecretKey)?;
-		Ok(SecretKey { bytes })
+		crate::sign::public_key_from_secret(&sk).ok_or(BadSecretKey)?;
+		Ok(SecretKey { bytes: *sk })
 	}
 
 	/// Compute a signature for a given message.

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -505,7 +505,10 @@ mod tests {
 
 		let keys = Keypair::generate(get_random_bytes());
 		let good = keys.secret.to_bytes();
-		assert!(SecretKey::from_bytes(good.as_slice()).is_ok(), "honest secret key must be accepted");
+		assert!(
+			SecretKey::from_bytes(good.as_slice()).is_ok(),
+			"honest secret key must be accepted"
+		);
 
 		// SK layout: rho (32) || key (32) || tr (64) || s1 || s2 || t0.
 		let tr_offset = 2 * SEEDBYTES;

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -56,19 +56,27 @@ impl Keypair {
 
 	/// Convert a Keypair to a bytes array.
 	///
-	/// Returns an array containing private and public keys bytes
-	pub fn to_bytes(&self) -> [u8; KEYPAIRBYTES] {
+	/// Returns a self-wiping buffer containing private and public key bytes.
+	/// The buffer contains the full secret key, so it is `Zeroizing`: it is
+	/// erased when dropped, and callers no longer need (or are able to
+	/// forget) manual cleanup. Deref to `[u8; KEYPAIRBYTES]` for access.
+	pub fn to_bytes(&self) -> Zeroizing<[u8; KEYPAIRBYTES]> {
 		// Copy the secret half directly from the stored key rather than via
-		// `self.secret.to_bytes()`: that would materialize a `Copy` temporary
-		// of the whole secret key on the stack, dropped without zeroization.
-		// The working buffer is itself zeroizing: it is not always elided
-		// into the return slot, and an unwiped local would leave the secret
-		// key readable in this frame's dead stack memory after return. The
-		// returned (caller-owned) copy is the caller's responsibility.
+		// `self.secret.to_bytes()`: that would materialize a temporary copy
+		// of the whole secret key on the stack.
+		//
+		// The working buffer is deliberately *not* returned by move: a
+		// moved-from local never runs `Drop`, so if the compiler does not
+		// elide the return move (empirically it does not here), the frame
+		// would keep an unwiped copy. Instead the buffer is copied into a
+		// fresh wrapper for the caller and then wiped by its own `Drop` on
+		// scope exit — only the copy into the return slot is left to the
+		// optimizer, and the release-mode stack probe in
+		// `tests/import_stack_zeroization.rs` verifies it is elided.
 		let mut result = Zeroizing::new([0u8; KEYPAIRBYTES]);
 		result[..SECRETKEYBYTES].copy_from_slice(&self.secret.bytes);
 		result[SECRETKEYBYTES..].copy_from_slice(&self.public.to_bytes());
-		*result
+		Zeroizing::new(*result)
 	}
 
 	/// Create a Keypair from bytes.
@@ -184,9 +192,13 @@ pub struct SecretKey {
 }
 
 impl SecretKey {
-	/// Returns a copy of underlying bytes.
-	pub fn to_bytes(&self) -> [u8; SECRETKEYBYTES] {
-		self.bytes
+	/// Returns a copy of the underlying bytes in a self-wiping buffer.
+	///
+	/// The copy is `Zeroizing`: it is erased when dropped, so callers no
+	/// longer need (or are able to forget) manual cleanup. Deref to
+	/// `[u8; SECRETKEYBYTES]` for access.
+	pub fn to_bytes(&self) -> Zeroizing<[u8; SECRETKEYBYTES]> {
+		Zeroizing::new(self.bytes)
 	}
 
 	/// Create a SecretKey from bytes.
@@ -432,11 +444,11 @@ mod tests {
 
 		// Genuine keypair bytes must round-trip.
 		let good = keys_a.to_bytes();
-		assert!(Keypair::from_bytes(&good).is_ok(), "honest keypair must be accepted");
+		assert!(Keypair::from_bytes(good.as_slice()).is_ok(), "honest keypair must be accepted");
 
 		// Splice A's secret key with B's (unrelated) public key.
 		let mut forged = [0u8; KEYPAIRBYTES];
-		forged[..SECRETKEYBYTES].copy_from_slice(&keys_a.secret.to_bytes());
+		forged[..SECRETKEYBYTES].copy_from_slice(keys_a.secret.to_bytes().as_slice());
 		forged[SECRETKEYBYTES..].copy_from_slice(&keys_b.public.to_bytes());
 
 		assert!(
@@ -457,17 +469,17 @@ mod tests {
 
 		let keys = Keypair::generate(get_random_bytes());
 		let good = keys.to_bytes();
-		assert!(Keypair::from_bytes(&good).is_ok(), "honest keypair must be accepted");
+		assert!(Keypair::from_bytes(good.as_slice()).is_ok(), "honest keypair must be accepted");
 
 		// SK layout: rho (32) || key (32) || tr (64) || s1 || s2 || t0.
 		let tr_offset = 2 * SEEDBYTES;
 		let t0_offset = SECRETKEYBYTES - crate::params::K * POLYT0_PACKEDBYTES;
 
 		// Corrupt one byte inside the stored tr region only.
-		let mut bad_tr = good;
+		let mut bad_tr = good.clone();
 		bad_tr[tr_offset + TR_BYTES / 2] ^= 0x01;
 		assert!(
-			matches!(Keypair::from_bytes(&bad_tr), Err(KeyParsingError::BadKeypair)),
+			matches!(Keypair::from_bytes(bad_tr.as_slice()), Err(KeyParsingError::BadKeypair)),
 			"secret key with corrupted tr must be rejected"
 		);
 
@@ -475,7 +487,7 @@ mod tests {
 		let mut bad_t0 = good;
 		bad_t0[t0_offset] ^= 0x01;
 		assert!(
-			matches!(Keypair::from_bytes(&bad_t0), Err(KeyParsingError::BadKeypair)),
+			matches!(Keypair::from_bytes(bad_t0.as_slice()), Err(KeyParsingError::BadKeypair)),
 			"secret key with corrupted t0 must be rejected"
 		);
 	}
@@ -493,17 +505,17 @@ mod tests {
 
 		let keys = Keypair::generate(get_random_bytes());
 		let good = keys.secret.to_bytes();
-		assert!(SecretKey::from_bytes(&good).is_ok(), "honest secret key must be accepted");
+		assert!(SecretKey::from_bytes(good.as_slice()).is_ok(), "honest secret key must be accepted");
 
 		// SK layout: rho (32) || key (32) || tr (64) || s1 || s2 || t0.
 		let tr_offset = 2 * SEEDBYTES;
 		let t0_offset = SECRETKEYBYTES - crate::params::K * POLYT0_PACKEDBYTES;
 
 		// Corrupt one byte inside the stored tr region only.
-		let mut bad_tr = good;
+		let mut bad_tr = good.clone();
 		bad_tr[tr_offset + TR_BYTES / 2] ^= 0x01;
 		assert!(
-			matches!(SecretKey::from_bytes(&bad_tr), Err(KeyParsingError::BadSecretKey)),
+			matches!(SecretKey::from_bytes(bad_tr.as_slice()), Err(KeyParsingError::BadSecretKey)),
 			"standalone secret key with corrupted tr must be rejected"
 		);
 
@@ -511,7 +523,7 @@ mod tests {
 		let mut bad_t0 = good;
 		bad_t0[t0_offset] ^= 0x01;
 		assert!(
-			matches!(SecretKey::from_bytes(&bad_t0), Err(KeyParsingError::BadSecretKey)),
+			matches!(SecretKey::from_bytes(bad_t0.as_slice()), Err(KeyParsingError::BadSecretKey)),
 			"standalone secret key with corrupted t0 must be rejected"
 		);
 	}
@@ -620,7 +632,10 @@ mod tests {
 		);
 
 		// Honest keys must still round-trip.
-		assert!(SecretKey::from_bytes(&sk_bytes).is_ok(), "honest secret key must be accepted");
+		assert!(
+			SecretKey::from_bytes(sk_bytes.as_slice()).is_ok(),
+			"honest secret key must be accepted"
+		);
 	}
 
 	// Malicious-key forgery defense: a public key with an all-zero t1 makes verification

--- a/dilithium/src/packing.rs
+++ b/dilithium/src/packing.rs
@@ -77,6 +77,14 @@ pub fn pack_sk(
 }
 
 /// Unpack secret key sk = (rho, key, tr, s1, s2, t0).
+///
+/// Returns `false` if the packed `s1`/`s2` regions contain a non-canonical
+/// 3-bit slot — an encoding that would decode to a coefficient outside
+/// `[-ETA, ETA]`, which key generation never emits and which lies outside
+/// the key distribution the signing rejection margin (`BETA = TAU * ETA`)
+/// is sized for. All output buffers are fully written either way; callers
+/// must treat the unpacked values as invalid when `false` is returned.
+#[must_use]
 pub fn unpack_sk(
 	rho: &mut [u8; params::SEEDBYTES],
 	tr: &mut [u8; params::TR_BYTES],
@@ -85,7 +93,7 @@ pub fn unpack_sk(
 	s1: &mut Polyvecl,
 	s2: &mut Polyveck,
 	sk: &[u8; params::SECRETKEYBYTES],
-) {
+) -> bool {
 	rho.copy_from_slice(&sk[..params::SEEDBYTES]);
 	let mut idx = params::SEEDBYTES;
 
@@ -95,19 +103,25 @@ pub fn unpack_sk(
 	tr.copy_from_slice(&sk[idx..idx + params::TR_BYTES]);
 	idx += params::TR_BYTES;
 
+	// Accumulate with `&` rather than short-circuiting so every polynomial is
+	// unpacked and checked regardless of earlier results (data-independent
+	// control flow; honest keys always pass anyway).
+	let mut canonical = true;
 	for i in 0..L {
-		poly::eta_unpack(&mut s1.vec[i], &sk[idx + i * params::POLYETA_PACKEDBYTES..]);
+		canonical &= poly::eta_unpack(&mut s1.vec[i], &sk[idx + i * params::POLYETA_PACKEDBYTES..]);
 	}
 	idx += L * params::POLYETA_PACKEDBYTES;
 
 	for i in 0..K {
-		poly::eta_unpack(&mut s2.vec[i], &sk[idx + i * params::POLYETA_PACKEDBYTES..]);
+		canonical &= poly::eta_unpack(&mut s2.vec[i], &sk[idx + i * params::POLYETA_PACKEDBYTES..]);
 	}
 	idx += K * params::POLYETA_PACKEDBYTES;
 
 	for i in 0..K {
 		poly::t0_unpack(&mut t0.vec[i], &sk[idx + i * params::POLYT0_PACKEDBYTES..]);
 	}
+
+	canonical
 }
 
 /// Bit-pack signature sig = (c, z, h).
@@ -285,14 +299,17 @@ mod tests {
 		let mut unpacked_s1 = Polyvecl::default();
 		let mut unpacked_s2 = Polyveck::default();
 
-		unpack_sk(
-			&mut unpacked_rho,
-			&mut unpacked_tr,
-			&mut unpacked_key,
-			&mut unpacked_t0,
-			&mut unpacked_s1,
-			&mut unpacked_s2,
-			&packed_sk,
+		assert!(
+			unpack_sk(
+				&mut unpacked_rho,
+				&mut unpacked_tr,
+				&mut unpacked_key,
+				&mut unpacked_t0,
+				&mut unpacked_s1,
+				&mut unpacked_s2,
+				&packed_sk,
+			),
+			"canonically packed secret key must unpack cleanly"
 		);
 
 		assert_eq!(rho, unpacked_rho);

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -14,10 +14,10 @@
 //! [`Poly`] seals its coefficient array:
 //!
 //! - [`Poly::from_coeffs`] is the validated entry point for untrusted data; it only accepts
-//!   coefficients in `(-Q, Q)`, which satisfies every precondition of the **public** routines
-//!   in this module. Routines with narrower preconditions (`shiftl`, whose bound is
-//!   `|c| < 2^(31-D)`) are `pub(crate)` so they cannot be reached with boundary-validated
-//!   data; their internal callers guarantee the bounds by construction.
+//!   coefficients in `(-Q, Q)`, which satisfies every precondition of the **public** routines in
+//!   this module. Routines with narrower preconditions (`shiftl`, whose bound is `|c| < 2^(31-D)`)
+//!   are `pub(crate)` so they cannot be reached with boundary-validated data; their internal
+//!   callers guarantee the bounds by construction.
 //! - The unpack functions (`z_unpack`, `eta_unpack`, …) produce bounded coefficients by
 //!   construction.
 //! - [`Poly::coeffs_mut`] grants raw mutable access and shifts responsibility for the documented

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -671,7 +671,16 @@ pub(crate) fn eta_pack(r: &mut [u8], a: &Poly) {
 }
 
 /// Unpack polynomial with coefficients in [-ETA,ETA].
-pub(crate) fn eta_unpack(r: &mut Poly, a: &[u8]) {
+///
+/// The packed encoding stores `ETA - coefficient` in 3 bits per slot. With
+/// `ETA = 2` only slots 0..=4 are canonical; slots 5..=7 would decode to
+/// coefficients -3..-5, which key generation never emits and which lie
+/// outside the key distribution the `BETA = TAU * ETA` signing rejection
+/// margin is sized for. Returns `false` if any slot is non-canonical (the
+/// output polynomial is still fully written in that case; callers must
+/// treat it as invalid).
+#[must_use]
+pub(crate) fn eta_unpack(r: &mut Poly, a: &[u8]) -> bool {
 	for i in 0..N / 8 {
 		r.coeffs[8 * i + 0] = (a[3 * i + 0] & 0x07) as i32;
 		r.coeffs[8 * i + 1] = ((a[3 * i + 0] >> 3) & 0x07) as i32;
@@ -691,6 +700,11 @@ pub(crate) fn eta_unpack(r: &mut Poly, a: &[u8]) {
 		r.coeffs[8 * i + 6] = params::ETA as i32 - r.coeffs[8 * i + 6];
 		r.coeffs[8 * i + 7] = params::ETA as i32 - r.coeffs[8 * i + 7];
 	}
+	// Canonicality sweep after the fact: branch-free over the whole
+	// polynomial, so honest keys (which always pass) take a data-independent
+	// path through this function.
+	let eta = params::ETA as i32;
+	r.coeffs.iter().all(|&c| (-eta..=eta).contains(&c))
 }
 
 /// Bit-pack polynomial z with coefficients in [-(GAMMA1 - 1), GAMMA1 - 1].
@@ -1561,11 +1575,28 @@ mod tests {
 		eta_pack(&mut packed, &poly);
 
 		let mut unpacked = Poly::default();
-		eta_unpack(&mut unpacked, &packed);
+		assert!(eta_unpack(&mut unpacked, &packed), "canonical packing must unpack cleanly");
 
 		for i in 0..N {
 			assert_eq!(poly.coeffs[i], unpacked.coeffs[i], "ETA pack/unpack failed at index {}", i);
 		}
+	}
+
+	#[test]
+	fn test_eta_unpack_rejects_noncanonical_slots() {
+		// 3-bit slots 5..7 decode to coefficients -3..-5, outside [-ETA, ETA].
+		// eta_unpack must flag them; slot values 0..=4 (the canonical range)
+		// must pass.
+		let mut packed = [0u8; params::POLYETA_PACKEDBYTES];
+		let mut unpacked = Poly::default();
+		assert!(eta_unpack(&mut unpacked, &packed), "all-zero slots are canonical");
+
+		// First 3-bit slot = 5 -> coefficient ETA - 5 = -3.
+		packed[0] = 5;
+		assert!(
+			!eta_unpack(&mut unpacked, &packed),
+			"slot 5 decodes outside [-ETA, ETA] and must be flagged"
+		);
 	}
 
 	#[test]

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -14,7 +14,10 @@
 //! [`Poly`] seals its coefficient array:
 //!
 //! - [`Poly::from_coeffs`] is the validated entry point for untrusted data; it only accepts
-//!   coefficients in `(-Q, Q)`, which satisfies every precondition in this module.
+//!   coefficients in `(-Q, Q)`, which satisfies every precondition of the **public** routines
+//!   in this module. Routines with narrower preconditions (`shiftl`, whose bound is
+//!   `|c| < 2^(31-D)`) are `pub(crate)` so they cannot be reached with boundary-validated
+//!   data; their internal callers guarantee the bounds by construction.
 //! - The unpack functions (`z_unpack`, `eta_unpack`, …) produce bounded coefficients by
 //!   construction.
 //! - [`Poly::coeffs_mut`] grants raw mutable access and shifts responsibility for the documented
@@ -23,6 +26,18 @@
 //!
 //! Preconditions are additionally checked with `debug_assert!` so misuse fails
 //! loudly in tests without costing anything in release builds.
+//!
+//! The following must not compile — external code cannot funnel
+//! boundary-validated coefficients into `shiftl`'s narrower domain:
+//!
+//! ```compile_fail
+//! use qp_rusty_crystals_dilithium::{params, poly::{self, Poly}};
+//!
+//! let mut coeffs = [0i32; 256];
+//! coeffs[0] = params::Q - 1; // accepted by from_coeffs, outside shiftl's domain
+//! let mut p = Poly::from_coeffs(coeffs).unwrap();
+//! poly::shiftl(&mut p); // error: `shiftl` is crate-private
+//! ```
 
 use crate::{fips202, ntt, params, reduce, rounding};
 use core::fmt;
@@ -72,8 +87,10 @@ impl Poly {
 	/// This is the entry point for coefficients that cross a trust boundary
 	/// (deserialized, received from a peer, …). The accepted range covers both
 	/// standard representatives `[0, Q)` and signed representatives, and is
-	/// well inside the domain of every routine in this module, so a `Poly`
-	/// built here can be passed to any of them without overflow.
+	/// inside the domain of every **public** routine in this module, so a
+	/// `Poly` built here can be passed to any of them without overflow.
+	/// Routines with narrower domains (`shiftl`) are crate-private and never
+	/// receive boundary-validated data.
 	pub fn from_coeffs(coeffs: [i32; N]) -> Result<Poly, CoefficientOutOfRange> {
 		for (index, &value) in coeffs.iter().enumerate() {
 			if value <= -params::Q || value >= params::Q {
@@ -162,7 +179,14 @@ pub fn sub_ip(a: &mut Poly, b: &Poly) {
 ///
 /// Input coefficients must be less than `2^{31-D}` in absolute value,
 /// otherwise the shift overflows. Checked with `debug_assert!`.
-pub fn shiftl(a: &mut Poly) {
+///
+/// This bound is **narrower** than the `(-Q, Q)` range accepted by
+/// [`Poly::from_coeffs`], so this routine is deliberately `pub(crate)`: a
+/// polynomial that crossed the validated trust boundary must not reach it.
+/// The only caller is the signature verify path, which applies it to `t1`
+/// (the public high bits of the public key), whose coefficients are masked
+/// to 10 bits by [`t1_unpack`] — far below `2^{31-D}` — by construction.
+pub(crate) fn shiftl(a: &mut Poly) {
 	debug_assert!(
 		a.coeffs.iter().all(|&c| c.unsigned_abs() < 1 << (31 - params::D)),
 		"poly::shiftl precondition violated: |coefficient| >= 2^(31-D)"
@@ -819,6 +843,40 @@ mod tests {
 		for i in 0..N {
 			assert_eq!(poly.coeffs[i], original.coeffs[i] * (1 << params::D));
 		}
+	}
+
+	/// `shiftl`'s domain (`|c| < 2^(31-D)`) is narrower than the `(-Q, Q)`
+	/// range of the validated constructor, which is why it is `pub(crate)`
+	/// (see the module docs' `compile_fail` example). In-crate misuse must
+	/// still fail loudly wherever debug assertions are on.
+	#[test]
+	#[cfg(debug_assertions)]
+	#[should_panic(expected = "shiftl precondition violated")]
+	fn shiftl_debug_asserts_its_domain() {
+		let mut coeffs = [0i32; N];
+		// Accepted by the validated constructor, yet `(Q - 1) << D` overflows i32.
+		coeffs[0] = params::Q - 1;
+		let mut poly = Poly::from_coeffs(coeffs).expect("(-Q, Q) is accepted by from_coeffs");
+		shiftl(&mut poly);
+	}
+
+	/// The verify path feeds `t1_unpack` output into `shiftl`; the unpack
+	/// masks every coefficient to 10 bits, which must satisfy `shiftl`'s
+	/// domain. This pins the by-construction bound the crate-private
+	/// visibility relies on.
+	#[test]
+	fn t1_unpack_output_satisfies_shiftl_domain() {
+		// All-ones packed input maximizes every 10-bit coefficient.
+		let packed = [0xFFu8; 5 * N / 4];
+		let mut t1 = Poly::default();
+		t1_unpack(&mut t1, &packed);
+		for &c in t1.coeffs.iter() {
+			assert!((0..1 << 10).contains(&c), "t1_unpack out of 10-bit range: {c}");
+			assert!(c.unsigned_abs() < 1 << (31 - params::D), "outside shiftl domain: {c}");
+		}
+		// And the shift itself must be exact for the maximal value.
+		shiftl(&mut t1);
+		assert_eq!(t1.coeffs[0], ((1 << 10) - 1) << params::D);
 	}
 
 	#[test]

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -563,14 +563,19 @@ pub fn uniform_eta(output_polynomial: &mut Poly, seed: &[u8; params::CRHBYTES], 
 	let mut state = fips202::KeccakState::default();
 	fips202::shake256_stream_init(&mut state, seed, nonce);
 
-	// Fixed number of rounds to reduce timing variations
+	// Two blocks = 544 nibbles, each accepted with probability 15/16 (mean
+	// 510, sigma ~5.7), so collecting fewer than the N = 256 needed is a
+	// ~45-sigma event (< 2^-600): the retry branch below is never taken in
+	// practice and observed timing is constant. Even in principle, timing
+	// here depends only on rejection counts (nibble == 15), which are
+	// independent of the accepted values that form the key — the standard
+	// argument for rejection sampling from a seeded XOF. A fallback must
+	// still exist for exact sampling, hence the loop.
 	const FIXED_ROUNDS: usize = 2;
 	let mut shake_output_buffer = [[0u8; fips202::SHAKE256_RATE]; 1];
 	let mut temporary_coefficient_storage = [0i32; 1000]; // Temp storage for all extracted coeffs
 	let mut total_coefficients_collected = 0usize;
 
-	// In the extremely rare case that 2 rounds isn't enough, we keep going.
-	// The vast majority of cases will run this outer loop exactly once
 	while total_coefficients_collected < N {
 		// Always run exactly FIXED_ROUNDS iterations
 		for _round_number in 0..FIXED_ROUNDS {

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -705,11 +705,12 @@ pub(crate) fn eta_unpack(r: &mut Poly, a: &[u8]) -> bool {
 		r.coeffs[8 * i + 6] = params::ETA as i32 - r.coeffs[8 * i + 6];
 		r.coeffs[8 * i + 7] = params::ETA as i32 - r.coeffs[8 * i + 7];
 	}
-	// Canonicality sweep after the fact: branch-free over the whole
-	// polynomial, so honest keys (which always pass) take a data-independent
-	// path through this function.
+	// Canonicality sweep after the fact, accumulated with non-short-circuiting
+	// `&` (`Iterator::all` would exit at the first failure): the sweep always
+	// traverses the whole polynomial, so honest keys (which always pass) take
+	// a data-independent path through this function.
 	let eta = params::ETA as i32;
-	r.coeffs.iter().all(|&c| (-eta..=eta).contains(&c))
+	r.coeffs.iter().fold(true, |ok, &c| ok & (c >= -eta) & (c <= eta))
 }
 
 /// Bit-pack polynomial z with coefficients in [-(GAMMA1 - 1), GAMMA1 - 1].

--- a/dilithium/src/polyvec.rs
+++ b/dilithium/src/polyvec.rs
@@ -238,8 +238,11 @@ pub fn k_sub(w: &mut Polyveck, v: &Polyveck) {
 }
 
 /// Multiply vector of polynomials of Length K by 2^D without modular
-/// reduction. Assumes input coefficients to be less than 2^{32-D}.
-pub fn k_shiftl(v: &mut Polyveck) {
+/// reduction. Input coefficients must be less than 2^{31-D} in absolute
+/// value — narrower than the `(-Q, Q)` range accepted by
+/// [`Poly::from_coeffs`](crate::poly::Poly::from_coeffs) — so this routine
+/// is `pub(crate)`; see [`poly::shiftl`].
+pub(crate) fn k_shiftl(v: &mut Polyveck) {
 	for i in 0..K {
 		poly::shiftl(&mut v.vec[i]);
 	}

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -149,8 +149,7 @@ pub(crate) fn public_key_from_secret(
 	let mut s2 = Polyveck::default();
 	// Invariant: every secret coefficient must be in [-ETA, ETA]; `unpack_sk`
 	// reports non-canonical packed slots (see the doc comment above).
-	let s_in_range =
-		packing::unpack_sk(&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, sk);
+	let s_in_range = packing::unpack_sk(&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, sk);
 
 	// Same derivation as key generation.
 	let (t1, mut t0_derived) = derive_public_components(&rho, &s1, &s2);

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -111,8 +111,14 @@ pub fn keypair(
 ///
 /// Recomputes `t1` and `t0` from the secret key's `(rho, s1, s2)` exactly as
 /// [`keypair`] does, and packs `pk = (rho, t1)`. In addition to re-deriving
-/// the public key, this checks the two remaining packed-SK invariants:
+/// the public key, this checks the remaining packed-SK invariants:
 ///
+/// - the unpacked `s1` and `s2` coefficients must lie in `[-ETA, ETA]`. The packed encoding uses 3
+///   bits per coefficient decoded as `ETA - slot`, so with `ETA = 2` the slots 5..7 decode to
+///   -3..-5 — encodings key generation never emits. They cannot be caught by the algebraic checks
+///   below (an attacker recomputes `t0`/`tr`/pk *from* the oversized coefficients), yet such a key
+///   lies outside the ML-DSA-87 key distribution that the `BETA = TAU * ETA` rejection margin in
+///   [`signature`] is sized for,
 /// - the stored `t0` must equal the re-derived low bits of `A·s1 + s2`,
 /// - the stored `tr` must equal `SHAKE256(pk)`, and
 /// - the derived `t1` must not be all-zero, matching the degenerate-key rejection in [`verify`] and
@@ -141,7 +147,10 @@ pub(crate) fn public_key_from_secret(
 	let mut t0 = Polyveck::default();
 	let mut s1 = Polyvecl::default();
 	let mut s2 = Polyveck::default();
-	packing::unpack_sk(&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, sk);
+	// Invariant: every secret coefficient must be in [-ETA, ETA]; `unpack_sk`
+	// reports non-canonical packed slots (see the doc comment above).
+	let s_in_range =
+		packing::unpack_sk(&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, sk);
 
 	// Same derivation as key generation.
 	let (t1, mut t0_derived) = derive_public_components(&rho, &s1, &s2);
@@ -172,7 +181,7 @@ pub(crate) fn public_key_from_secret(
 	t0.zeroize();
 	t0_derived.zeroize();
 
-	if t0_consistent && tr_consistent && t1_nonzero {
+	if s_in_range && t0_consistent && tr_consistent && t1_nonzero {
 		Some(pk)
 	} else {
 		None
@@ -229,7 +238,11 @@ fn unpack_secret_key_for_signing(
 	let mut secret_poly_s1 = Polyvecl::default();
 	let mut secret_poly_s2 = Polyveck::default();
 
-	packing::unpack_sk(
+	// Every signing entry point receives key bytes that already passed the
+	// import validation (`SecretKey`'s storage is private and only filled by
+	// `generate`/`from_bytes`), so a non-canonical encoding here is a crate
+	// bug, not reachable attacker input.
+	let canonical = packing::unpack_sk(
 		&mut public_seed_rho,
 		&mut public_key_hash_tr,
 		&mut private_key_seed,
@@ -238,6 +251,7 @@ fn unpack_secret_key_for_signing(
 		&mut secret_poly_s2,
 		secret_key_bytes,
 	);
+	debug_assert!(canonical, "signing with a secret key that failed import validation");
 
 	// Convert secret polynomials to NTT domain for efficiency
 	polyvec::l_ntt(&mut secret_poly_s1);

--- a/dilithium/tests/import_stack_zeroization.rs
+++ b/dilithium/tests/import_stack_zeroization.rs
@@ -1,0 +1,131 @@
+//! Regression tests (security review): the key import/serialize paths must
+//! not leave plaintext copies of the secret key in dead stack memory.
+//!
+//! `Keypair::from_bytes` and `SecretKey::from_bytes` built a local
+//! `[u8; SECRETKEYBYTES]` copy of the secret key and "moved" it into the
+//! returned struct — but `[u8; N]` is `Copy`, so the local survived the move
+//! and was never zeroized. `Keypair::to_bytes` materialized a
+//! `self.secret.to_bytes()` temporary that was dropped unwiped. (Contrast
+//! `Keypair::generate`, which explicitly wipes its `sk` local.) Any of these
+//! leaves the full secret key readable in stale stack memory after the live
+//! `SecretKey` has been dropped and zeroized.
+//!
+//! Detection uses the same painted-stack technique as the crate's
+//! `stack_probe` example: run the operation on a dedicated sentinel-painted
+//! buffer via `psm::on_stack`, then scan the buffer — which we own, so the
+//! read is sound — for a distinctive window of the packed secret key. The
+//! caller-side result is wiped inside the probe, so any surviving match is a
+//! copy the library itself failed to clean up.
+//!
+//! The scan window is taken from the packed s1 region of the secret key:
+//! those bytes only ever appear in this packed form in full serialized-key
+//! copies (the unpacked polynomial representation is laid out differently),
+//! so a match cannot come from the legitimate, separately-zeroized unpacked
+//! intermediates.
+//!
+//! Only compiled for optimized builds (`cargo test --release`): unoptimized
+//! codegen materializes additional compiler-generated move temporaries for
+//! the large by-value key structs which no source-level fix can wipe, so a
+//! zero-copy assertion is only meaningful once those are elided.
+#![cfg(not(debug_assertions))]
+
+use qp_rusty_crystals_dilithium::ml_dsa_87::{Keypair, SecretKey, SECRETKEYBYTES};
+use std::alloc::{alloc, dealloc, Layout};
+use zeroize::Zeroize;
+
+const PAINT: u8 = 0xAA;
+// 4 MiB: comfortably above the keygen-scale derivation the import paths run.
+const STACK_BYTES: usize = 4 * 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// A distinctive 32-byte window from the packed s1 region of the secret key.
+/// SK layout: rho (32) || key (32) || tr (64) || s1 || s2 || t0; s1 starts at
+/// offset 128 and is high-entropy packed data for a random key.
+fn sk_pattern(sk_bytes: &[u8; SECRETKEYBYTES]) -> [u8; 32] {
+	let mut pattern = [0u8; 32];
+	pattern.copy_from_slice(&sk_bytes[128..160]);
+	pattern
+}
+
+#[test]
+fn key_import_and_serialize_leave_no_secret_copies_on_the_stack() {
+	let keypair = Keypair::generate((&mut [0x5Au8; 32]).into());
+	let kp_bytes = keypair.to_bytes();
+	let sk_bytes = keypair.secret.to_bytes();
+	let pattern = sk_pattern(&sk_bytes);
+
+	// Sanity: the technique detects an unwiped copy. A closure that
+	// deliberately leaves the secret key in a dead stack frame must be seen.
+	assert!(
+		probe_stack_for(&pattern, || {
+			let leaked: [u8; SECRETKEYBYTES] = sk_bytes;
+			core::hint::black_box(&leaked);
+		}),
+		"probe self-check: a deliberately leaked stack copy was not detected"
+	);
+
+	// Scenario A: Keypair::from_bytes. The imported keypair is wiped in place
+	// (through a reference, so the probe itself never moves the secret and
+	// cannot smear its own copies around); anything left afterwards is a copy
+	// the import path failed to wipe.
+	let keypair_import_leaked = probe_stack_for(&pattern, || {
+		let mut imported = Keypair::from_bytes(&kp_bytes);
+		if let Ok(kp) = imported.as_mut() {
+			kp.secret.zeroize();
+		}
+	});
+
+	// Scenario B: SecretKey::from_bytes, same contract.
+	let secret_key_import_leaked = probe_stack_for(&pattern, || {
+		let mut imported = SecretKey::from_bytes(&sk_bytes);
+		if let Ok(sk) = imported.as_mut() {
+			sk.zeroize();
+		}
+	});
+
+	// Scenario C: Keypair::to_bytes. The returned serialization necessarily
+	// contains the secret key; the caller wipes it, so any surviving match is
+	// an internal temporary the library dropped unwiped.
+	let serialize_leaked = probe_stack_for(&pattern, || {
+		let mut serialized = keypair.to_bytes();
+		serialized.zeroize();
+	});
+
+	assert!(
+		!keypair_import_leaked,
+		"Keypair::from_bytes left a plaintext secret key copy in stack memory"
+	);
+	assert!(
+		!secret_key_import_leaked,
+		"SecretKey::from_bytes left a plaintext secret key copy in stack memory"
+	);
+	assert!(
+		!serialize_leaked,
+		"Keypair::to_bytes left a plaintext secret key copy in stack memory"
+	);
+}

--- a/dilithium/tests/import_stack_zeroization.rs
+++ b/dilithium/tests/import_stack_zeroization.rs
@@ -14,8 +14,10 @@
 //! `stack_probe` example: run the operation on a dedicated sentinel-painted
 //! buffer via `psm::on_stack`, then scan the buffer — which we own, so the
 //! read is sound — for a distinctive window of the packed secret key. The
-//! caller-side result is wiped inside the probe, so any surviving match is a
-//! copy the library itself failed to clean up.
+//! import scenarios wipe the caller-side result in place; the serialize
+//! scenarios simply drop it, since `to_bytes` returns a self-wiping
+//! `Zeroizing` buffer. Any surviving match is a copy the library failed to
+//! clean up.
 //!
 //! The scan window is taken from the packed s1 region of the secret key:
 //! those bytes only ever appear in this packed form in full serialized-key
@@ -83,7 +85,7 @@ fn key_import_and_serialize_leave_no_secret_copies_on_the_stack() {
 	// deliberately leaves the secret key in a dead stack frame must be seen.
 	assert!(
 		probe_stack_for(&pattern, || {
-			let leaked: [u8; SECRETKEYBYTES] = sk_bytes;
+			let leaked: [u8; SECRETKEYBYTES] = *sk_bytes;
 			core::hint::black_box(&leaked);
 		}),
 		"probe self-check: a deliberately leaked stack copy was not detected"
@@ -94,7 +96,7 @@ fn key_import_and_serialize_leave_no_secret_copies_on_the_stack() {
 	// cannot smear its own copies around); anything left afterwards is a copy
 	// the import path failed to wipe.
 	let keypair_import_leaked = probe_stack_for(&pattern, || {
-		let mut imported = Keypair::from_bytes(&kp_bytes);
+		let mut imported = Keypair::from_bytes(kp_bytes.as_slice());
 		if let Ok(kp) = imported.as_mut() {
 			kp.secret.zeroize();
 		}
@@ -102,18 +104,26 @@ fn key_import_and_serialize_leave_no_secret_copies_on_the_stack() {
 
 	// Scenario B: SecretKey::from_bytes, same contract.
 	let secret_key_import_leaked = probe_stack_for(&pattern, || {
-		let mut imported = SecretKey::from_bytes(&sk_bytes);
+		let mut imported = SecretKey::from_bytes(sk_bytes.as_slice());
 		if let Ok(sk) = imported.as_mut() {
 			sk.zeroize();
 		}
 	});
 
 	// Scenario C: Keypair::to_bytes. The returned serialization necessarily
-	// contains the secret key; the caller wipes it, so any surviving match is
-	// an internal temporary the library dropped unwiped.
+	// contains the secret key, but it is `Zeroizing`, so simply dropping it
+	// — as a caller who forgets manual hygiene would — must leave nothing.
+	// Any surviving match is either an internal temporary the library
+	// dropped unwiped or a caller-side copy the API failed to self-wipe.
 	let serialize_leaked = probe_stack_for(&pattern, || {
-		let mut serialized = keypair.to_bytes();
-		serialized.zeroize();
+		let serialized = keypair.to_bytes();
+		core::hint::black_box(&serialized);
+	});
+
+	// Scenario D: SecretKey::to_bytes, same contract as C.
+	let sk_serialize_leaked = probe_stack_for(&pattern, || {
+		let serialized = keypair.secret.to_bytes();
+		core::hint::black_box(&serialized);
 	});
 
 	assert!(
@@ -127,5 +137,9 @@ fn key_import_and_serialize_leave_no_secret_copies_on_the_stack() {
 	assert!(
 		!serialize_leaked,
 		"Keypair::to_bytes left a plaintext secret key copy in stack memory"
+	);
+	assert!(
+		!sk_serialize_leaked,
+		"SecretKey::to_bytes left a plaintext secret key copy in stack memory"
 	);
 }

--- a/hdwallet/src/hderive.rs
+++ b/hdwallet/src/hderive.rs
@@ -12,9 +12,17 @@ pub enum Error {
 	NotHardened,
 	PathTooLong(usize),
 	PathTooDeep(usize),
+	InvalidSeedLength(usize),
 }
 
 const HARDENED_BIT: u32 = 1 << 31;
+
+/// Master-seed length bounds (bytes), per BIP32 (128..=512 bits). The
+/// higher-level wrappers always pass a fixed 64-byte BIP39 seed; this bound
+/// keeps the public low-level entrypoint from doing unbounded HMAC work over
+/// an attacker-sized buffer.
+pub const MIN_SEED_BYTES: usize = 16;
+pub const MAX_SEED_BYTES: usize = 64;
 
 /// Reject paths whose raw byte length or `/`-segment count exceed the workspace caps.
 /// Runs before any allocation so attacker-controlled paths cannot drive memory or CPU.
@@ -138,10 +146,19 @@ pub struct ExtendedPrivKey {
 
 impl ExtendedPrivKey {
 	/// Attempts to derive an extended private key from a path.
+	///
+	/// The path is parsed and validated first and the seed length is bounded
+	/// to [`MIN_SEED_BYTES`]`..=`[`MAX_SEED_BYTES`], so malformed requests are
+	/// rejected before any HMAC work is spent on the seed.
 	pub fn derive<Path>(seed: &[u8], path: Path) -> Result<ExtendedPrivKey, Error>
 	where
 		Path: IntoDerivationPath,
 	{
+		let path = path.into()?;
+		if seed.len() < MIN_SEED_BYTES || seed.len() > MAX_SEED_BYTES {
+			return Err(Error::InvalidSeedLength(seed.len()));
+		}
+
 		let mut hmac: Hmac<Sha512> =
 			Hmac::new_from_slice(b"Dilithium seed").expect("seed is always correct; qed");
 		hmac.update(seed);
@@ -154,7 +171,7 @@ impl ExtendedPrivKey {
 			chain_code: SensitiveBytes32::from(&mut chain_code.try_into().unwrap()),
 		};
 
-		for child in path.into()?.as_ref() {
+		for child in path.as_ref() {
 			sk = sk.child(*child)?;
 		}
 
@@ -282,5 +299,40 @@ mod tests {
 		}
 		// Beyond u32 entirely.
 		assert_eq!("4294967296'".parse::<ChildNumber>().unwrap_err(), Error::InvalidChildNumber);
+	}
+
+	// `derive` is a public entrypoint that may see attacker-controlled input.
+	// The seed must be bounded (BIP32-style 16..=64 bytes) so a caller cannot
+	// force linear HMAC work over an arbitrarily large buffer.
+	#[test]
+	fn seed_length_bounds_enforced() {
+		let path = "m/44'/60'/0'";
+		for ok_len in [16usize, 32, 64] {
+			assert!(
+				ExtendedPrivKey::derive(&vec![7u8; ok_len], path).is_ok(),
+				"seed of {ok_len} bytes must be accepted"
+			);
+		}
+		for bad_len in [0usize, 15, 65, 1 << 20] {
+			assert_eq!(
+				ExtendedPrivKey::derive(&vec![7u8; bad_len], path).unwrap_err(),
+				Error::InvalidSeedLength(bad_len),
+				"seed of {bad_len} bytes must be rejected"
+			);
+		}
+	}
+
+	// The path must be validated before any seed processing, so a malformed
+	// request fails on the cheap string parse rather than after doing HMAC
+	// work over the seed. Pinned observably: with a bad path AND a bad seed,
+	// the path error wins.
+	#[test]
+	fn invalid_path_rejected_before_seed_is_touched() {
+		let huge_seed = vec![7u8; 1 << 20];
+		assert_eq!(
+			ExtendedPrivKey::derive(&huge_seed, "not-a-path").unwrap_err(),
+			Error::InvalidDerivationPath,
+			"path validation must run (and fail) before the seed is processed"
+		);
 	}
 }

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -27,8 +27,9 @@
 //! Poseidon hashing, which is particularly well-suited for zero-knowledge proof systems.
 
 use qp_poseidon_core::{
-	hash_bytes, hash_to_bytes, hash_twice, Goldilocks,
+	hash_bytes, hash_to_bytes, hash_twice,
 	serialization::{bytes_to_digest_lossy, string_to_felts},
+	Goldilocks,
 };
 extern crate alloc;
 use alloc::vec::Vec;

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -27,7 +27,7 @@
 //! Poseidon hashing, which is particularly well-suited for zero-knowledge proof systems.
 
 use qp_poseidon_core::{
-	hash_bytes, hash_to_bytes, hash_twice,
+	hash_bytes, hash_to_bytes, hash_twice, Goldilocks,
 	serialization::{bytes_to_digest_lossy, string_to_felts},
 };
 extern crate alloc;
@@ -36,6 +36,23 @@ use qp_rusty_crystals_dilithium::SensitiveBytes32;
 
 /// Salt used when deriving wormhole addresses.
 pub const ADDRESS_SALT: &str = "wormhole";
+
+/// Overwrite field elements holding secret material with zeros.
+///
+/// `Goldilocks` is a foreign type without a `Zeroize` impl, so the `zeroize`
+/// crate cannot wipe it directly. A plain `*felt = Default::default()` loop is
+/// a dead store the optimizer may elide (the buffer is freed right after), so
+/// the writes go through `write_volatile`, followed by a compiler fence —
+/// the same construction `zeroize` itself uses.
+fn zeroize_felts(felts: &mut [Goldilocks]) {
+	for felt in felts.iter_mut() {
+		// SAFETY: `felt` is a valid, aligned, exclusive reference; writing a
+		// plain `Copy` value through it is always sound. Volatile only opts
+		// the store out of dead-store elimination.
+		unsafe { core::ptr::write_volatile(felt, Goldilocks::default()) };
+	}
+	core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+}
 
 /// A struct representing a wormhole identity pair: address + secret.
 ///
@@ -106,7 +123,6 @@ impl WormholePair {
 	/// The secret parameter is zeroized before returning.
 	fn generate_pair_from_secret(secret: SensitiveBytes32) -> WormholePair {
 		let mut secret_bytes = secret.into_bytes();
-		let mut preimage_felts = Vec::new();
 		let salt_felt = string_to_felts(ADDRESS_SALT);
 		// Encode the 32-byte secret as 4 felts via the 8-bytes/felt `bytes_to_digest_lossy`.
 		// This encoding is non-injective (limbs ≥ the Goldilocks prime are reduced),
@@ -115,6 +131,9 @@ impl WormholePair {
 		// it cannot forge another user's address without their secret. The same
 		// encoding is used when proving, so derivation stays consistent.
 		let mut secret_felt = bytes_to_digest_lossy(&secret_bytes);
+		// Exact capacity: growing the vector after the secret felts are in it
+		// would reallocate and free a block still holding the secret.
+		let mut preimage_felts = Vec::with_capacity(salt_felt.len() + secret_felt.len());
 		preimage_felts.extend_from_slice(&salt_felt);
 		preimage_felts.extend_from_slice(&secret_felt);
 		let inner_hash = hash_to_bytes(&preimage_felts);
@@ -129,11 +148,11 @@ impl WormholePair {
 			secret: SensitiveBytes32::new(&mut secret_bytes),
 		};
 
-		// Manually clear intermediate sensitive data
-		for elem in secret_felt.iter_mut() {
-			*elem = Default::default();
-		}
-		preimage_felts.clear();
+		// Wipe the felt-encoded copies of the secret before their backing
+		// memory is released: `clear()`/drop alone would hand the allocator a
+		// block that still contains the secret limbs.
+		zeroize_felts(&mut secret_felt);
+		zeroize_felts(&mut preimage_felts);
 
 		result
 	}

--- a/hdwallet/tests/wormhole_zeroization.rs
+++ b/hdwallet/tests/wormhole_zeroization.rs
@@ -1,0 +1,67 @@
+//! Regression test (security review): wormhole address derivation must never
+//! free heap memory that still contains the secret.
+//!
+//! `generate_pair_from_secret` encodes the secret as Goldilocks felts and
+//! copies them into a heap-backed `Vec` preimage for Poseidon hashing. That
+//! vector used to be `clear()`ed — which resets the length but does not touch
+//! the backing allocation — so the felt-encoded secret survived in freed heap
+//! memory after the pair's own zeroizing wrappers had done their job.
+//!
+//! The test installs a global allocator that scans every block for the secret
+//! pattern at `dealloc` time (the block is still valid inside the hook, so the
+//! scan is sound) and asserts that no secret-bearing block is ever freed while
+//! derivation runs. This file contains exactly one test so no unrelated
+//! concurrent allocations can race the scanner.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::alloc::{GlobalAlloc, Layout, System};
+
+use qp_rusty_crystals_hdwallet::wormhole::WormholePair;
+
+/// Distinctive 32-byte secret. Each 8-byte little-endian limb is below the
+/// Goldilocks prime (high byte is ASCII < 0x80), so `bytes_to_digest_lossy`
+/// stores the limbs verbatim and the felt buffer contains these exact bytes.
+const SECRET_PATTERN: [u8; 32] = *b"wormhole-heap-zeroize-pattern-32";
+
+static SCANNING: AtomicBool = AtomicBool::new(false);
+static SECRET_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+
+struct SecretScanningAllocator;
+
+unsafe impl GlobalAlloc for SecretScanningAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		if SCANNING.load(Ordering::SeqCst) && layout.size() >= SECRET_PATTERN.len() {
+			let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+			if block.windows(SECRET_PATTERN.len()).any(|w| w == SECRET_PATTERN) {
+				SECRET_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+			}
+		}
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: SecretScanningAllocator = SecretScanningAllocator;
+
+#[test]
+fn wormhole_derivation_never_frees_heap_memory_containing_the_secret() {
+	let mut secret = SECRET_PATTERN;
+
+	SCANNING.store(true, Ordering::SeqCst);
+	let pair = WormholePair::verify([0u8; 32], (&mut secret).into());
+	SCANNING.store(false, Ordering::SeqCst);
+
+	assert!(
+		!SECRET_FREED_UNCLEARED.load(Ordering::SeqCst),
+		"wormhole derivation freed a heap block still containing the secret \
+		 (felt-encoded preimage); the secret grants control of the derived \
+		 address, so it must be zeroized before its memory is released"
+	);
+
+	// Sanity: the pattern secret does not verify against a zero address.
+	assert!(!pair);
+}

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -56,7 +56,11 @@
 
 use alloc::vec::Vec;
 
-use qp_rusty_crystals_dilithium::fips202;
+use qp_rusty_crystals_dilithium::{
+	fips202,
+	params::{K, L},
+};
+use zeroize::Zeroizing;
 
 use crate::keys::{PrivateKeyShare, PublicKey, TR_SIZE};
 
@@ -126,7 +130,12 @@ pub(crate) fn hash_secret_shares(master_share: &PrivateKeyShare) -> [u8; 64] {
 	fips202::shake256_absorb(&mut state, b"threshold-share-digest-v1");
 	fips202::shake256_absorb(&mut state, &master_share.party_id().to_le_bytes());
 
-	let mut buf: Vec<u8> = Vec::new();
+	// The linearization buffer holds raw secret share coefficients, so it must
+	// be a zeroizing container (a plain Vec freed after `clear()` leaves the
+	// coefficients in allocator memory) and it must be allocated at full size
+	// up front (growing mid-fill would free an unwiped intermediate block).
+	const SUBSET_BYTES: usize = 2 + (L + K) * 256 * core::mem::size_of::<i32>();
+	let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(Vec::with_capacity(SUBSET_BYTES));
 	for (subset_mask, share_data) in master_share.shares() {
 		buf.clear();
 		buf.extend_from_slice(&subset_mask.to_le_bytes());

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -12,7 +12,10 @@
 //! 2. Parties run full DKG using these contributions for randomness
 //! 3. The resulting shares are stored (cannot be recomputed on-the-fly)
 //! 4. There is one canonical derived key per `(master_key, tweak)`: the key produced by the single
-//!    DKG run performed for that tweak, then stored and looked up by [`DerivedKeyId`]
+//!    DKG run performed for that tweak, then stored and looked up by [`DerivedKeyId`], which binds
+//!    the domain and tweak **plus the TR hash of that run's public key** — because a different DKG
+//!    attempt for the same tweak produces a different key (see below), the identifier must pin
+//!    down *which* attempt's output it refers to
 //!
 //! # The derived key is NOT recomputable
 //!
@@ -38,7 +41,10 @@
 //! the MPC nodes agreed on *which* derived key a request refers to: the
 //! contract stores the derived public key produced by the canonical DKG run,
 //! keyed by the same tweak the nodes use to derive their contributions and
-//! look up their stored shares.
+//! look up their stored shares. Node-side storage must additionally be keyed
+//! by the registered key itself (via [`DerivedKeyId`]'s `public_key_hash`), so
+//! that shares from a superseded or concurrent DKG attempt can never be
+//! confused with the canonical run's shares.
 //!
 //! # Security
 //!
@@ -52,7 +58,7 @@ use alloc::vec::Vec;
 
 use qp_rusty_crystals_dilithium::fips202;
 
-use crate::keys::PrivateKeyShare;
+use crate::keys::{PrivateKeyShare, PublicKey, TR_SIZE};
 
 /// Domain separator for DKG contribution derivation.
 const DKG_CONTRIBUTION_DOMAIN: &[u8] = b"near-mpc-dilithium-dkg-contribution-v2";
@@ -145,20 +151,52 @@ pub(crate) fn hash_secret_shares(master_share: &PrivateKeyShare) -> [u8; 64] {
 
 /// Identifier for a derived key, used for storage lookup.
 ///
-/// This uniquely identifies a derived key by the domain and tweak.
-/// MPC nodes use this to look up stored derived shares.
+/// This uniquely identifies one *specific DKG output*: the domain and tweak
+/// select which derived key a request refers to, and `public_key_hash` binds
+/// the identifier to the concrete key produced by one DKG session. MPC nodes
+/// use this to look up stored derived shares.
+///
+/// The public-key binding is load-bearing. Derived keys are **not**
+/// recomputable (see the module docs): every DKG attempt for the same
+/// `(master_key, tweak)` mixes a fresh `session_nonce` and yields a different
+/// key, so `(domain_id, tweak)` alone does not identify a key — it identifies
+/// a *family* of possible keys, one per DKG attempt. Without the binding, a
+/// repeated-request or retry race can store one session's shares under an
+/// identifier that the rest of the system associates with a different
+/// session's public key, leaving nodes disagreeing or signing under an
+/// unregistered key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DerivedKeyId {
 	/// The domain ID (identifies the master key)
 	pub domain_id: u64,
 	/// The derivation tweak (derived from account + path by the caller)
 	pub tweak: [u8; 32],
+	/// TR hash (`SHAKE256` of the packed key, as in FIPS 204) of the derived
+	/// public key produced by the canonical DKG run for this `(domain, tweak)`.
+	/// Binds the identifier to that run's non-recomputable output.
+	pub public_key_hash: [u8; TR_SIZE],
 }
 
 impl DerivedKeyId {
-	/// Create a new derived key identifier.
-	pub fn new(domain_id: u64, tweak: [u8; 32]) -> Self {
-		Self { domain_id, tweak }
+	/// Create an identifier for a derived key produced by a completed DKG run.
+	///
+	/// `derived_public_key` is the DKG output's public key (e.g.
+	/// [`DkgOutput::public_key`](crate::keygen::dkg::DkgOutput)); its TR hash
+	/// becomes the session binding.
+	pub fn new(domain_id: u64, tweak: [u8; 32], derived_public_key: &PublicKey) -> Self {
+		Self { domain_id, tweak, public_key_hash: *derived_public_key.tr() }
+	}
+
+	/// Create an identifier from a stored/registered public-key hash.
+	///
+	/// For lookups where the full public key is not at hand but its TR hash
+	/// was recorded (e.g. alongside the contract-registered derived key).
+	pub fn from_key_hash(
+		domain_id: u64,
+		tweak: [u8; 32],
+		public_key_hash: [u8; TR_SIZE],
+	) -> Self {
+		Self { domain_id, tweak, public_key_hash }
 	}
 }
 
@@ -293,11 +331,12 @@ mod tests {
 	#[test]
 	fn test_derived_key_id_new() {
 		let tweak = test_tweak("alice.near", "ethereum");
-		let id1 = DerivedKeyId::new(5, tweak);
-		let id2 = DerivedKeyId::new(5, tweak);
+		let key_hash = [0x5Au8; TR_SIZE];
+		let id1 = DerivedKeyId::from_key_hash(5, tweak, key_hash);
+		let id2 = DerivedKeyId::from_key_hash(5, tweak, key_hash);
 		assert_eq!(id1, id2);
 
-		let id3 = DerivedKeyId::new(6, tweak);
+		let id3 = DerivedKeyId::from_key_hash(6, tweak, key_hash);
 		assert_ne!(id1, id3); // Different domain
 	}
 
@@ -305,9 +344,34 @@ mod tests {
 	fn test_derived_key_id_different_tweaks() {
 		let tweak1 = test_tweak("alice.near", "ethereum");
 		let tweak2 = test_tweak("bob.near", "ethereum");
+		let key_hash = [0x5Au8; TR_SIZE];
 
-		let id1 = DerivedKeyId::new(5, tweak1);
-		let id2 = DerivedKeyId::new(5, tweak2);
+		let id1 = DerivedKeyId::from_key_hash(5, tweak1, key_hash);
+		let id2 = DerivedKeyId::from_key_hash(5, tweak2, key_hash);
 		assert_ne!(id1, id2);
+	}
+
+	#[test]
+	fn test_derived_key_id_binds_derived_key() {
+		// Same (domain, tweak), different DKG outputs: the IDs must differ,
+		// and `new` must agree with `from_key_hash` on the TR binding.
+		let tweak = test_tweak("alice.near", "ethereum");
+		let pk_a = crate::keygen::generate_with_dealer(
+			&[3u8; 32],
+			crate::ThresholdConfig::new(2, 3).unwrap(),
+		)
+		.unwrap()
+		.0;
+		let pk_b = crate::keygen::generate_with_dealer(
+			&[4u8; 32],
+			crate::ThresholdConfig::new(2, 3).unwrap(),
+		)
+		.unwrap()
+		.0;
+
+		let id_a = DerivedKeyId::new(5, tweak, &pk_a);
+		let id_b = DerivedKeyId::new(5, tweak, &pk_b);
+		assert_ne!(id_a, id_b, "different DKG outputs must not collide");
+		assert_eq!(id_a, DerivedKeyId::from_key_hash(5, tweak, *pk_a.tr()));
 	}
 }

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -14,8 +14,8 @@
 //! 4. There is one canonical derived key per `(master_key, tweak)`: the key produced by the single
 //!    DKG run performed for that tweak, then stored and looked up by [`DerivedKeyId`], which binds
 //!    the domain and tweak **plus the TR hash of that run's public key** — because a different DKG
-//!    attempt for the same tweak produces a different key (see below), the identifier must pin
-//!    down *which* attempt's output it refers to
+//!    attempt for the same tweak produces a different key (see below), the identifier must pin down
+//!    *which* attempt's output it refers to
 //!
 //! # The derived key is NOT recomputable
 //!
@@ -200,11 +200,7 @@ impl DerivedKeyId {
 	///
 	/// For lookups where the full public key is not at hand but its TR hash
 	/// was recorded (e.g. alongside the contract-registered derived key).
-	pub fn from_key_hash(
-		domain_id: u64,
-		tweak: [u8; 32],
-		public_key_hash: [u8; TR_SIZE],
-	) -> Self {
+	pub fn from_key_hash(domain_id: u64, tweak: [u8; 32], public_key_hash: [u8; TR_SIZE]) -> Self {
 		Self { domain_id, tweak, public_key_hash }
 	}
 }

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -58,7 +58,7 @@ use alloc::vec::Vec;
 
 use qp_rusty_crystals_dilithium::{
 	fips202,
-	params::{K, L},
+	params::{K, L, N},
 };
 use zeroize::Zeroizing;
 
@@ -134,7 +134,7 @@ pub(crate) fn hash_secret_shares(master_share: &PrivateKeyShare) -> [u8; 64] {
 	// be a zeroizing container (a plain Vec freed after `clear()` leaves the
 	// coefficients in allocator memory) and it must be allocated at full size
 	// up front (growing mid-fill would free an unwiped intermediate block).
-	const SUBSET_BYTES: usize = 2 + (L + K) * 256 * core::mem::size_of::<i32>();
+	const SUBSET_BYTES: usize = 2 + (L + K) * N as usize * core::mem::size_of::<i32>();
 	let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(Vec::with_capacity(SUBSET_BYTES));
 	for (subset_mask, share_data) in master_share.shares() {
 		buf.clear();

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -257,7 +257,7 @@ type ThresholdSharesResult = (
 
 /// Generate threshold shares for all subset combinations.
 fn generate_threshold_shares(
-	state: &mut fips202::KeccakState,
+	state: &mut fips202::Shake256State,
 	threshold: u32,
 	parties: u32,
 ) -> ThresholdResult<ThresholdSharesResult> {

--- a/threshold/src/keygen/dkg/mod.rs
+++ b/threshold/src/keygen/dkg/mod.rs
@@ -200,11 +200,15 @@ mod protocol;
 mod state;
 mod types;
 
-// Re-export public types
+// Re-export public types.
+//
+// The quorum predicate `all_broadcasts_received` is deliberately not
+// re-exported: it takes a raw participant slice and returns "complete" for an
+// empty list (vacuous truth), which is only sound because every in-crate
+// caller passes a `DkgConfig`-validated, non-empty list. See the invariants
+// section of `DkgConfig`'s docs, which pins this with a compile_fail test.
 pub use protocol::{run_local_dkg, Dkg, DkgAction, DkgError};
-pub use state::{
-	all_broadcasts_received, all_private_messages_received, DkgOutput, DkgPhase, DkgState,
-};
+pub use state::{all_private_messages_received, DkgOutput, DkgPhase, DkgState};
 pub use types::{
 	compute_dkg_ssid,
 	compute_partial_output_hash,

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -516,9 +516,9 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// Using a counter, timestamp, or random value from the transport layer is acceptable.
 	pub fn new(config: DkgConfig<S>, seed: [u8; 32], session_nonce: &[u8; 32]) -> Self {
 		let ssid = compute_dkg_ssid(
-			config.threshold_config.threshold(),
-			config.threshold_config.total_parties(),
-			&config.all_participants,
+			config.threshold(),
+			config.total_parties(),
+			config.all_participants(),
 			session_nonce,
 		);
 		Self {
@@ -960,9 +960,9 @@ impl<S: TranscriptSigner> Dkg<S> {
 		// Derive all randomness from the master seed
 		let leader_subsets = config.my_leader_subsets();
 		let (my_randomness, my_shared_secrets) =
-			derive_round1_randomness(&self.seed, &self.ssid, config.my_party_id, &leader_subsets);
+			derive_round1_randomness(&self.seed, &self.ssid, config.my_party_id(), &leader_subsets);
 
-		let my_commitment = h_commit(&self.ssid, config.my_party_id, &my_randomness);
+		let my_commitment = h_commit(&self.ssid, config.my_party_id(), &my_randomness);
 
 		// Transition to Round1 by setting fields directly
 		self.state.phase = DkgPhase::Round1;
@@ -1055,7 +1055,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 			let broadcast = Round1Broadcast {
 				ssid: self.ssid,
-				party_id: config.my_party_id,
+				party_id: config.my_party_id(),
 				commitment: my_commitment,
 			};
 			let msg = DkgMessage::Round1Broadcast(broadcast);
@@ -1075,10 +1075,10 @@ impl<S: TranscriptSigner> Dkg<S> {
 			for (&subset, &secret) in my_shared_secrets {
 				let parties = config.get_parties_in_subset(subset);
 				for &party in &parties {
-					if party != config.my_party_id {
+					if party != config.my_party_id() {
 						let private = Round1Private {
 							ssid: self.ssid,
-							from_party_id: config.my_party_id,
+							from_party_id: config.my_party_id(),
 							subset_mask: subset,
 							shared_secret: secret,
 						};
@@ -1115,8 +1115,8 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 		let all_broadcasts = all_broadcasts_received(
 			round1_broadcasts,
-			&config.all_participants,
-			config.my_party_id,
+			config.all_participants(),
+			config.my_party_id(),
 		);
 		let my_subsets = config.my_subsets();
 		let all_privates =
@@ -1176,7 +1176,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 			let broadcast = Round2Broadcast {
 				ssid: self.ssid,
-				party_id: config.my_party_id,
+				party_id: config.my_party_id(),
 				randomness: my_randomness,
 			};
 			let msg = DkgMessage::Round2Broadcast(broadcast);
@@ -1200,8 +1200,8 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 		let all_broadcasts = all_broadcasts_received(
 			round2_broadcasts,
-			&config.all_participants,
-			config.my_party_id,
+			config.all_participants(),
+			config.my_party_id(),
 		);
 
 		if all_broadcasts {
@@ -1225,7 +1225,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 	fn transition_to_round3(&mut self) -> Result<(), DkgError> {
 		let config = self.state.expect_round2()?;
-		let my_party_id = config.my_party_id; // Copy before mutable borrows
+		let my_party_id = config.my_party_id(); // Copy before mutable borrows
 		let my_randomness = self
 			.state
 			.my_randomness
@@ -1307,7 +1307,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 			let broadcast = Round3Broadcast {
 				ssid: self.ssid,
-				party_id: config.my_party_id,
+				party_id: config.my_party_id(),
 				partial_pk_commitments: my_pk_commitments.clone(),
 			};
 			let msg = DkgMessage::Round3Broadcast(broadcast);
@@ -1326,8 +1326,8 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 		let all_broadcasts = all_broadcasts_received(
 			round3_broadcasts,
-			&config.all_participants,
-			config.my_party_id,
+			config.all_participants(),
+			config.my_party_id(),
 		);
 
 		if all_broadcasts {
@@ -1340,7 +1340,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 	fn transition_to_round4(&mut self) -> Result<(), DkgError> {
 		let config = self.state.expect_round3()?;
-		let my_party_id = config.my_party_id; // Copy before mutable borrows
+		let my_party_id = config.my_party_id(); // Copy before mutable borrows
 		let my_pk_commitments = self
 			.state
 			.my_pk_commitments
@@ -1399,8 +1399,8 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 		let all_broadcasts = all_broadcasts_received(
 			round4_broadcasts,
-			&config.all_participants,
-			config.my_party_id,
+			config.all_participants(),
+			config.my_party_id(),
 		);
 
 		if all_broadcasts {
@@ -1550,7 +1550,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 			})?;
 
 			// Skip if we're the leader for this subset
-			if leader_id == config.my_party_id {
+			if leader_id == config.my_party_id() {
 				continue;
 			}
 
@@ -1619,11 +1619,11 @@ impl<S: TranscriptSigner> Dkg<S> {
 		);
 		let partial_output_hash = compute_partial_output_hash(my_partial_pks);
 		let signing_message = compute_signing_message(&transcript_hash, &partial_output_hash);
-		let signature = config.my_signer.sign(&signing_message);
+		let signature = config.signer().sign(&signing_message);
 
 		Ok(Round4Broadcast {
 			ssid: self.ssid,
-			party_id: config.my_party_id,
+			party_id: config.my_party_id(),
 			partial_public_keys: my_partial_pks.clone(),
 			transcript_signature: signature.as_ref().to_vec(),
 		})
@@ -1642,11 +1642,12 @@ fn compute_global_randomness<S: TranscriptSigner>(
 	received_broadcasts: &BTreeMap<ParticipantId, Round2Broadcast>,
 	my_randomness: [u8; RANDOMNESS_SIZE],
 ) -> (Vec<u8>, Round2Broadcast) {
+	let my_party_id = config.my_party_id();
 	let my_broadcast =
-		Round2Broadcast { ssid: *ssid, party_id: config.my_party_id, randomness: my_randomness };
+		Round2Broadcast { ssid: *ssid, party_id: my_party_id, randomness: my_randomness };
 
 	let mut all_randomness: Vec<_> = received_broadcasts.iter().collect();
-	all_randomness.push((&config.my_party_id, &my_broadcast));
+	all_randomness.push((&my_party_id, &my_broadcast));
 	all_randomness.sort_by_key(|(id, _)| *id);
 
 	let mut global_randomness = Vec::with_capacity(all_randomness.len() * RANDOMNESS_SIZE);
@@ -1683,7 +1684,7 @@ fn compute_my_contributions<S: TranscriptSigner>(
 			let contribution = derive_subset_contribution(&seed);
 			let t = compute_partial_pk_t(rho, &contribution.s1, &contribution.s2);
 			let partial_pk = PartialPublicKey { subset_mask: subset, t };
-			let pk_commitment = h_commit_pk(ssid, config.my_party_id, subset, &partial_pk);
+			let pk_commitment = h_commit_pk(ssid, config.my_party_id(), subset, &partial_pk);
 
 			my_contributions.insert(subset, contribution);
 			my_partial_pks.insert(subset, partial_pk);
@@ -1806,7 +1807,7 @@ fn verify_party_broadcast<S: TranscriptSigner>(
 	let partial_output_hash = compute_partial_output_hash(&broadcast.partial_public_keys);
 	let signing_message = compute_signing_message(transcript_hash, &partial_output_hash);
 
-	let public_key = config.participant_public_keys.get(&party_id).ok_or_else(|| {
+	let public_key = config.participant_public_keys().get(&party_id).ok_or_else(|| {
 		DkgError::MissingData(format!("missing public key for party {}", party_id))
 	})?;
 
@@ -1885,7 +1886,7 @@ fn build_private_share<S: TranscriptSigner>(
 	rho: &[u8; 32],
 	public_key: &PublicKey,
 ) -> Result<PrivateKeyShare, DkgError> {
-	let dkg_participants = ParticipantList::new(&config.all_participants)
+	let dkg_participants = ParticipantList::new(config.all_participants())
 		.ok_or_else(|| DkgError::InternalError("invalid participants".into()))?;
 
 	let mut combined_shares: BTreeMap<SubsetMask, SecretShareData> = BTreeMap::new();
@@ -1911,7 +1912,7 @@ fn build_private_share<S: TranscriptSigner>(
 		let mut h = fips202::KeccakState::default();
 		fips202::shake256_absorb(&mut h, b"dkg-party-key-v2");
 		fips202::shake256_absorb(&mut h, rho);
-		fips202::shake256_absorb(&mut h, &config.my_party_id.to_le_bytes());
+		fips202::shake256_absorb(&mut h, &config.my_party_id().to_le_bytes());
 		// The linearization buffer holds raw secret share coefficients, so it
 		// must be a zeroizing container (a plain Vec freed after `clear()`
 		// leaves the coefficients in allocator memory) and it must be allocated
@@ -1943,7 +1944,7 @@ fn build_private_share<S: TranscriptSigner>(
 	let tr = *public_key.tr();
 
 	Ok(PrivateKeyShare::new(
-		config.my_party_id,
+		config.my_party_id(),
 		config.total_parties(),
 		config.threshold(),
 		party_key,

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -547,8 +547,25 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// # Returns
 	/// * `Ok(DkgAction)` - The action to perform
 	/// * `Err(DkgError)` - If the protocol encounters an error
+	/// Pop the next queued Round 1 private without leaving K_S behind.
+	///
+	/// `Vec::pop` alone moves the element out but leaves its bytes intact in
+	/// the buffer beyond the shrunken length, where the drop-time wipe (which
+	/// only covers live elements) cannot reach them. Clone the element out and
+	/// wipe the slot in place before shrinking.
+	fn pop_pending_private(&mut self) -> Option<(ParticipantId, Round1Private)> {
+		let (to, private) = {
+			let (to, slot) = self.pending_privates.last_mut()?;
+			let out = (*to, slot.clone());
+			slot.zeroize();
+			out
+		};
+		self.pending_privates.pop();
+		Some((to, private))
+	}
+
 	pub fn poke(&mut self) -> Result<DkgAction, DkgError> {
-		if let Some((to, private)) = self.pending_privates.pop() {
+		if let Some((to, private)) = self.pop_pending_private() {
 			return serialize_round1_private(to, private);
 		}
 
@@ -1001,9 +1018,13 @@ impl<S: TranscriptSigner> Dkg<S> {
 			}
 		}
 
-		// Drain buffered Round 1 private messages with validation
-		let buffered_privates = self.message_buffer.take_round1_privates();
-		for ((from_party_id, subset_mask), private) in buffered_privates {
+		// Drain buffered Round 1 private messages with validation. Iterate by
+		// mutable reference rather than by value: consuming the map would move
+		// each Copy `Round1Private` out while leaving its K_S bytes intact in
+		// the freed map nodes. Every entry — including ones discarded by
+		// validation — is wiped in place before the map is dropped.
+		let mut buffered_privates = self.message_buffer.take_round1_privates();
+		for (&(from_party_id, subset_mask), private) in buffered_privates.iter_mut() {
 			// Validate subset_mask is valid
 			if !config.is_valid_subset(subset_mask) {
 				warn!(
@@ -1037,6 +1058,9 @@ impl<S: TranscriptSigner> Dkg<S> {
 				.get_or_insert_with(BTreeMap::new)
 				.entry(subset_mask)
 				.or_insert(private.shared_secret);
+		}
+		for private in buffered_privates.values_mut() {
+			private.zeroize();
 		}
 
 		Ok(())
@@ -1091,7 +1115,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 			self.state.privates_sent = true;
 
-			if let Some((to, private)) = self.pending_privates.pop() {
+			if let Some((to, private)) = self.pop_pending_private() {
 				return serialize_round1_private(to, private);
 			}
 		}
@@ -1139,9 +1163,15 @@ impl<S: TranscriptSigner> Dkg<S> {
 			.my_shared_secrets
 			.take()
 			.ok_or_else(|| DkgError::InvalidState("Round1 but no my_shared_secrets".into()))?;
-		if let Some(received) = self.state.received_shared_secrets.take() {
-			for (subset, secret) in received {
-				combined_secrets.insert(subset, secret);
+		if let Some(mut received) = self.state.received_shared_secrets.take() {
+			// K_S is a Copy `[u8; 32]`: consuming the map would move each
+			// secret out while leaving its bytes intact in the freed map
+			// nodes, beyond the reach of `DkgState::zeroize` (the field is
+			// already None by the time it runs). Copy the secrets out and
+			// wipe each node in place before the map is dropped.
+			for (&subset, secret) in received.iter_mut() {
+				combined_secrets.insert(subset, *secret);
+				secret.zeroize();
 			}
 		}
 

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -11,7 +11,7 @@ use alloc::{
 use core::{fmt, mem};
 
 use log::warn;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
 	config::ThresholdConfig,
@@ -66,6 +66,26 @@ fn deserialize_message(data: &[u8]) -> Result<DkgMessage, String> {
 		return Err(format!("Message size {} exceeds maximum {}", data.len(), MAX_DKG_MESSAGE_SIZE));
 	}
 	borsh::from_slice(data).map_err(|e| e.to_string())
+}
+
+/// Serialize a queued Round 1 private message into a self-wiping transport buffer.
+///
+/// The frame carries the secret K_S, so two properties matter beyond plain
+/// `borsh::to_vec`:
+/// - the buffer is allocated at its exact final size before serialization —
+///   letting borsh grow a `Vec` incrementally frees intermediate blocks that
+///   already contain a prefix of the secret payload;
+/// - the buffer is [`Zeroizing`], so it is wiped when the caller drops it
+///   after handing the frame to the transport.
+fn serialize_round1_private(
+	to: ParticipantId,
+	private: Round1Private,
+) -> Result<DkgAction, DkgError> {
+	let msg = DkgMessage::Round1Private(private);
+	let len = borsh::object_length(&msg).map_err(|e| DkgError::InternalError(e.to_string()))?;
+	let mut data = Zeroizing::new(Vec::with_capacity(len));
+	borsh::to_writer(&mut *data, &msg).map_err(|e| DkgError::InternalError(e.to_string()))?;
+	Ok(DkgAction::SendPrivate(to, data))
 }
 
 // ============================================================================
@@ -211,7 +231,12 @@ pub enum DkgAction {
 	///
 	/// This is used in Round 1 to distribute the per-subset secret K_S to subset members.
 	/// Without proper channel security, the threshold scheme's security is compromised.
-	SendPrivate(ParticipantId, Vec<u8>),
+	///
+	/// The payload is [`Zeroizing`] because the serialized bytes contain K_S:
+	/// once the caller has handed the frame to the transport and drops this
+	/// value, the buffer is wiped instead of leaving key material in freed
+	/// heap memory.
+	SendPrivate(ParticipantId, Zeroizing<Vec<u8>>),
 	/// DKG is complete, return the output.
 	Return(Box<DkgOutput>),
 }
@@ -524,9 +549,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// * `Err(DkgError)` - If the protocol encounters an error
 	pub fn poke(&mut self) -> Result<DkgAction, DkgError> {
 		if let Some((to, private)) = self.pending_privates.pop() {
-			let data = borsh::to_vec(&DkgMessage::Round1Private(private))
-				.map_err(|e| DkgError::InternalError(e.to_string()))?;
-			return Ok(DkgAction::SendPrivate(to, data));
+			return serialize_round1_private(to, private);
 		}
 
 		match self.state.phase {
@@ -599,6 +622,13 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// * `Ok(())` - Message was processed, buffered, or legitimately ignored
 	/// * `Err(_)` - Message was malformed and could not be deserialized
 	pub fn message(&mut self, from: ParticipantId, data: Vec<u8>) -> Result<(), DkgError> {
+		// Round 1 private frames carry the serialized secret K_S. Taking
+		// ownership into a zeroizing wrapper wipes the transport bytes on every
+		// return path, instead of freeing a heap block that still contains key
+		// material. (Broadcast frames are public; wiping them too costs one
+		// memset.)
+		let data = Zeroizing::new(data);
+
 		// Validate sender is a known participant to prevent quorum inflation attacks
 		if let Some(participants) = self.state.all_participants() {
 			if !participants.contains(&from) {
@@ -1062,9 +1092,7 @@ impl<S: TranscriptSigner> Dkg<S> {
 			self.state.privates_sent = true;
 
 			if let Some((to, private)) = self.pending_privates.pop() {
-				let data = borsh::to_vec(&DkgMessage::Round1Private(private))
-					.map_err(|e| DkgError::InternalError(e.to_string()))?;
-				return Ok(DkgAction::SendPrivate(to, data));
+				return serialize_round1_private(to, private);
 			}
 		}
 
@@ -1884,7 +1912,14 @@ fn build_private_share<S: TranscriptSigner>(
 		fips202::shake256_absorb(&mut h, b"dkg-party-key-v2");
 		fips202::shake256_absorb(&mut h, rho);
 		fips202::shake256_absorb(&mut h, &config.my_party_id.to_le_bytes());
-		let mut buf: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+		// The linearization buffer holds raw secret share coefficients, so it
+		// must be a zeroizing container (a plain Vec freed after `clear()`
+		// leaves the coefficients in allocator memory) and it must be allocated
+		// at full size up front (growing mid-fill would free an unwiped
+		// intermediate block).
+		const SUBSET_BYTES: usize = 2 + (L + K) * 256 * core::mem::size_of::<i32>();
+		let mut buf: Zeroizing<alloc::vec::Vec<u8>> =
+			Zeroizing::new(alloc::vec::Vec::with_capacity(SUBSET_BYTES));
 		for (subset_mask, contribution) in my_contributions {
 			buf.clear();
 			buf.extend_from_slice(&subset_mask.to_le_bytes());
@@ -2024,7 +2059,10 @@ where
 		.collect::<Result<Vec<Dkg<S>>, DkgError>>()?;
 
 	let mut outputs: Vec<Option<DkgOutput>> = vec![None; total_parties as usize];
-	let mut pending_messages: Vec<Vec<(ParticipantId, Vec<u8>)>> =
+	// Queued frames may be Round 1 privates carrying K_S, so the queue holds
+	// zeroizing buffers: an early error drops the whole queue with the secrets
+	// wiped instead of leaving them in freed memory.
+	let mut pending_messages: Vec<Vec<(ParticipantId, Zeroizing<Vec<u8>>)>> =
 		vec![Vec::new(); total_parties as usize];
 
 	let mut iterations = 0;
@@ -2039,8 +2077,10 @@ where
 		// Deliver pending messages
 		for party_id in 0..total_parties as usize {
 			let messages = mem::take(&mut pending_messages[party_id]);
-			for (from, data) in messages {
-				dkgs[party_id].message(from, data)?;
+			for (from, mut data) in messages {
+				// Hand the inner Vec to `message`, which wipes it internally;
+				// the emptied wrapper drops with nothing left to erase.
+				dkgs[party_id].message(from, mem::take(&mut *data))?;
 			}
 		}
 
@@ -2061,7 +2101,7 @@ where
 						let from = party_id as ParticipantId;
 						for (other, pending) in pending_messages.iter_mut().enumerate() {
 							if other != party_id {
-								pending.push((from, data.clone()));
+								pending.push((from, Zeroizing::new(data.clone())));
 							}
 						}
 					},
@@ -2166,7 +2206,7 @@ mod tests {
 			"test setup: secret not present in serialized payload"
 		);
 
-		let action = DkgAction::SendPrivate(3, data);
+		let action = DkgAction::SendPrivate(3, Zeroizing::new(data));
 		let rendered = format!("{action:?}");
 
 		// A derived `Debug` renders the payload as `[.., 171, 171, ..]`; the
@@ -2582,7 +2622,7 @@ mod tests {
 						Ok(DkgAction::SendPrivate(to, data)) => {
 							made_progress = true;
 							let from = party_id as ParticipantId;
-							pending_messages[to as usize].push((from, data));
+							pending_messages[to as usize].push((from, data.to_vec()));
 						},
 						Ok(DkgAction::Return(output)) => {
 							made_progress = true;
@@ -2697,7 +2737,7 @@ mod tests {
 						Ok(DkgAction::SendPrivate(to, data)) => {
 							made_progress = true;
 							let from = party_id as ParticipantId;
-							pending_messages[to as usize].push((from, data));
+							pending_messages[to as usize].push((from, data.to_vec()));
 						},
 						Ok(DkgAction::Return(output)) => {
 							made_progress = true;
@@ -2824,7 +2864,7 @@ mod tests {
 						Ok(DkgAction::SendPrivate(to, data)) => {
 							made_progress = true;
 							let from = party_id as ParticipantId;
-							pending_messages[to as usize].push((from, data));
+							pending_messages[to as usize].push((from, data.to_vec()));
 						},
 						Ok(DkgAction::Return(output)) => {
 							made_progress = true;
@@ -3400,7 +3440,7 @@ mod tests {
 							}
 						},
 					DkgAction::SendPrivate(to, data) => {
-						pending[to as usize].push((from as ParticipantId, data));
+						pending[to as usize].push((from as ParticipantId, data.to_vec()));
 					},
 					DkgAction::Wait => break,
 					DkgAction::Return(_) => break,
@@ -3438,9 +3478,9 @@ mod tests {
 					DkgAction::SendPrivate(to, data) => {
 						if to == 0 {
 							// Send to party 0 - should be buffered if it's a future round message
-							dkgs[0].message(dkg_idx as ParticipantId, data).unwrap();
+							dkgs[0].message(dkg_idx as ParticipantId, data.to_vec()).unwrap();
 						} else {
-							pending[to as usize].push((dkg_idx as ParticipantId, data));
+							pending[to as usize].push((dkg_idx as ParticipantId, data.to_vec()));
 						}
 					},
 					DkgAction::Wait => break,
@@ -3942,7 +3982,7 @@ mod tests {
 						}
 					},
 					DkgAction::SendPrivate(to, data) => {
-						pending_messages[to as usize].push((party_id as ParticipantId, data));
+						pending_messages[to as usize].push((party_id as ParticipantId, data.to_vec()));
 					},
 					DkgAction::Wait => {},
 					DkgAction::Return(_) => {},
@@ -4104,7 +4144,7 @@ mod tests {
 						}
 					},
 					DkgAction::SendPrivate(to, data) => {
-						pending_messages[to as usize].push((party_id as ParticipantId, data));
+						pending_messages[to as usize].push((party_id as ParticipantId, data.to_vec()));
 					},
 					DkgAction::Wait => {},
 					DkgAction::Return(output) => {
@@ -4211,7 +4251,7 @@ mod tests {
 						}
 					},
 					DkgAction::SendPrivate(to, data) => {
-						pending_messages[to as usize].push((party_id as ParticipantId, data));
+						pending_messages[to as usize].push((party_id as ParticipantId, data.to_vec()));
 					},
 					DkgAction::Wait => {},
 					DkgAction::Return(_) => {},
@@ -4281,7 +4321,7 @@ mod tests {
 						}
 					},
 					DkgAction::SendPrivate(to, data) => {
-						pending_messages[to as usize].push((party_id as ParticipantId, data));
+						pending_messages[to as usize].push((party_id as ParticipantId, data.to_vec()));
 					},
 					_ => {},
 				}

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -72,11 +72,11 @@ fn deserialize_message(data: &[u8]) -> Result<DkgMessage, String> {
 ///
 /// The frame carries the secret K_S, so two properties matter beyond plain
 /// `borsh::to_vec`:
-/// - the buffer is allocated at its exact final size before serialization —
-///   letting borsh grow a `Vec` incrementally frees intermediate blocks that
-///   already contain a prefix of the secret payload;
-/// - the buffer is [`Zeroizing`], so it is wiped when the caller drops it
-///   after handing the frame to the transport.
+/// - the buffer is allocated at its exact final size before serialization — letting borsh grow a
+///   `Vec` incrementally frees intermediate blocks that already contain a prefix of the secret
+///   payload;
+/// - the buffer is [`Zeroizing`], so it is wiped when the caller drops it after handing the frame
+///   to the transport.
 fn serialize_round1_private(
 	to: ParticipantId,
 	private: Round1Private,
@@ -538,15 +538,6 @@ impl<S: TranscriptSigner> Dkg<S> {
 		&self.ssid
 	}
 
-	/// Advance the protocol state machine.
-	///
-	/// Call this method repeatedly to drive the protocol forward. It returns
-	/// an action that the caller should perform (broadcast, send private, wait,
-	/// or return the final output).
-	///
-	/// # Returns
-	/// * `Ok(DkgAction)` - The action to perform
-	/// * `Err(DkgError)` - If the protocol encounters an error
 	/// Pop the next queued Round 1 private without leaving K_S behind.
 	///
 	/// `Vec::pop` alone moves the element out but leaves its bytes intact in
@@ -564,6 +555,15 @@ impl<S: TranscriptSigner> Dkg<S> {
 		Some((to, private))
 	}
 
+	/// Advance the protocol state machine.
+	///
+	/// Call this method repeatedly to drive the protocol forward. It returns
+	/// an action that the caller should perform (broadcast, send private, wait,
+	/// or return the final output).
+	///
+	/// # Returns
+	/// * `Ok(DkgAction)` - The action to perform
+	/// * `Err(DkgError)` - If the protocol encounters an error
 	pub fn poke(&mut self) -> Result<DkgAction, DkgError> {
 		if let Some((to, private)) = self.pop_pending_private() {
 			return serialize_round1_private(to, private);
@@ -4013,7 +4013,8 @@ mod tests {
 						}
 					},
 					DkgAction::SendPrivate(to, data) => {
-						pending_messages[to as usize].push((party_id as ParticipantId, data.to_vec()));
+						pending_messages[to as usize]
+							.push((party_id as ParticipantId, data.to_vec()));
 					},
 					DkgAction::Wait => {},
 					DkgAction::Return(_) => {},
@@ -4175,7 +4176,8 @@ mod tests {
 						}
 					},
 					DkgAction::SendPrivate(to, data) => {
-						pending_messages[to as usize].push((party_id as ParticipantId, data.to_vec()));
+						pending_messages[to as usize]
+							.push((party_id as ParticipantId, data.to_vec()));
 					},
 					DkgAction::Wait => {},
 					DkgAction::Return(output) => {
@@ -4282,7 +4284,8 @@ mod tests {
 						}
 					},
 					DkgAction::SendPrivate(to, data) => {
-						pending_messages[to as usize].push((party_id as ParticipantId, data.to_vec()));
+						pending_messages[to as usize]
+							.push((party_id as ParticipantId, data.to_vec()));
 					},
 					DkgAction::Wait => {},
 					DkgAction::Return(_) => {},
@@ -4352,7 +4355,8 @@ mod tests {
 						}
 					},
 					DkgAction::SendPrivate(to, data) => {
-						pending_messages[to as usize].push((party_id as ParticipantId, data.to_vec()));
+						pending_messages[to as usize]
+							.push((party_id as ParticipantId, data.to_vec()));
 					},
 					_ => {},
 				}

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -544,6 +544,17 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// the buffer beyond the shrunken length, where the drop-time wipe (which
 	/// only covers live elements) cannot reach them. Clone the element out and
 	/// wipe the slot in place before shrinking.
+	///
+	/// Known residual (heap is covered, stack is not): the clone returned
+	/// here moves by value through `poke` into `serialize_round1_private`,
+	/// and each move can leave a bitwise temporary of K_S in a dead stack
+	/// frame. The final binding is wiped (`Round1Private: ZeroizeOnDrop`),
+	/// but intermediate move temporaries are compiler-managed — the same
+	/// class of leak addressed for key import/serialize in the dilithium
+	/// crate, where it is pinned by a painted-stack probe. Closing it here
+	/// would need a by-reference serialization path plus an equivalent
+	/// probe; tracked as follow-up, not covered by the heap-zeroization
+	/// tests.
 	fn pop_pending_private(&mut self) -> Option<(ParticipantId, Round1Private)> {
 		let (to, private) = {
 			let (to, slot) = self.pending_privates.last_mut()?;

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -2507,9 +2507,8 @@ mod tests {
 
 			public_keys.push(keypair.public.clone());
 			// Explicitly copy secret key to create signer (keypair.secret is moved)
-			let sk =
-				SecretKey::from_bytes(keypair.secret.to_bytes().as_slice())
-					.expect("valid secret key bytes");
+			let sk = SecretKey::from_bytes(keypair.secret.to_bytes().as_slice())
+				.expect("valid secret key bytes");
 			signers.push(DilithiumSigner { sk, pk: keypair.public });
 		}
 

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -37,7 +37,7 @@ use crate::participants::ParticipantId;
 
 use qp_rusty_crystals_dilithium::{
 	fips202,
-	params::{K, L},
+	params::{K, L, N},
 };
 
 /// Maximum DKG message size in bytes (256 KB).
@@ -1948,7 +1948,7 @@ fn build_private_share<S: TranscriptSigner>(
 		// leaves the coefficients in allocator memory) and it must be allocated
 		// at full size up front (growing mid-fill would free an unwiped
 		// intermediate block).
-		const SUBSET_BYTES: usize = 2 + (L + K) * 256 * core::mem::size_of::<i32>();
+		const SUBSET_BYTES: usize = 2 + (L + K) * N as usize * core::mem::size_of::<i32>();
 		let mut buf: Zeroizing<alloc::vec::Vec<u8>> =
 			Zeroizing::new(alloc::vec::Vec::with_capacity(SUBSET_BYTES));
 		for (subset_mask, contribution) in my_contributions {

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -2442,8 +2442,8 @@ mod tests {
 		impl Clone for DilithiumSigner {
 			fn clone(&self) -> Self {
 				// Explicitly copy secret key material (visible at call site per SecretKey design)
-				let sk =
-					SecretKey::from_bytes(&self.sk.to_bytes()).expect("valid secret key bytes");
+				let sk = SecretKey::from_bytes(self.sk.to_bytes().as_slice())
+					.expect("valid secret key bytes");
 				Self { sk, pk: self.pk.clone() }
 			}
 		}
@@ -2497,7 +2497,8 @@ mod tests {
 			public_keys.push(keypair.public.clone());
 			// Explicitly copy secret key to create signer (keypair.secret is moved)
 			let sk =
-				SecretKey::from_bytes(&keypair.secret.to_bytes()).expect("valid secret key bytes");
+				SecretKey::from_bytes(keypair.secret.to_bytes().as_slice())
+					.expect("valid secret key bytes");
 			signers.push(DilithiumSigner { sk, pk: keypair.public });
 		}
 

--- a/threshold/src/keygen/dkg/state.rs
+++ b/threshold/src/keygen/dkg/state.rs
@@ -289,7 +289,7 @@ impl<S: TranscriptSigner> Zeroize for DkgState<S> {
 		// makes erasure a state-machine invariant rather than a matter of
 		// downstream implementer discipline.
 		if let Some(ref mut config) = self.config {
-			config.my_signer.zeroize();
+			config.zeroize_signer();
 		}
 		self.config = None;
 
@@ -364,7 +364,7 @@ impl<S: TranscriptSigner> DkgState<S> {
 		if self.phase == DkgPhase::Complete || self.phase == DkgPhase::Failed {
 			return None;
 		}
-		self.config.as_ref().map(|c| c.all_participants.as_slice())
+		self.config.as_ref().map(|c| c.all_participants())
 	}
 
 	/// Get this party's ID from the config.
@@ -374,7 +374,7 @@ impl<S: TranscriptSigner> DkgState<S> {
 		if self.phase == DkgPhase::Complete || self.phase == DkgPhase::Failed {
 			return None;
 		}
-		self.config.as_ref().map(|c| c.my_party_id)
+		self.config.as_ref().map(|c| c.my_party_id())
 	}
 
 	// ========================================================================
@@ -448,12 +448,19 @@ impl<S: TranscriptSigner> DkgState<S> {
 }
 
 /// Check if all broadcasts received.
+///
+/// A round is complete when a broadcast has been received from every
+/// participant other than `my_party_id`. The expected count is derived by
+/// filtering the participant list rather than assuming `len() - 1`, so the
+/// predicate stays total over untrusted inputs: an empty list is vacuously
+/// complete (no underflow), and a `my_party_id` that is not a participant
+/// means every listed party is an "other".
 pub fn all_broadcasts_received<T>(
 	received: &BTreeMap<ParticipantId, T>,
 	all_participants: &[ParticipantId],
 	my_party_id: ParticipantId,
 ) -> bool {
-	let expected_count = all_participants.len() - 1;
+	let expected_count = all_participants.iter().filter(|&&p| p != my_party_id).count();
 	let actual_count = received.keys().filter(|&&p| p != my_party_id).count();
 	actual_count >= expected_count
 }
@@ -612,6 +619,30 @@ mod tests {
 			"DkgState::zeroize() must explicitly zeroize the transcript signer; \
 			 dropping a bare-marker ZeroizeOnDrop signer wipes nothing"
 		);
+	}
+
+	/// `all_broadcasts_received` is exported publicly and takes a raw
+	/// participant slice, so its quorum arithmetic must tolerate degenerate
+	/// inputs: an empty list previously computed `0usize - 1`, panicking in
+	/// checked builds.
+	#[test]
+	fn all_broadcasts_received_does_not_underflow_on_empty_participant_list() {
+		let received: BTreeMap<ParticipantId, u8> = BTreeMap::new();
+		// Vacuously complete: there is nobody to wait for.
+		assert!(all_broadcasts_received(&received, &[], 0));
+	}
+
+	/// The expected count must be "participants other than me", not
+	/// `len() - 1`: when `my_party_id` is not in the list at all, every listed
+	/// participant is an "other", and `len() - 1` would report completion one
+	/// broadcast early.
+	#[test]
+	fn all_broadcasts_received_counts_others_when_caller_not_in_list() {
+		let mut received: BTreeMap<ParticipantId, u8> = BTreeMap::new();
+		received.insert(1, 0);
+		assert!(!all_broadcasts_received(&received, &[1, 2], 99));
+		received.insert(2, 0);
+		assert!(all_broadcasts_received(&received, &[1, 2], 99));
 	}
 
 	/// Regression test: `DkgState::zeroize()` must erase the transcript signer's

--- a/threshold/src/keygen/dkg/state.rs
+++ b/threshold/src/keygen/dkg/state.rs
@@ -452,10 +452,17 @@ impl<S: TranscriptSigner> DkgState<S> {
 /// A round is complete when a broadcast has been received from every
 /// participant other than `my_party_id`. The expected count is derived by
 /// filtering the participant list rather than assuming `len() - 1`, so the
-/// predicate stays total over untrusted inputs: an empty list is vacuously
-/// complete (no underflow), and a `my_party_id` that is not a participant
-/// means every listed party is an "other".
-pub fn all_broadcasts_received<T>(
+/// predicate stays total (no underflow panic) even on degenerate inputs, and
+/// a `my_party_id` that is not a participant means every listed party is an
+/// "other".
+///
+/// Crate-internal on purpose: an empty participant list is treated as
+/// vacuously complete, which is the permissive reading of the quorum. That
+/// is sound only because every caller passes a `DkgConfig`-validated list
+/// (non-empty, contains `my_party_id`), so the vacuous case is unreachable —
+/// exposing the predicate publicly would let a caller advance a round having
+/// received zero broadcasts.
+pub(crate) fn all_broadcasts_received<T>(
 	received: &BTreeMap<ParticipantId, T>,
 	all_participants: &[ParticipantId],
 	my_party_id: ParticipantId,
@@ -621,14 +628,14 @@ mod tests {
 		);
 	}
 
-	/// `all_broadcasts_received` is exported publicly and takes a raw
-	/// participant slice, so its quorum arithmetic must tolerate degenerate
-	/// inputs: an empty list previously computed `0usize - 1`, panicking in
-	/// checked builds.
+	/// `all_broadcasts_received`'s quorum arithmetic must stay total over
+	/// degenerate inputs: an empty list previously computed `0usize - 1`,
+	/// panicking in checked builds. The predicate is `pub(crate)` and every
+	/// caller passes a `DkgConfig`-validated (non-empty) list, so this pins
+	/// totality — no panic — not a reachable "vacuously complete" semantics.
 	#[test]
 	fn all_broadcasts_received_does_not_underflow_on_empty_participant_list() {
 		let received: BTreeMap<ParticipantId, u8> = BTreeMap::new();
-		// Vacuously complete: there is nobody to wait for.
 		assert!(all_broadcasts_received(&received, &[], 0));
 	}
 

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -382,12 +382,60 @@ where
 // ============================================================================
 
 /// Contribution for a single subset (η-bounded secret polynomials).
-#[derive(Clone, BorshSerialize, BorshDeserialize, Zeroize, ZeroizeOnDrop)]
+///
+/// # Deserialization Limits
+///
+/// This type is exported and may be deserialized from untrusted bytes, so
+/// [`BorshDeserialize`] is implemented manually (mirroring `SecretShareData`
+/// in keys.rs): `s1`/`s2` must hold exactly `L`/`K` polynomials and every
+/// coefficient must lie in `[-ETA, ETA]`. Every legitimate producer satisfies
+/// both (contributions are sampled via `uniform_eta`), and consumers feed the
+/// coefficients into NTT arithmetic whose bounds are a caller-enforced
+/// contract — so malformed blobs are rejected at import rather than
+/// discovered as an overflow panic or silent wraparound mid-protocol.
+#[derive(Clone, BorshSerialize, Zeroize, ZeroizeOnDrop)]
 pub struct SubsetContribution {
 	/// Share of s1 polynomial vector.
 	pub s1: Vec<[i32; N as usize]>,
 	/// Share of s2 polynomial vector.
 	pub s2: Vec<[i32; N as usize]>,
+}
+
+/// Read one length-prefixed polynomial vector for [`SubsetContribution`],
+/// enforcing the exact expected length (checked before any allocation
+/// proportional to the attacker-chosen prefix) and the η coefficient bound.
+fn read_eta_bounded_polys<R: borsh::io::Read>(
+	reader: &mut R,
+	expected: usize,
+) -> borsh::io::Result<Vec<[i32; N as usize]>> {
+	let eta = qp_rusty_crystals_dilithium::params::ETA as i32;
+	let len = u32::deserialize_reader(reader)? as usize;
+	if len != expected {
+		return Err(borsh::io::Error::new(
+			borsh::io::ErrorKind::InvalidData,
+			"SubsetContribution polynomial vector has wrong length",
+		));
+	}
+	let mut polys = Vec::with_capacity(expected);
+	for _ in 0..expected {
+		let poly = <[i32; N as usize]>::deserialize_reader(reader)?;
+		if poly.iter().any(|&c| c < -eta || c > eta) {
+			return Err(borsh::io::Error::new(
+				borsh::io::ErrorKind::InvalidData,
+				"SubsetContribution coefficient outside [-eta, eta]",
+			));
+		}
+		polys.push(poly);
+	}
+	Ok(polys)
+}
+
+impl BorshDeserialize for SubsetContribution {
+	fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+		let s1 = read_eta_bounded_polys(reader, L)?;
+		let s2 = read_eta_bounded_polys(reader, K)?;
+		Ok(Self { s1, s2 })
+	}
 }
 
 impl SubsetContribution {
@@ -1004,6 +1052,80 @@ mod tests {
 		let seed = [42u8; SUBSET_SEED_SIZE];
 		let contribution = derive_subset_contribution(&seed);
 		assert!(contribution.verify_bounds(2));
+	}
+
+	/// A well-formed contribution must round-trip through Borsh.
+	#[test]
+	fn test_subset_contribution_roundtrip() {
+		let contribution = derive_subset_contribution(&[7u8; SUBSET_SEED_SIZE]);
+		let bytes = borsh::to_vec(&contribution).unwrap();
+		let recovered: SubsetContribution = borsh::from_slice(&bytes).unwrap();
+		assert_eq!(recovered.s1, contribution.s1);
+		assert_eq!(recovered.s2, contribution.s2);
+	}
+
+	/// `SubsetContribution` is exported and may be deserialized from untrusted
+	/// bytes downstream. Its invariants — exactly L s1 / K s2 polynomials —
+	/// must be enforced at deserialize, mirroring `SecretShareData` in
+	/// keys.rs, rather than left to every caller.
+	#[test]
+	fn test_subset_contribution_deserialize_rejects_wrong_shape() {
+		// Too many s1 polynomials.
+		let mut fat = derive_subset_contribution(&[7u8; SUBSET_SEED_SIZE]);
+		fat.s1.push([0i32; N as usize]);
+		let bytes = borsh::to_vec(&fat).unwrap();
+		assert!(
+			borsh::from_slice::<SubsetContribution>(&bytes).is_err(),
+			"s1 with {} polynomials (expected {}) must be rejected",
+			L + 1,
+			L
+		);
+
+		// Too few s2 polynomials.
+		let mut thin = derive_subset_contribution(&[7u8; SUBSET_SEED_SIZE]);
+		thin.s2.pop();
+		let bytes = borsh::to_vec(&thin).unwrap();
+		assert!(
+			borsh::from_slice::<SubsetContribution>(&bytes).is_err(),
+			"s2 with {} polynomials (expected {}) must be rejected",
+			K - 1,
+			K
+		);
+
+		// A raw blob advertising an enormous s1 length must be rejected on
+		// the length prefix, before any allocation proportional to it.
+		let huge = u32::MAX.to_le_bytes().to_vec();
+		assert!(
+			borsh::from_slice::<SubsetContribution>(&huge).is_err(),
+			"an attacker-chosen length prefix must be rejected up front"
+		);
+	}
+
+	/// Coefficients outside [-ETA, ETA] must be rejected at deserialize:
+	/// every legitimate producer is η-bounded (`derive_subset_contribution`
+	/// samples via `uniform_eta`), and consumers feed these coefficients into
+	/// NTT arithmetic whose bounds are a caller-enforced contract.
+	#[test]
+	fn test_subset_contribution_deserialize_rejects_out_of_range_coefficients() {
+		use qp_rusty_crystals_dilithium::params::ETA;
+
+		let mut contribution = derive_subset_contribution(&[7u8; SUBSET_SEED_SIZE]);
+		contribution.s1[0][0] = ETA as i32 + 1;
+		let bytes = borsh::to_vec(&contribution).unwrap();
+		assert!(
+			borsh::from_slice::<SubsetContribution>(&bytes).is_err(),
+			"s1 coefficient {} outside [-{ETA}, {ETA}] must be rejected",
+			ETA + 1
+		);
+
+		let mut contribution = derive_subset_contribution(&[7u8; SUBSET_SEED_SIZE]);
+		contribution.s2[K - 1][N as usize - 1] = -(ETA as i32) - 1;
+		let bytes = borsh::to_vec(&contribution).unwrap();
+		assert!(
+			borsh::from_slice::<SubsetContribution>(&bytes).is_err(),
+			"s2 coefficient -{} outside [-{ETA}, {ETA}] must be rejected",
+			ETA + 1
+		);
 	}
 
 	#[test]

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -153,18 +153,36 @@ use qp_rusty_crystals_dilithium::{
 // ============================================================================
 
 /// Configuration for the DKG protocol.
+///
+/// # Invariants
+///
+/// The fields are private so that [`DkgConfig::new`] is the only way to build
+/// a config: the state machine (including quorum arithmetic such as
+/// [`all_broadcasts_received`](super::all_broadcasts_received)) trusts that
+/// `all_participants` is non-empty, sorted, duplicate-free, matches the
+/// threshold configuration's party count, contains `my_party_id`, and has a
+/// verifying key for every participant. A struct literal bypassing those
+/// checks does not compile:
+///
+/// ```compile_fail
+/// use qp_rusty_crystals_threshold::keygen::dkg::{DkgConfig, TranscriptSigner};
+///
+/// fn corrupt<S: TranscriptSigner>(config: &mut DkgConfig<S>) {
+///     config.all_participants.clear(); // ERROR: field is private
+/// }
+/// ```
 #[derive(Clone)]
 pub struct DkgConfig<S: TranscriptSigner> {
 	/// The threshold configuration (t, n).
-	pub threshold_config: ThresholdConfig,
+	threshold_config: ThresholdConfig,
 	/// This party's identifier.
-	pub my_party_id: ParticipantId,
+	my_party_id: ParticipantId,
 	/// All participants in the DKG (sorted).
-	pub all_participants: Vec<ParticipantId>,
+	all_participants: Vec<ParticipantId>,
 	/// This party's signing key for transcript authentication.
-	pub my_signer: S,
+	my_signer: S,
 	/// Public keys of all participants for signature verification.
-	pub participant_public_keys: BTreeMap<ParticipantId, S::PublicKey>,
+	participant_public_keys: BTreeMap<ParticipantId, S::PublicKey>,
 }
 
 impl<S: TranscriptSigner> DkgConfig<S> {
@@ -208,6 +226,39 @@ impl<S: TranscriptSigner> DkgConfig<S> {
 			my_signer,
 			participant_public_keys,
 		})
+	}
+
+	/// Get the threshold configuration (t, n).
+	pub fn threshold_config(&self) -> ThresholdConfig {
+		self.threshold_config
+	}
+
+	/// Get this party's identifier.
+	pub fn my_party_id(&self) -> ParticipantId {
+		self.my_party_id
+	}
+
+	/// Get all participants in the DKG (sorted, duplicate-free).
+	pub fn all_participants(&self) -> &[ParticipantId] {
+		&self.all_participants
+	}
+
+	/// Get this party's transcript signer.
+	pub fn signer(&self) -> &S {
+		&self.my_signer
+	}
+
+	/// Get the verifying keys of all participants.
+	pub fn participant_public_keys(&self) -> &BTreeMap<ParticipantId, S::PublicKey> {
+		&self.participant_public_keys
+	}
+
+	/// Zeroize the transcript signer's key material in place.
+	///
+	/// Called at the state machine's zeroization boundary so key erasure does
+	/// not depend on the signer's `Drop` behavior.
+	pub(crate) fn zeroize_signer(&mut self) {
+		self.my_signer.zeroize();
 	}
 
 	/// Get the threshold value.

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -157,12 +157,12 @@ use qp_rusty_crystals_dilithium::{
 /// # Invariants
 ///
 /// The fields are private so that [`DkgConfig::new`] is the only way to build
-/// a config: the state machine (including quorum arithmetic such as
-/// [`all_broadcasts_received`](super::all_broadcasts_received)) trusts that
-/// `all_participants` is non-empty, sorted, duplicate-free, matches the
-/// threshold configuration's party count, contains `my_party_id`, and has a
-/// verifying key for every participant. A struct literal bypassing those
-/// checks does not compile:
+/// a config: the state machine (including quorum arithmetic such as the
+/// crate-internal `all_broadcasts_received`) trusts that `all_participants`
+/// is non-empty, sorted, duplicate-free, matches the threshold
+/// configuration's party count, contains `my_party_id`, and has a verifying
+/// key for every participant. A struct literal bypassing those checks does
+/// not compile:
 ///
 /// ```compile_fail
 /// use qp_rusty_crystals_threshold::keygen::dkg::{DkgConfig, TranscriptSigner};
@@ -170,6 +170,15 @@ use qp_rusty_crystals_dilithium::{
 /// fn corrupt<S: TranscriptSigner>(config: &mut DkgConfig<S>) {
 ///     config.all_participants.clear(); // ERROR: field is private
 /// }
+/// ```
+///
+/// The quorum predicate itself is `pub(crate)` for the same reason: it treats
+/// an empty participant list as vacuously complete, which is only sound
+/// because every caller passes a config-validated list. It cannot be reached
+/// with raw, unvalidated inputs from outside the crate:
+///
+/// ```compile_fail
+/// use qp_rusty_crystals_threshold::keygen::dkg::all_broadcasts_received;
 /// ```
 #[derive(Clone)]
 pub struct DkgConfig<S: TranscriptSigner> {

--- a/threshold/src/keygen/mod.rs
+++ b/threshold/src/keygen/mod.rs
@@ -31,19 +31,25 @@
 //! recommended approach for production deployments.
 //!
 //! ```ignore
-//! use qp_rusty_crystals_threshold::keygen::dkg::{DilithiumDkg, DkgConfig, Action};
-//! use rand::rngs::OsRng;
+//! use qp_rusty_crystals_threshold::keygen::dkg::{Dkg, DkgConfig, DkgAction};
 //!
-//! // Each party runs this independently
-//! let config = DkgConfig::new(threshold_config, my_party_id, all_participants)?;
-//! let mut dkg = DilithiumDkg::new(config, OsRng);
+//! // Each party runs this independently. `DkgConfig::new` validates the
+//! // participant set and is the only way to construct a config.
+//! let config = DkgConfig::new(
+//!     threshold_config,
+//!     my_party_id,
+//!     all_participants,
+//!     my_signer,
+//!     participant_public_keys,
+//! )?;
+//! let mut dkg = Dkg::new(config, seed, &session_nonce);
 //!
 //! loop {
 //!     match dkg.poke()? {
-//!         Action::Wait => { /* wait for messages */ }
-//!         Action::SendMany(data) => { /* broadcast to all */ }
-//!         Action::SendPrivate(to, data) => { /* send to specific party */ }
-//!         Action::Return(output) => {
+//!         DkgAction::Wait => { /* wait for messages */ }
+//!         DkgAction::SendMany(data) => { /* broadcast to all */ }
+//!         DkgAction::SendPrivate(to, data) => { /* send to specific party */ }
+//!         DkgAction::Return(output) => {
 //!             // DKG complete!
 //!             let public_key = output.public_key;
 //!             let my_share = output.private_share;

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -167,7 +167,22 @@ pub struct PrivateKeyShare {
 }
 
 impl BorshDeserialize for PrivateKeyShare {
+	/// Deserialize with cross-field consistency validation.
+	///
+	/// The signing state machine treats this metadata as authoritative
+	/// without re-checking it: Round 3 share recovery looks `party_id` up in
+	/// `dkg_participants`, and `translated_subset_masks` indexes arrays sized
+	/// by `total_parties` with dkg indices. A tampered blob violating these
+	/// invariants would otherwise initialize a signer, run rounds 1-2
+	/// (wasting local and peer work on a session that can never complete),
+	/// and only surface at Round 3 - as a late `InvalidConfiguration` error
+	/// or, for `dkg_participants.len() > total_parties`, an out-of-bounds
+	/// panic. Every producer (dealer, DKG, resharing) satisfies these
+	/// invariants by construction, so rejecting violations here only rejects
+	/// malformed or tampered blobs.
 	fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+		let invalid = |msg: &str| borsh::io::Error::new(borsh::io::ErrorKind::InvalidData, msg);
+
 		let party_id = ParticipantId::deserialize_reader(reader)?;
 		let total_parties = u32::deserialize_reader(reader)?;
 		let threshold = u32::deserialize_reader(reader)?;
@@ -176,18 +191,38 @@ impl BorshDeserialize for PrivateKeyShare {
 		let rho = <[u8; 32]>::deserialize_reader(reader)?;
 		let tr = <[u8; TR_SIZE]>::deserialize_reader(reader)?;
 
+		// (threshold, total_parties) must be a combination the scheme
+		// actually supports; this also bounds total_parties by MAX_PARTIES,
+		// keeping the mask-domain shift below well-defined.
+		crate::config::ThresholdConfig::new(threshold, total_parties).map_err(|_| {
+			invalid("PrivateKeyShare threshold/total_parties is not a supported configuration")
+		})?;
+		if dkg_participants.len() != total_parties as usize {
+			return Err(invalid(
+				"PrivateKeyShare dkg_participants length does not match total_parties",
+			));
+		}
+		if dkg_participants.index_of(party_id).is_none() {
+			return Err(invalid("PrivateKeyShare party_id is not in dkg_participants"));
+		}
+
 		// Read shares map with bound check
 		let len = u32::deserialize_reader(reader)? as usize;
 		if len > MAX_SUBSETS {
-			return Err(borsh::io::Error::new(
-				borsh::io::ErrorKind::InvalidData,
-				"PrivateKeyShare.shares exceeds MAX_SUBSETS",
-			));
+			return Err(invalid("PrivateKeyShare.shares exceeds MAX_SUBSETS"));
 		}
+
+		// Subset masks are bitmasks over dkg indices 0..total_parties.
+		let mask_domain: u32 = 1u32 << total_parties;
 
 		let mut shares = BTreeMap::new();
 		for _ in 0..len {
 			let key = u16::deserialize_reader(reader)?;
+			if key == 0 || u32::from(key) >= mask_domain {
+				return Err(invalid(
+					"PrivateKeyShare share subset mask outside participant index domain",
+				));
+			}
 			let value = SecretShareData::deserialize_reader(reader)?;
 			shares.insert(key, value);
 		}
@@ -465,6 +500,85 @@ mod tests {
 				if valid { "accepted" } else { "rejected" }
 			);
 		}
+	}
+
+	/// Security review: deserialization must reject metadata that is not
+	/// mutually consistent. Round 3 share recovery and
+	/// `translated_subset_masks` treat `party_id`, `threshold`,
+	/// `total_parties`, and `dkg_participants` as already self-consistent; a
+	/// tampered blob that violates that either fails only after the signing
+	/// state machine has progressed (wasting peer work) or panics with an
+	/// out-of-bounds index instead of returning an error.
+	#[test]
+	fn test_private_key_share_borsh_rejects_inconsistent_metadata() {
+		let roundtrip = |party_id: u32,
+		                 total_parties: u32,
+		                 threshold: u32,
+		                 participants: &[ParticipantId],
+		                 masks: &[u16]|
+		 -> Result<PrivateKeyShare, borsh::io::Error> {
+			let dkg_participants = ParticipantList::new(participants).unwrap();
+			let mut shares = BTreeMap::new();
+			for &mask in masks {
+				shares.insert(mask, SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] });
+			}
+			let share = PrivateKeyShare::new(
+				party_id,
+				total_parties,
+				threshold,
+				[0x11u8; 32],
+				[0x22u8; 32],
+				[0x33u8; TR_SIZE],
+				shares,
+				dkg_participants,
+			);
+			let bytes = borsh::to_vec(&share).unwrap();
+			borsh::from_slice(&bytes)
+		};
+
+		// Baseline: consistent metadata imports fine.
+		assert!(roundtrip(0, 3, 2, &[0, 1, 2], &[0b011]).is_ok());
+
+		// party_id not in dkg_participants: Round 3 recovery would fail late
+		// with InvalidConfiguration after rounds 1-2 already ran.
+		assert!(
+			roundtrip(99, 3, 2, &[0, 1, 2], &[0b011]).is_err(),
+			"party_id missing from dkg_participants must be rejected at import"
+		);
+
+		// dkg_participants larger than total_parties: drives an out-of-bounds
+		// panic in translated_subset_masks during signing.
+		assert!(
+			roundtrip(0, 2, 2, &[0, 1, 2], &[0b01]).is_err(),
+			"dkg_participants.len() > total_parties must be rejected at import"
+		);
+
+		// dkg_participants smaller than total_parties: protocol waits on
+		// share subsets that cannot exist.
+		assert!(
+			roundtrip(0, 3, 2, &[0, 1], &[0b011]).is_err(),
+			"dkg_participants.len() < total_parties must be rejected at import"
+		);
+
+		// (threshold, total_parties) pairs the scheme does not support.
+		assert!(
+			roundtrip(0, 3, 1, &[0, 1, 2], &[0b011]).is_err(),
+			"threshold below 2 must be rejected at import"
+		);
+		assert!(
+			roundtrip(0, 3, 4, &[0, 1, 2], &[0b011]).is_err(),
+			"threshold above total_parties must be rejected at import"
+		);
+
+		// Subset masks outside the participant index domain.
+		assert!(
+			roundtrip(0, 3, 2, &[0, 1, 2], &[0b1001]).is_err(),
+			"share mask with a bit beyond total_parties must be rejected at import"
+		);
+		assert!(
+			roundtrip(0, 3, 2, &[0, 1, 2], &[0]).is_err(),
+			"empty share mask must be rejected at import"
+		);
 	}
 
 	#[test]

--- a/threshold/src/protocol/primitives.rs
+++ b/threshold/src/protocol/primitives.rs
@@ -39,7 +39,7 @@ use qp_rusty_crystals_dilithium::{
 	params::{C_DASH_BYTES, GAMMA2, K, L, N, Q, SIGNBYTES},
 	poly, polyvec,
 };
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 // Constants for decompose (ML-DSA-87)
 // ALPHA = 2 * GAMMA2 = 2 * ((Q-1)/32) = 523776
@@ -326,7 +326,13 @@ impl HyperballSampleVector {
 	/// timing information about the sampled values.
 	pub fn sample_hyperball(&mut self, radius: f64, nu: f64, rhop: &[u8; 64], nonce: u16) {
 		let size = self.data.len();
-		let mut samples = vec![0.0f64; size + 2];
+		// Both intermediates duplicate the per-signature mask material that
+		// ends up in `self.data` (which zeroizes on drop): `buf` is the raw
+		// nonce-derived XOF stream and `samples` the unscaled Gaussian draws.
+		// Leaking either with the published response allows recovering the
+		// secret share, so they must be wiped before their allocations are
+		// freed — hence the zeroizing wrappers.
+		let mut samples = Zeroizing::new(vec![0.0f64; size + 2]);
 
 		// Use SHAKE256 for cryptographic randomness
 		let mut keccak_state = fips202::KeccakState::default();
@@ -336,7 +342,7 @@ impl HyperballSampleVector {
 		fips202::shake256_absorb(&mut keccak_state, &nonce_bytes);
 		fips202::shake256_finalize(&mut keccak_state);
 
-		let mut buf = vec![0u8; (size + 2) * 8]; // 8 bytes per f64
+		let mut buf = Zeroizing::new(vec![0u8; (size + 2) * 8]); // 8 bytes per f64
 		fips202::shake256_squeeze(&mut buf, &mut keccak_state);
 
 		// Generate normally distributed random numbers using Box-Muller transform

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -130,6 +130,8 @@ Because sub-share derivation is deterministic from the (public, post-Round-2) se
 
 On successful completion (`Action::Return`), the protocol zeroizes, in place: the caller-provided seed, this party's entropy, the session seed, all derived sub-shares `r_{I→J}`, all received Round 4 messages, the aggregated new-share working set, and — for old committee members — **the old share held in the config**. `old_share_erased()` reports whether the config's share is gone. The same erasure runs again on `Drop` (covering abort paths). Callers must still erase their own copies: the original share file/keystore entry and anything cloned before `ResharingConfig::new`.
 
+**Abort recovery**: a session that fails or stalls before Round 6 certification has produced no replacement share, and dropping the failed protocol erases the old share held in the config. Old committee members that moved their only live copy of the share into `ResharingConfig` must recover it with `take_existing_share()` before dropping the protocol, then retry with a fresh session. Recovering the share marks an in-flight session as failed (it cannot continue without the share).
+
 ## Security Properties
 
 | Property | Guarantee |

--- a/threshold/src/resharing/README.md
+++ b/threshold/src/resharing/README.md
@@ -130,7 +130,7 @@ Because sub-share derivation is deterministic from the (public, post-Round-2) se
 
 On successful completion (`Action::Return`), the protocol zeroizes, in place: the caller-provided seed, this party's entropy, the session seed, all derived sub-shares `r_{I→J}`, all received Round 4 messages, the aggregated new-share working set, and — for old committee members — **the old share held in the config**. `old_share_erased()` reports whether the config's share is gone. The same erasure runs again on `Drop` (covering abort paths). Callers must still erase their own copies: the original share file/keystore entry and anything cloned before `ResharingConfig::new`.
 
-**Abort recovery**: a session that fails or stalls before Round 6 certification has produced no replacement share, and dropping the failed protocol erases the old share held in the config. Old committee members that moved their only live copy of the share into `ResharingConfig` must recover it with `take_existing_share()` before dropping the protocol, then retry with a fresh session. Recovering the share marks an in-flight session as failed (it cannot continue without the share).
+**Abort recovery**: a session that fails or stalls before Round 6 certification has produced no replacement share, and dropping the failed protocol erases the old share held in the config. Old committee members that moved their only live copy of the share into `ResharingConfig` must recover it with `abort_and_take_existing_share()` before dropping the protocol, then retry with a fresh session. Recovering the share marks an in-flight session as failed (it cannot continue without the share) — hence the `abort_` prefix.
 
 ## Security Properties
 
@@ -240,6 +240,9 @@ loop {
         Action::Wait => { /* wait for network messages */ }
         Action::SendMany(data) => { /* broadcast to all parties */ }
         // ⚠️ CRITICAL: Use authenticated-encrypted channel!
+        // `data` is `Zeroizing<Vec<u8>>`, not a plain `Vec<u8>`: the payload
+        // carries plaintext sub-shares, so it wipes itself from heap memory
+        // when dropped after transmission. Deref (`&data[..]`) to send.
         Action::SendPrivate(to, data) => { /* send to specific party over secure channel */ }
         Action::Return(output) => {
             // Resharing complete

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -106,6 +106,13 @@
 //! its config (check via `ResharingProtocol::old_share_erased`). Callers remain responsible for
 //! erasing their own copies of the old share (key files, keystore entries).
 //!
+//! The same erasure runs again on `Drop` — **including for failed or stalled sessions**. A
+//! session that aborts before Round 6 certification has produced no replacement share, so old
+//! committee members that moved their only live copy of the share into [`ResharingConfig`]
+//! MUST recover it via `ResharingProtocol::take_existing_share` before dropping the failed
+//! protocol, then retry with a fresh session. Otherwise the old key material is destroyed and
+//! the group can fall below signing quorum.
+//!
 //! # Why Custom Protocol?
 //!
 //! Existing resharing protocols (CHURP, MPSS) are designed for Shamir polynomial

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -109,8 +109,8 @@
 //! The same erasure runs again on `Drop` — **including for failed or stalled sessions**. A
 //! session that aborts before Round 6 certification has produced no replacement share, so old
 //! committee members that moved their only live copy of the share into [`ResharingConfig`]
-//! MUST recover it via `ResharingProtocol::take_existing_share` before dropping the failed
-//! protocol, then retry with a fresh session. Otherwise the old key material is destroyed and
+//! MUST recover it via `ResharingProtocol::abort_and_take_existing_share` before dropping the
+//! failed protocol, then retry with a fresh session. Otherwise the old key material is destroyed and
 //! the group can fall below signing quorum.
 //!
 //! # Why Custom Protocol?

--- a/threshold/src/resharing/mod.rs
+++ b/threshold/src/resharing/mod.rs
@@ -110,8 +110,8 @@
 //! session that aborts before Round 6 certification has produced no replacement share, so old
 //! committee members that moved their only live copy of the share into [`ResharingConfig`]
 //! MUST recover it via `ResharingProtocol::abort_and_take_existing_share` before dropping the
-//! failed protocol, then retry with a fresh session. Otherwise the old key material is destroyed and
-//! the group can fall below signing quorum.
+//! failed protocol, then retry with a fresh session. Otherwise the old key material is destroyed
+//! and the group can fall below signing quorum.
 //!
 //! # Why Custom Protocol?
 //!

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -2737,7 +2737,7 @@ fn add_mean_subtracted_noise(
 	is_s1: bool,
 	poly_idx: usize,
 	coeff_idx: usize,
-	state: &mut fips202::KeccakState,
+	state: &mut fips202::Shake256State,
 ) {
 	let m = out.len();
 	let m_i32 = m as i32;
@@ -2764,7 +2764,7 @@ fn balanced_split_coeff(
 	is_s1: bool,
 	poly_idx: usize,
 	coeff_idx: usize,
-	state: &mut fips202::KeccakState,
+	state: &mut fips202::Shake256State,
 ) {
 	let m = out.len();
 	let centered = center_mod_q(coeff);
@@ -2812,7 +2812,7 @@ fn split_noise_threshold(num_old_subsets: usize) -> u32 {
 /// stream, with `P(+1) = P(-1) = threshold / 256`. Consumes exactly one PRF byte
 /// per coefficient, so it is deterministic and stream-aligned across all parties
 /// (every member of an old subset derives identical sub-shares).
-fn sample_split_noise_coeff(state: &mut fips202::KeccakState, threshold: u32) -> i32 {
+fn sample_split_noise_coeff(state: &mut fips202::Shake256State, threshold: u32) -> i32 {
 	let mut buf = [0u8; 1];
 	fips202::shake256_squeeze(&mut buf, state);
 	let b = buf[0] as u32;
@@ -2825,7 +2825,7 @@ fn sample_split_noise_coeff(state: &mut fips202::KeccakState, threshold: u32) ->
 	}
 }
 
-fn sample_uniform_usize(state: &mut fips202::KeccakState, upper: usize) -> usize {
+fn sample_uniform_usize(state: &mut fips202::Shake256State, upper: usize) -> usize {
 	if upper <= 1 {
 		return 0;
 	}

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -1859,14 +1859,13 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 				&session_seed,
 				self.old_subset_order.len(),
 			);
-			// Move each sub-share out with `mem::replace` rather than
+			// Move each sub-share out with `mem::take` rather than
 			// `into_iter()`: consuming the Vec by value skips the elements'
 			// zeroizing drops, freeing the backing buffer with the raw
-			// coefficients still in it. Replacing leaves zeros in the slots,
+			// coefficients still in it. Taking leaves zeros in the slots,
 			// which the Vec's (zeroizing) element drops then wipe redundantly.
 			for (j_mask, subshare) in new_subsets.iter().zip(subshares.iter_mut()) {
-				self.my_subshares
-					.insert((i_mask, *j_mask), core::mem::replace(subshare, NewShareData::new()));
+				self.my_subshares.insert((i_mask, *j_mask), core::mem::take(subshare));
 			}
 		}
 		Ok(())
@@ -2432,8 +2431,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			// `clear()` leaves the coefficients in allocator memory) and it
 			// must be allocated at full size up front (growing mid-fill would
 			// free an unwiped intermediate block).
-			const SUBSET_BYTES: usize =
-				2 + (L + K) * N as usize * core::mem::size_of::<i32>();
+			const SUBSET_BYTES: usize = 2 + (L + K) * N as usize * core::mem::size_of::<i32>();
 			let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(Vec::with_capacity(SUBSET_BYTES));
 			for (j_mask, share) in &self.new_shares {
 				buf.clear();

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -128,7 +128,14 @@ pub const MAX_RESHARING_MESSAGE_SIZE: usize = 2 * 1024 * 1024;
 // ============================================================================
 
 /// Actions returned by the protocol's `poke` method.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is implemented manually (rather than derived) so that the
+/// [`SendPrivate`](Action::SendPrivate) transport bytes — which carry the
+/// serialized Round 4 sub-shares — are never rendered. A derived formatter
+/// would print the raw `Vec<u8>`, persisting share material into any log or
+/// trace that includes `{:?}` output. Only the recipient and payload length
+/// are shown.
+#[derive(Clone)]
 pub enum Action<T> {
 	/// Do nothing, waiting for more messages from other participants.
 	Wait,
@@ -151,6 +158,27 @@ pub enum Action<T> {
 	SendPrivate(ParticipantId, Vec<u8>),
 	/// The protocol has completed, returning the output.
 	Return(T),
+}
+
+impl<T: fmt::Debug> fmt::Debug for Action<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Action::Wait => f.write_str("Wait"),
+			// Broadcast payloads are public, but the serialized bytes are noise in
+			// a log; show only the length for consistency with SendPrivate.
+			Action::SendMany(data) =>
+				f.debug_tuple("SendMany").field(&format_args!("{} bytes", data.len())).finish(),
+			// The payload is the serialized Round 4 private message (plaintext
+			// sub-shares). Never render the bytes; keep the recipient and length
+			// for diagnostics.
+			Action::SendPrivate(to, data) => f
+				.debug_struct("SendPrivate")
+				.field("to", to)
+				.field("payload", &format_args!("<{} bytes redacted>", data.len()))
+				.finish(),
+			Action::Return(output) => f.debug_tuple("Return").field(output).finish(),
+		}
+	}
 }
 
 // ============================================================================
@@ -3201,6 +3229,51 @@ mod tests {
 			Action::Return(val) => assert_eq!(val, 123),
 			_ => panic!("Expected Return"),
 		}
+	}
+
+	/// The `SendPrivate` payload carries the borsh-serialized Round 4 message,
+	/// which contains plaintext sub-share coefficients. Its `Debug` output must
+	/// never expose those secret bytes, otherwise any downstream `{:?}` logging
+	/// persists share material outside the encrypted transport path.
+	#[test]
+	fn send_private_debug_does_not_leak_subshares() {
+		// A recognizable coefficient whose little-endian bytes are all 0xAB
+		// (== 171 decimal), so the serialized payload contains long runs of
+		// the exact form a derived `Debug` on `Vec<u8>` would print.
+		let marker = [0xABu8; 4];
+		let coeff = i32::from_le_bytes(marker);
+		let contribution =
+			NewShareData { s1: [[coeff; N as usize]; L], s2: [[coeff; N as usize]; K] };
+		let mut contributions = BTreeMap::new();
+		contributions.insert((0b011, 0b101), contribution);
+		let msg = ResharingRound4Message {
+			// Non-marker ssid so the sanity check below matches sub-share
+			// bytes, not session metadata.
+			ssid: [0x11u8; RESHARING_SSID_SIZE],
+			from_party_id: 1,
+			to_party_id: 3,
+			contributions,
+		};
+		let data = borsh::to_vec(&ResharingMessage::Round4(msg)).unwrap();
+
+		// Sanity: the sub-share coefficients really are inside the payload.
+		assert!(
+			data.windows(marker.len()).any(|w| w == marker),
+			"test setup: sub-share bytes not present in serialized payload"
+		);
+
+		let action: Action<()> = Action::SendPrivate(3, data);
+		let rendered = format!("{action:?}");
+
+		// A derived `Debug` renders the payload as `[.., 171, 171, ..]`; the
+		// redacting impl must emit no run of the secret bytes.
+		assert!(
+			!rendered.contains("171, 171"),
+			"SendPrivate Debug leaked raw sub-share bytes: {rendered}"
+		);
+		// Still useful for debugging: recipient visible, payload redacted.
+		assert!(rendered.contains("to: 3"), "recipient should stay visible: {rendered}");
+		assert!(rendered.contains("redacted"), "payload should be redacted: {rendered}");
 	}
 
 	#[test]

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -50,7 +50,7 @@ use qp_rusty_crystals_dilithium::{
 	fips202,
 	params::{ETA, K, L, N, Q, TAU},
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
 	keys::{PrivateKeyShare, SecretShareData},
@@ -155,7 +155,10 @@ pub enum Action<T> {
 	///
 	/// Sending this message over an unencrypted channel exposes secret shares
 	/// to eavesdroppers and compromises the security of the threshold scheme.
-	SendPrivate(ParticipantId, Vec<u8>),
+	///
+	/// The payload is a [`Zeroizing`] buffer so the plaintext sub-shares are
+	/// wiped from heap memory when the caller drops it after transmission.
+	SendPrivate(ParticipantId, Zeroizing<Vec<u8>>),
 	/// The protocol has completed, returning the output.
 	Return(T),
 }
@@ -800,6 +803,12 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		from: ParticipantId,
 		data: Vec<u8>,
 	) -> Result<(), ResharingProtocolError> {
+		// Round 4 frames carry plaintext sub-shares. Take ownership into a
+		// zeroizing wrapper immediately so the buffer is wiped on every
+		// return path (ignored, malformed, wrong session, or processed) —
+		// dropping the frame unwiped would leave share material in freed
+		// allocator memory.
+		let data = Zeroizing::new(data);
 		if matches!(self.state, ResharingState::Done | ResharingState::Failed(_)) {
 			return Ok(());
 		}
@@ -1388,7 +1397,19 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		}
 		let msg = &self.pending_round4[self.round4_sent_count];
 		let to_party = msg.to_party_id;
-		let data = Self::serialize_message(&ResharingMessage::Round4(msg.clone()))?;
+		// Round 4 frames carry plaintext sub-shares, so serialize into an
+		// exactly pre-sized zeroizing buffer: `borsh::to_vec`'s incremental
+		// growth would free unwiped intermediate blocks still holding share
+		// coefficients, and a plain payload Vec would leave them in allocator
+		// memory once the transport drops it.
+		let wire = ResharingMessage::Round4(msg.clone());
+		let len = borsh::object_length(&wire).map_err(|e| {
+			ResharingProtocolError::SerializationError(format!("Failed to serialize: {}", e))
+		})?;
+		let mut data = Zeroizing::new(Vec::with_capacity(len));
+		borsh::to_writer(&mut *data, &wire).map_err(|e| {
+			ResharingProtocolError::SerializationError(format!("Failed to serialize: {}", e))
+		})?;
 		self.round4_sent_count += 1;
 		Ok(Action::SendPrivate(to_party, data))
 	}
@@ -1831,15 +1852,21 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 					i_mask
 				))
 			})?;
-			let subshares = derive_subshares_with_session_seed(
+			let mut subshares = derive_subshares_with_session_seed(
 				i_mask,
 				s_i,
 				&new_subsets,
 				&session_seed,
 				self.old_subset_order.len(),
 			);
-			for (j_mask, subshare) in new_subsets.iter().zip(subshares.into_iter()) {
-				self.my_subshares.insert((i_mask, *j_mask), subshare);
+			// Move each sub-share out with `mem::replace` rather than
+			// `into_iter()`: consuming the Vec by value skips the elements'
+			// zeroizing drops, freeing the backing buffer with the raw
+			// coefficients still in it. Replacing leaves zeros in the slots,
+			// which the Vec's (zeroizing) element drops then wipe redundantly.
+			for (j_mask, subshare) in new_subsets.iter().zip(subshares.iter_mut()) {
+				self.my_subshares
+					.insert((i_mask, *j_mask), core::mem::replace(subshare, NewShareData::new()));
 			}
 		}
 		Ok(())
@@ -2400,7 +2427,14 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			fips202::shake256_absorb(&mut h, b"reshare-party-key-v2");
 			fips202::shake256_absorb(&mut h, &rho);
 			fips202::shake256_absorb(&mut h, &self.config.my_party_id().to_le_bytes());
-			let mut buf: Vec<u8> = Vec::new();
+			// The linearization buffer holds raw secret share coefficients, so
+			// it must be a zeroizing container (a plain Vec freed after
+			// `clear()` leaves the coefficients in allocator memory) and it
+			// must be allocated at full size up front (growing mid-fill would
+			// free an unwiped intermediate block).
+			const SUBSET_BYTES: usize =
+				2 + (L + K) * N as usize * core::mem::size_of::<i32>();
+			let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(Vec::with_capacity(SUBSET_BYTES));
 			for (j_mask, share) in &self.new_shares {
 				buf.clear();
 				buf.extend_from_slice(&j_mask.to_le_bytes());
@@ -2851,7 +2885,10 @@ fn build_subset_seed_with_session(
 	// Mix in session seed for per-session randomization.
 	fips202::shake256_absorb(&mut state, session_seed);
 	fips202::shake256_absorb(&mut state, &i_mask.to_le_bytes());
-	let mut buf: Vec<u8> = Vec::new();
+	// Holds raw old-share coefficients: zeroizing, pre-sized to one
+	// polynomial so it never reallocates mid-fill.
+	let mut buf: Zeroizing<Vec<u8>> =
+		Zeroizing::new(Vec::with_capacity(N as usize * core::mem::size_of::<i32>()));
 	for poly in &s_i.s1 {
 		buf.clear();
 		for c in poly {
@@ -2892,7 +2929,10 @@ fn commit_subshare(
 	fips202::shake256_absorb(&mut state, COMMIT_DOMAIN);
 	fips202::shake256_absorb(&mut state, &i_mask.to_le_bytes());
 	fips202::shake256_absorb(&mut state, &j_mask.to_le_bytes());
-	let mut buf: Vec<u8> = Vec::new();
+	// Holds raw sub-share coefficients: zeroizing, pre-sized to one
+	// polynomial so it never reallocates mid-fill.
+	let mut buf: Zeroizing<Vec<u8>> =
+		Zeroizing::new(Vec::with_capacity(N as usize * core::mem::size_of::<i32>()));
 	for poly in &r.s1 {
 		buf.clear();
 		for c in poly {
@@ -2917,7 +2957,10 @@ fn commit_new_share(j_mask: SubsetMask, share: &NewShareData) -> [u8; COMMITMENT
 	let mut state = fips202::KeccakState::default();
 	fips202::shake256_absorb(&mut state, NEW_SHARE_COMMIT_DOMAIN);
 	fips202::shake256_absorb(&mut state, &j_mask.to_le_bytes());
-	let mut buf: Vec<u8> = Vec::new();
+	// Holds raw new-share coefficients: zeroizing, pre-sized to one
+	// polynomial so it never reallocates mid-fill.
+	let mut buf: Zeroizing<Vec<u8>> =
+		Zeroizing::new(Vec::with_capacity(N as usize * core::mem::size_of::<i32>()));
 	for poly in &share.s1 {
 		buf.clear();
 		for c in poly {
@@ -3234,7 +3277,7 @@ mod tests {
 	fn test_action_variants() {
 		let wait: Action<()> = Action::Wait;
 		let send_many: Action<()> = Action::SendMany(vec![1, 2, 3]);
-		let send_private: Action<()> = Action::SendPrivate(42, vec![4, 5, 6]);
+		let send_private: Action<()> = Action::SendPrivate(42, Zeroizing::new(vec![4, 5, 6]));
 		let ret: Action<i32> = Action::Return(123);
 
 		match wait {
@@ -3248,7 +3291,7 @@ mod tests {
 		match send_private {
 			Action::SendPrivate(to, data) => {
 				assert_eq!(to, 42);
-				assert_eq!(data, vec![4, 5, 6]);
+				assert_eq!(*data, vec![4, 5, 6]);
 			},
 			_ => panic!("Expected SendPrivate"),
 		}
@@ -3363,7 +3406,7 @@ mod tests {
 			"test setup: sub-share bytes not present in serialized payload"
 		);
 
-		let action: Action<()> = Action::SendPrivate(3, data);
+		let action: Action<()> = Action::SendPrivate(3, Zeroizing::new(data));
 		let rendered = format!("{action:?}");
 
 		// A derived `Debug` renders the payload as `[.., 171, 171, ..]`; the

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -562,6 +562,33 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		}
 	}
 
+	/// Recover the old committee share from a session that did not complete.
+	///
+	/// Dropping the protocol erases every session secret, **including the old
+	/// share held in the config**. A session that failed or stalled before the
+	/// Round 6 certificate was produced has generated no replacement share, so
+	/// a caller that moved its only live copy of the old share into
+	/// [`ResharingConfig`] MUST call this before dropping the failed protocol,
+	/// or the old key material is lost and no retry is possible.
+	///
+	/// Returns `None` for new-only parties, and after successful completion
+	/// (the share is erased at finalize; the new share from
+	/// [`Self::take_output`] is then the only live key material).
+	///
+	/// Recovering the share renders the session unable to continue, so an
+	/// in-flight session is marked failed.
+	pub fn take_existing_share(&mut self) -> Option<PrivateKeyShare> {
+		let share = self.config.take_existing_share();
+		if share.is_some() &&
+			!matches!(self.state, ResharingState::Done | ResharingState::Failed(_))
+		{
+			self.state = ResharingState::Failed(
+				"old share recovered by caller before completion".to_string(),
+			);
+		}
+		share
+	}
+
 	/// Check if the protocol has completed successfully.
 	pub fn is_done(&self) -> bool {
 		matches!(self.state, ResharingState::Done)
@@ -3229,6 +3256,80 @@ mod tests {
 			Action::Return(val) => assert_eq!(val, 123),
 			_ => panic!("Expected Return"),
 		}
+	}
+
+	/// Build a 2-of-3 old-committee protocol for party 1, returning the
+	/// protocol and a copy of party 1's original share.
+	fn share_recovery_fixture() -> (ResharingProtocol<TestSigner>, PrivateKeyShare) {
+		let config = crate::ThresholdConfig::new(2, 3).expect("valid config");
+		let (public_key, shares) =
+			crate::keygen::generate_with_dealer(&[8u8; 32], config).expect("keygen");
+		let original = shares[1].clone();
+		let resharing_config = ResharingConfig::new(
+			Some(shares[1].clone()),
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 2],
+			1,
+			public_key,
+		)
+		.expect("valid resharing config");
+		let protocol = ResharingProtocol::new(
+			resharing_config,
+			test_signer_config(1, &[0, 1, 2]),
+			[1u8; 32],
+			&[2u8; 32],
+			0,
+		);
+		(protocol, original)
+	}
+
+	/// A session that fails before Round 6 certification has produced no
+	/// replacement share, so the old committee member must be able to recover
+	/// their share for a retry instead of losing it when the failed protocol
+	/// is dropped.
+	#[test]
+	fn failed_session_allows_old_share_recovery() {
+		let (mut protocol, original) = share_recovery_fixture();
+
+		// A peer-induced abort: e.g. leader equivocation or verification failure.
+		protocol.state = ResharingState::Failed("attacker stalled the session".to_string());
+
+		let recovered = protocol
+			.take_existing_share()
+			.expect("failed session must preserve the old share for retry");
+		assert_eq!(recovered, original, "recovered share must be intact");
+		// The protocol no longer holds the share; dropping it is now safe.
+		assert!(protocol.old_share_erased());
+	}
+
+	/// Recovering the share from an in-flight (stalled) session must also work,
+	/// and must render the session terminal: it cannot continue without the
+	/// share, and a later poke must not resurrect it.
+	#[test]
+	fn share_recovery_marks_in_flight_session_failed() {
+		let (mut protocol, original) = share_recovery_fixture();
+
+		// Session stalled mid-protocol (e.g. transport timeout while waiting).
+		let recovered =
+			protocol.take_existing_share().expect("stalled session must yield the share");
+		assert_eq!(recovered, original);
+		assert!(protocol.is_failed(), "session must be terminal after share recovery");
+	}
+
+	/// After a successful handoff the old share is erased at finalize; the
+	/// recovery path must not bypass that erasure.
+	#[test]
+	fn share_recovery_returns_none_after_successful_completion() {
+		let (mut protocol, _original) = share_recovery_fixture();
+
+		// Mirror the finalize order: erase session secrets, then mark Done.
+		protocol.zeroize_session_secrets();
+		protocol.state = ResharingState::Done;
+
+		assert!(protocol.take_existing_share().is_none());
+		assert!(protocol.is_done(), "recovery attempt must not disturb a completed session");
 	}
 
 	/// The `SendPrivate` payload carries the borsh-serialized Round 4 message,

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -579,8 +579,9 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// [`Self::take_output`] is then the only live key material).
 	///
 	/// Recovering the share renders the session unable to continue, so an
-	/// in-flight session is marked failed.
-	pub fn take_existing_share(&mut self) -> Option<PrivateKeyShare> {
+	/// in-flight session is marked failed — the name carries the side
+	/// effect: this is an abort-recovery operation, not an accessor.
+	pub fn abort_and_take_existing_share(&mut self) -> Option<PrivateKeyShare> {
 		let share = self.config.take_existing_share();
 		if share.is_some() &&
 			!matches!(self.state, ResharingState::Done | ResharingState::Failed(_))
@@ -3338,7 +3339,7 @@ mod tests {
 		protocol.state = ResharingState::Failed("attacker stalled the session".to_string());
 
 		let recovered = protocol
-			.take_existing_share()
+			.abort_and_take_existing_share()
 			.expect("failed session must preserve the old share for retry");
 		assert_eq!(recovered, original, "recovered share must be intact");
 		// The protocol no longer holds the share; dropping it is now safe.
@@ -3353,8 +3354,9 @@ mod tests {
 		let (mut protocol, original) = share_recovery_fixture();
 
 		// Session stalled mid-protocol (e.g. transport timeout while waiting).
-		let recovered =
-			protocol.take_existing_share().expect("stalled session must yield the share");
+		let recovered = protocol
+			.abort_and_take_existing_share()
+			.expect("stalled session must yield the share");
 		assert_eq!(recovered, original);
 		assert!(protocol.is_failed(), "session must be terminal after share recovery");
 	}
@@ -3369,7 +3371,7 @@ mod tests {
 		protocol.zeroize_session_secrets();
 		protocol.state = ResharingState::Done;
 
-		assert!(protocol.take_existing_share().is_none());
+		assert!(protocol.abort_and_take_existing_share().is_none());
 		assert!(protocol.is_done(), "recovery attempt must not disturb a completed session");
 	}
 

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -277,13 +277,26 @@ impl ResharingConfig {
 
 	/// Securely erase the old committee share held in this config.
 	///
-	/// Called automatically when the protocol completes successfully. Integrators
-	/// should treat the returned new share as the only live key material after
-	/// a successful handoff.
+	/// Called automatically when the protocol completes successfully, and again
+	/// when the protocol is dropped. Integrators should treat the returned new
+	/// share as the only live key material after a successful handoff. For
+	/// sessions that failed or stalled before completion, recover the share
+	/// with [`Self::take_existing_share`] before dropping the protocol.
 	pub fn zeroize_existing_share(&mut self) {
 		if let Some(mut share) = self.existing_share.take() {
 			share.zeroize();
 		}
+	}
+
+	/// Take ownership of the old committee share, removing it from the config.
+	///
+	/// This is the abort-recovery path: a session that failed or stalled before
+	/// Round 6 certification has produced no replacement share, so the old share
+	/// must survive for a retry. Dropping the protocol (and with it this config)
+	/// zeroizes the share, so callers that moved their only live copy in must
+	/// take it back out first.
+	pub fn take_existing_share(&mut self) -> Option<PrivateKeyShare> {
+		self.existing_share.take()
 	}
 
 	/// Get old threshold config.

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -619,7 +619,7 @@ pub struct ResharingRound1EntropyCommitment {
 /// (commitments hide entropy until Round 2). Equivocating proposals put the
 /// receiving parties in different sessions; their deterministic sub-share
 /// commitments then disagree and the protocol aborts.
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize)]
 pub struct ResharingActProposal {
 	/// Session identifier binding this message to the resharing session.
 	pub ssid: [u8; RESHARING_SSID_SIZE],
@@ -628,6 +628,31 @@ pub struct ResharingActProposal {
 	/// Proposed active set: old committee members that will contribute entropy
 	/// and deal sub-shares. Strictly sorted, unique, `|active_set| >= t_old`.
 	pub active_set: Vec<ParticipantId>,
+}
+
+impl BorshDeserialize for ResharingActProposal {
+	fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+		let ssid = <[u8; RESHARING_SSID_SIZE]>::deserialize_reader(reader)?;
+		let party_id = ParticipantId::deserialize_reader(reader)?;
+
+		// The length prefix is attacker-controlled and the protocol only
+		// validates the proposal semantically *after* deserialization, so
+		// bound it here like every other variable-length resharing field.
+		// active_set is at most one entry per old committee member.
+		let len = u32::deserialize_reader(reader)? as usize;
+		if len > MAX_PARTIES as usize {
+			return Err(borsh::io::Error::new(
+				borsh::io::ErrorKind::InvalidData,
+				"ResharingActProposal.active_set exceeds MAX_PARTIES",
+			));
+		}
+		let mut active_set = Vec::with_capacity(len);
+		for _ in 0..len {
+			active_set.push(ParticipantId::deserialize_reader(reader)?);
+		}
+
+		Ok(Self { ssid, party_id, active_set })
+	}
 }
 
 // ============================================================================
@@ -2141,6 +2166,40 @@ mod tests {
 
 		let result: Result<ResharingCertificate, _> = borsh::from_slice(&payload);
 		assert!(result.is_err(), "accepts exceeding MAX_PARTIES must be rejected");
+	}
+
+	/// An `ActProposal` whose `active_set` count exceeds `MAX_PARTIES` must be
+	/// rejected at the deserialization boundary, before the protocol's
+	/// leader/sortedness/threshold validation ever runs. With the derived
+	/// deserializer, borsh happily parses an attacker-controlled vector of up
+	/// to `MAX_RESHARING_MESSAGE_SIZE / 4` entries on every receiver.
+	#[test]
+	fn test_act_proposal_rejects_oversized_active_set() {
+		// Honest round-trip still works, through the enum wrapper the protocol
+		// entrypoint uses.
+		let proposal =
+			ResharingActProposal { ssid: TEST_SSID, party_id: 0, active_set: alloc::vec![0, 1, 2] };
+		let bytes = borsh::to_vec(&ResharingMessage::ActProposal(proposal.clone())).unwrap();
+		match borsh::from_slice::<ResharingMessage>(&bytes).unwrap() {
+			ResharingMessage::ActProposal(back) => {
+				assert_eq!(back.party_id, proposal.party_id);
+				assert_eq!(back.active_set, proposal.active_set);
+			},
+			_ => panic!("expected ActProposal"),
+		}
+
+		// Oversized active_set length prefix must be rejected.
+		let huge = MAX_PARTIES + 100;
+		let mut payload = Vec::new();
+		payload.extend_from_slice(&TEST_SSID); // ssid
+		payload.extend_from_slice(&0u32.to_le_bytes()); // party_id
+		payload.extend_from_slice(&huge.to_le_bytes()); // active_set len
+		for i in 0..huge {
+			payload.extend_from_slice(&i.to_le_bytes()); // ParticipantId entries
+		}
+
+		let result: Result<ResharingActProposal, _> = borsh::from_slice(&payload);
+		assert!(result.is_err(), "active_set exceeding MAX_PARTIES must be rejected");
 	}
 
 	/// Regression test (security review): a `ResharingAccept` whose signature

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -281,7 +281,8 @@ impl ResharingConfig {
 	/// when the protocol is dropped. Integrators should treat the returned new
 	/// share as the only live key material after a successful handoff. For
 	/// sessions that failed or stalled before completion, recover the share
-	/// with [`Self::take_existing_share`] before dropping the protocol.
+	/// with `ResharingProtocol::abort_and_take_existing_share` before
+	/// dropping the protocol.
 	pub fn zeroize_existing_share(&mut self) {
 		if let Some(mut share) = self.existing_share.take() {
 			share.zeroize();

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -485,7 +485,11 @@ impl ThresholdSigner {
 	/// are from parties whose IDs exist in the DKG participant set.
 	///
 	/// Broadcasts with unknown `party_id` values will cause share recovery to fail
-	/// with an `InvalidConfiguration` error.
+	/// with an `InvalidConfiguration` error. Because that failure is detected after
+	/// the peers' reveals have already been folded into the commitment aggregate
+	/// (and the offending participant set was frozen in Round 2, so no retry of
+	/// this session could succeed), it resets the signing session: restart from
+	/// Round 1.
 	///
 	/// For network usage, use
 	/// [`DilithiumSignProtocol`](crate::signing_protocol::DilithiumSignProtocol) which handles
@@ -584,10 +588,25 @@ impl ThresholdSigner {
 			}
 		}
 
-		// Generate the response from the committed aggregate.
-		let (round1_data, round2_data) = self.state.expect_round2()?;
-		let responses =
-			generate_round3_response(&self.private_key, &self.config, round1_data, round2_data)?;
+		// Generate the response from the committed aggregate. From this point
+		// the aggregate already includes every peer's commitment, so ANY
+		// failure before the phase advances to AfterRound3 must reset the
+		// session, exactly like the aggregation failure path above: leaving
+		// AfterRound2 would let a retry re-run `aggregate_reveals` and
+		// double-count the peers' commitments. This path is reachable with
+		// attacker-influenced input — an active party outside the DKG
+		// participant set is only detected here, inside `recover_share` —
+		// and such a failure is baked into the session's frozen participant
+		// set, so no retry of the same session could ever succeed anyway.
+		let responses = match self.state.expect_round2().and_then(|(round1_data, round2_data)| {
+			generate_round3_response(&self.private_key, &self.config, round1_data, round2_data)
+		}) {
+			Ok(responses) => responses,
+			Err(e) => {
+				self.state = SignerState::default();
+				return Err(e);
+			},
+		};
 
 		// Pack responses for broadcast
 		let packed_response = pack_responses(&responses);
@@ -1252,6 +1271,75 @@ mod tests {
 			matches!(err, ThresholdError::InvalidCommitmentData { party_id: 1, .. }),
 			"oversized reveal must fail the O(1) length check before any hashing; \
 			 got {err:?} (CommitmentMismatch would mean the payload was hashed first)"
+		);
+	}
+
+	/// A failure *after* `aggregate_reveals` has folded peer commitments into
+	/// `w_aggregated` must reset the session, exactly like the aggregation
+	/// failure path itself: leaving the signer in AfterRound2 with a mutated
+	/// aggregate would let a retry re-run `aggregate_reveals` and double-count
+	/// every peer's commitment, silently poisoning the session.
+	///
+	/// The failure is triggered through the documented recoverable-looking
+	/// path: a Round 1 broadcast from a party that is not in the DKG
+	/// participant set is accepted by `round2_reveal` (the docs defer the
+	/// check), passes all Round 3 reveal validation (its reveal is genuinely
+	/// hash-bound and well-formed), and only fails inside
+	/// `generate_round3_response` -> `recover_share` with
+	/// `InvalidConfiguration` — after the aggregate is already committed.
+	#[test]
+	fn test_round3_failure_after_aggregation_resets_session() {
+		use crate::{
+			broadcast::{Round1Broadcast, Round2Broadcast},
+			generate_with_dealer,
+			protocol::signing::compute_commitment_hash,
+		};
+
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[13u8; 32], config).unwrap();
+		let mut s0 = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
+		// A real signer produces well-formed commitment data we can rebrand.
+		let mut s1 = ThresholdSigner::new(shares[1].clone(), pk, config).unwrap();
+
+		let ssid = [0x21u8; 32];
+		let r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+		let _r1_1 = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
+		let r2_1 = s1.round2_reveal(&ssid, b"reset", b"", core::slice::from_ref(&r1_0)).unwrap();
+
+		// Rebrand party 1's valid commitment data as coming from party 99,
+		// which does not exist in the DKG participant set {0, 1, 2}. The
+		// reveal is hash-bound (we pre-commit to exactly these bytes), has
+		// the correct length, and unpacks — so every Round 3 validation
+		// passes and the aggregate is committed before anything fails.
+		let ghost_hash = compute_commitment_hash(&ssid, 99, &r2_1.commitment_data);
+		let r1_99 = Round1Broadcast::new(ssid, 99, ghost_hash);
+		let r2_99 = Round2Broadcast::new(ssid, 99, r2_1.commitment_data.clone());
+
+		s0.round2_reveal(&ssid, b"reset", b"", core::slice::from_ref(&r1_99)).unwrap();
+
+		let err = s0
+			.round3_respond(&ssid, core::slice::from_ref(&r1_99), core::slice::from_ref(&r2_99))
+			.expect_err("share recovery must fail for a party outside the DKG set");
+		assert!(
+			matches!(err, ThresholdError::InvalidConfiguration(_)),
+			"expected InvalidConfiguration from recover_share, got {err:?}"
+		);
+
+		// The aggregate already contains party 99's commitment, so the
+		// session is unrecoverable: it must have been reset, not left in
+		// AfterRound2 where a retry would double-aggregate.
+		assert_ne!(
+			s0.state.phase,
+			SigningPhase::AfterRound2,
+			"a failure after the aggregate was mutated must reset the session; \
+			 leaving AfterRound2 lets a retry double-count every peer commitment"
+		);
+		let err_again = s0
+			.round3_respond(&ssid, core::slice::from_ref(&r1_99), core::slice::from_ref(&r2_99))
+			.expect_err("a reset session must reject further Round 3 attempts");
+		assert!(
+			matches!(err_again, ThresholdError::InvalidState { .. }),
+			"retry after reset must fail with InvalidState, got {err_again:?}"
 		);
 	}
 }

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -647,6 +647,26 @@ impl ThresholdSigner {
 				});
 			}
 
+			// Enforce the exact per-config length BEFORE the hash check. The
+			// bounded deserializer admits payloads up to the global maximum
+			// (~10.5 MB, sized for the largest supported config), and
+			// `verify_commitment_hash` runs SHAKE256 over the whole payload —
+			// so hashing first would let a peer who pre-committed to an
+			// oversized blob force that hashing work in a session whose
+			// legitimate reveal is orders of magnitude smaller. The length is
+			// public, so rejecting on it first leaks nothing.
+			if r2.commitment_data.len() != expected_len {
+				return Err(ThresholdError::InvalidCommitmentData {
+					party_id: r2.party_id,
+					reason: format!(
+						"Commitment data length {} does not match expected {} for k={}",
+						r2.commitment_data.len(),
+						expected_len,
+						k
+					),
+				});
+			}
+
 			// The Round 1 hash frozen during round2_reveal is authoritative.
 			// A reveal from a party we recorded no Round 1 commitment for
 			// cannot be bound and is rejected.
@@ -676,19 +696,6 @@ impl ThresholdSigner {
 					party_id: r2.party_id,
 					message: "Round 2 commitment data does not match Round 1 commitment hash"
 						.to_string(),
-				});
-			}
-
-			// Validate data length
-			if r2.commitment_data.len() != expected_len {
-				return Err(ThresholdError::InvalidCommitmentData {
-					party_id: r2.party_id,
-					reason: format!(
-						"Commitment data length {} does not match expected {} for k={}",
-						r2.commitment_data.len(),
-						expected_len,
-						k
-					),
 				});
 			}
 		}
@@ -1200,6 +1207,51 @@ mod tests {
 		assert!(
 			matches!(err_again, ThresholdError::InvalidCommitmentData { party_id: 1, .. }),
 			"expected InvalidCommitmentData for party 1 on retry, got {err_again:?}"
+		);
+	}
+
+	/// A mis-sized reveal must be rejected on its length *before* the
+	/// commitment hash is verified, so a peer cannot force SHAKE256 work over
+	/// a payload far larger than the session's configuration can legitimately
+	/// produce (the bounded deserializer admits up to the global
+	/// `MAX_COMMITMENT_DATA_SIZE`, ~10.5 MB, sized for the largest config).
+	///
+	/// The ordering is pinned through the error variant: an oversized reveal
+	/// whose hash does NOT match the frozen commitment must fail as
+	/// `InvalidCommitmentData` (the O(1) length check), not as
+	/// `CommitmentMismatch` (which would prove the hash ran first).
+	#[test]
+	fn test_oversized_reveal_rejected_on_length_before_hashing() {
+		use crate::{
+			broadcast::{Round1Broadcast, Round2Broadcast, MAX_COMMITMENT_DATA_SIZE},
+			generate_with_dealer,
+			protocol::signing::compute_commitment_hash,
+		};
+
+		let config = ThresholdConfig::new(2, 2).unwrap();
+		let (pk, shares) = generate_with_dealer(&[11u8; 32], config).unwrap();
+		let mut s0 = ThresholdSigner::new(shares[0].clone(), pk, config).unwrap();
+
+		let ssid = [0x77u8; 32];
+		let _r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+
+		// Peer 1's frozen Round 1 commitment is over placeholder data; the
+		// Round 3 reveal is the largest blob the bounded deserializer would
+		// admit for *any* config — vastly oversized for this (2,2) session.
+		let placeholder_hash = compute_commitment_hash(&ssid, 1, b"placeholder");
+		let r1_1 = Round1Broadcast::new(ssid, 1, placeholder_hash);
+		let oversized = alloc::vec![0xA5u8; MAX_COMMITMENT_DATA_SIZE];
+		let r2_1 = Round2Broadcast::new(ssid, 1, oversized);
+
+		s0.round2_reveal(&ssid, b"dos", b"", core::slice::from_ref(&r1_1)).unwrap();
+
+		let err = s0
+			.round3_respond(&ssid, core::slice::from_ref(&r1_1), core::slice::from_ref(&r2_1))
+			.expect_err("oversized reveal must be rejected");
+		assert!(
+			matches!(err, ThresholdError::InvalidCommitmentData { party_id: 1, .. }),
+			"oversized reveal must fail the O(1) length check before any hashing; \
+			 got {err:?} (CommitmentMismatch would mean the payload was hashed first)"
 		);
 	}
 }

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -275,6 +275,27 @@ impl ThresholdSigner {
             )));
 		}
 
+		// Cross-field consistency of the share itself. Borsh import enforces
+		// the same invariants, but the signer is the last construction
+		// boundary before the state machine trusts this metadata: without
+		// these checks a malformed share runs rounds 1-2 and fails only at
+		// Round 3 share recovery - a late error for a missing party_id, or an
+		// out-of-bounds panic in translated_subset_masks when
+		// dkg_participants outnumber total_parties.
+		if private_key.dkg_participants().len() != private_key.total_parties() as usize {
+			return Err(ThresholdError::InvalidConfiguration(format!(
+				"Private key dkg_participants length ({}) does not match its total parties ({})",
+				private_key.dkg_participants().len(),
+				private_key.total_parties()
+			)));
+		}
+		if private_key.dkg_index().is_none() {
+			return Err(ThresholdError::InvalidConfiguration(format!(
+				"Private key party_id ({}) is not in its dkg_participants list",
+				private_key.party_id()
+			)));
+		}
+
 		Ok(Self { config, public_key, private_key, state: SignerState::default() })
 	}
 
@@ -960,6 +981,60 @@ mod tests {
 			Err(e) => panic!("Expected InvalidConfiguration error, got: {:?}", e),
 			Ok(_) => panic!("Should reject public key with TR not matching private key TR"),
 		}
+	}
+
+	/// Security review: `ThresholdSigner::new` is the construction boundary
+	/// for locally supplied share material, so it must reject shares whose
+	/// metadata is not mutually consistent rather than let the signing state
+	/// machine run rounds 1-2 and fail (or panic out-of-bounds in
+	/// `translated_subset_masks`) only at Round 3 share recovery.
+	#[test]
+	fn test_signer_rejects_share_with_inconsistent_metadata() {
+		use crate::{generate_with_dealer, keys::PrivateKeyShare};
+
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[9u8; 32], config).unwrap();
+		let good = &shares[0];
+
+		// party_id missing from dkg_participants: passes the TR and threshold
+		// checks, then Round 3 recovery would fail late with
+		// "Party not found in DKG participants".
+		let tampered = PrivateKeyShare::new(
+			99,
+			good.total_parties(),
+			good.threshold(),
+			[0u8; 32],
+			*good.rho(),
+			*good.tr(),
+			good.shares().clone(),
+			good.dkg_participants().clone(),
+		);
+		assert!(
+			ThresholdSigner::new(tampered, pk.clone(), config).is_err(),
+			"signer must reject a share whose party_id is not in dkg_participants"
+		);
+
+		// dkg_participants larger than the claimed total_parties: signing-set
+		// masks built over dkg indices can then exceed the participant count,
+		// which panics in translated_subset_masks instead of erroring.
+		let config22 = ThresholdConfig::new(2, 2).unwrap();
+		let (pk22, shares22) = generate_with_dealer(&[10u8; 32], config22).unwrap();
+		let good22 = &shares22[0];
+		let oversized_list = ParticipantList::new(&[0, 1, 2]).unwrap();
+		let tampered = PrivateKeyShare::new(
+			good22.party_id(),
+			good22.total_parties(),
+			good22.threshold(),
+			[0u8; 32],
+			*good22.rho(),
+			*good22.tr(),
+			good22.shares().clone(),
+			oversized_list,
+		);
+		assert!(
+			ThresholdSigner::new(tampered, pk22.clone(), config22).is_err(),
+			"signer must reject a share whose dkg_participants exceed total_parties"
+		);
 	}
 
 	/// The direct signer must enforce the ML-DSA `MAX_MESSAGE_SIZE` bound before

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -63,7 +63,7 @@ use crate::{
 /// Packed size in bytes of one commitment (one `Polyveck` of K polynomials,
 /// 736 bytes each in the 23-bit encoding). Round 2 commitment data is
 /// `k_iterations` of these, concatenated.
-const SINGLE_COMMITMENT_SIZE: usize = 8 * 736; // K * POLY_Q_SIZE
+pub(crate) const SINGLE_COMMITMENT_SIZE: usize = 8 * 736; // K * POLY_Q_SIZE
 
 /// A threshold signer for a single party.
 ///

--- a/threshold/src/signer.rs
+++ b/threshold/src/signer.rs
@@ -375,19 +375,19 @@ impl ThresholdSigner {
 	/// * `context` - Optional context string (max 255 bytes)
 	/// * `other_round1` - Round 1 broadcasts from other participating parties
 	///
-	/// # Caller Responsibility
+	/// # Participant Validation
 	///
-	/// **Important:** This method does not validate that Round 1 broadcasts come from
-	/// parties that participated in the original DKG. The caller must ensure that
-	/// `other_round1` contains only broadcasts from parties whose IDs exist in the
-	/// DKG participant set (i.e., parties that hold valid key shares).
-	///
-	/// Passing broadcasts with unknown `party_id` values will cause `round3_respond()`
-	/// to fail with an `InvalidConfiguration` error during share recovery.
+	/// Every Round 1 broadcast's `party_id` is checked against the DKG
+	/// participant set before any state is modified. A broadcast from an
+	/// unknown party is rejected with `InvalidConfiguration` and the session
+	/// stays in `AfterRound1`, so the caller can retry with a corrected set.
+	/// (Deferred to Round 3, the same condition would only surface inside
+	/// share recovery — after the session's participant set was frozen and
+	/// the commitment aggregate mutated, forcing a full session reset.)
 	///
 	/// For network usage, use
-	/// [`DilithiumSignProtocol`](crate::signing_protocol::DilithiumSignProtocol) which handles
-	/// participant validation automatically.
+	/// [`DilithiumSignProtocol`](crate::signing_protocol::DilithiumSignProtocol) which also
+	/// validates participants at message receipt.
 	///
 	/// # Errors
 	///
@@ -395,6 +395,7 @@ impl ThresholdSigner {
 	/// - The signer is not in the `AfterRound1` state
 	/// - Context is too long (> 255 bytes)
 	/// - Not enough parties are participating
+	/// - A Round 1 broadcast comes from a party outside the DKG participant set
 	///
 	/// # State Transition
 	///
@@ -426,6 +427,23 @@ impl ThresholdSigner {
 				provided: total_parties,
 				required: self.config.threshold(),
 			});
+		}
+
+		// Reject Round 1 broadcasts from parties outside the DKG participant
+		// set now, before the commit point below (and before the keygen-scale
+		// commitment packing). Deferred, such a party is only detected inside
+		// `recover_share` during Round 3 — after the peers' reveals have been
+		// folded into the commitment aggregate, where the only safe recovery
+		// is a full session reset. Failing here is cheap and leaves the
+		// session in AfterRound1, cleanly retryable with a corrected set.
+		let dkg_participants = self.private_key.dkg_participants();
+		for r1 in other_round1 {
+			if dkg_participants.index_of(r1.party_id).is_none() {
+				return Err(ThresholdError::InvalidConfiguration(format!(
+					"Round 1 broadcast from party {} which is not in the DKG participant set",
+					r1.party_id
+				)));
+			}
 		}
 
 		// Check state and get round1_data
@@ -478,22 +496,23 @@ impl ThresholdSigner {
 	/// * `other_round1` - Round 1 broadcasts from other parties (for commitment verification)
 	/// * `other_round2` - Round 2 broadcasts from other participating parties
 	///
-	/// # Caller Responsibility
+	/// # Participant Validation
 	///
-	/// **Important:** This method does not validate that broadcasts come from parties
-	/// that participated in the original DKG. The caller must ensure that all broadcasts
-	/// are from parties whose IDs exist in the DKG participant set.
+	/// Parties outside the DKG participant set are rejected by
+	/// [`round2_reveal`](Self::round2_reveal) before the session's participant
+	/// set is frozen, so through the public API they cannot reach this method.
+	/// Reveals are verified against the commitment map frozen in Round 2; a
+	/// reveal from a party not in that map fails the exact-set check before
+	/// the aggregate is touched.
 	///
-	/// Broadcasts with unknown `party_id` values will cause share recovery to fail
-	/// with an `InvalidConfiguration` error. Because that failure is detected after
-	/// the peers' reveals have already been folded into the commitment aggregate
-	/// (and the offending participant set was frozen in Round 2, so no retry of
-	/// this session could succeed), it resets the signing session: restart from
-	/// Round 1.
+	/// Should share recovery nonetheless fail after the peers' reveals have
+	/// been folded into the commitment aggregate (defense in depth), the
+	/// signing session is reset — the frozen participant set means no retry
+	/// of the same session could succeed: restart from Round 1.
 	///
 	/// For network usage, use
-	/// [`DilithiumSignProtocol`](crate::signing_protocol::DilithiumSignProtocol) which handles
-	/// participant validation automatically.
+	/// [`DilithiumSignProtocol`](crate::signing_protocol::DilithiumSignProtocol) which also
+	/// validates participants at message receipt.
 	///
 	/// # Security
 	///
@@ -593,11 +612,11 @@ impl ThresholdSigner {
 		// failure before the phase advances to AfterRound3 must reset the
 		// session, exactly like the aggregation failure path above: leaving
 		// AfterRound2 would let a retry re-run `aggregate_reveals` and
-		// double-count the peers' commitments. This path is reachable with
-		// attacker-influenced input — an active party outside the DKG
-		// participant set is only detected here, inside `recover_share` —
-		// and such a failure is baked into the session's frozen participant
-		// set, so no retry of the same session could ever succeed anyway.
+		// double-count the peers' commitments. Through the public API this
+		// path should be unreachable — `round2_reveal` rejects parties
+		// outside the DKG set before freezing the session — but the reset
+		// stays as defense in depth: a failure here is baked into the frozen
+		// participant set, so no retry of the same session could succeed.
 		let responses = match self.state.expect_round2().and_then(|(round1_data, round2_data)| {
 			generate_round3_response(&self.private_key, &self.config, round1_data, round2_data)
 		}) {
@@ -1274,19 +1293,64 @@ mod tests {
 		);
 	}
 
+	/// A Round 1 broadcast from a party outside the DKG participant set must
+	/// be rejected by `round2_reveal` *before* its commit point. Deferring
+	/// the check means Round 3 only detects the ghost inside
+	/// `recover_share`, after the peers' reveals have been folded into the
+	/// aggregate — where the only safe recovery is a full session reset.
+	/// Failing early keeps the session in AfterRound1, cleanly retryable
+	/// with a corrected participant set.
+	#[test]
+	fn test_round2_rejects_party_outside_dkg_set_before_commit() {
+		use crate::{broadcast::Round1Broadcast, generate_with_dealer};
+
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[14u8; 32], config).unwrap();
+		let mut s0 = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
+		let mut s1 = ThresholdSigner::new(shares[1].clone(), pk, config).unwrap();
+
+		let ssid = [0x22u8; 32];
+		let r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
+		let r1_1 = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
+		let _ = r1_0;
+
+		// Well-formed Round 1 broadcast from party 99, which is not in the
+		// DKG participant set {0, 1, 2}.
+		let r1_99 = Round1Broadcast::new(ssid, 99, [0xEEu8; 32]);
+
+		let err = s0
+			.round2_reveal(&ssid, b"early", b"", core::slice::from_ref(&r1_99))
+			.expect_err("round2_reveal must reject a party outside the DKG set");
+		assert!(
+			matches!(err, ThresholdError::InvalidConfiguration(_)),
+			"expected InvalidConfiguration for a non-DKG party, got {err:?}"
+		);
+
+		// The rejection must precede the commit point: the session stays in
+		// AfterRound1 and a retry with the honest participant set succeeds.
+		assert_eq!(
+			s0.state.phase,
+			SigningPhase::AfterRound1,
+			"early rejection must leave the session cleanly retryable"
+		);
+		s0.round2_reveal(&ssid, b"early", b"", core::slice::from_ref(&r1_1))
+			.expect("retry with the honest participant set must succeed");
+	}
+
 	/// A failure *after* `aggregate_reveals` has folded peer commitments into
 	/// `w_aggregated` must reset the session, exactly like the aggregation
 	/// failure path itself: leaving the signer in AfterRound2 with a mutated
 	/// aggregate would let a retry re-run `aggregate_reveals` and double-count
 	/// every peer's commitment, silently poisoning the session.
 	///
-	/// The failure is triggered through the documented recoverable-looking
-	/// path: a Round 1 broadcast from a party that is not in the DKG
-	/// participant set is accepted by `round2_reveal` (the docs defer the
-	/// check), passes all Round 3 reveal validation (its reveal is genuinely
-	/// hash-bound and well-formed), and only fails inside
-	/// `generate_round3_response` -> `recover_share` with
-	/// `InvalidConfiguration` — after the aggregate is already committed.
+	/// The failure is triggered inside `generate_round3_response` ->
+	/// `recover_share` (`InvalidConfiguration` for a party outside the DKG
+	/// set) — after the aggregate is already committed. Through the public
+	/// API this trigger is no longer reachable: `round2_reveal` rejects
+	/// non-DKG parties before freezing the session (see
+	/// `test_round2_rejects_party_outside_dkg_set_before_commit`). The test
+	/// therefore plants the ghost by editing the frozen session state
+	/// directly, keeping the defensive reset covered.
 	#[test]
 	fn test_round3_failure_after_aggregation_resets_session() {
 		use crate::{
@@ -1303,7 +1367,7 @@ mod tests {
 
 		let ssid = [0x21u8; 32];
 		let r1_0 = s0.round1_commit_with_seed(&ssid, &[1u8; 32]).unwrap();
-		let _r1_1 = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
+		let r1_1 = s1.round1_commit_with_seed(&ssid, &[2u8; 32]).unwrap();
 		let r2_1 = s1.round2_reveal(&ssid, b"reset", b"", core::slice::from_ref(&r1_0)).unwrap();
 
 		// Rebrand party 1's valid commitment data as coming from party 99,
@@ -1315,7 +1379,16 @@ mod tests {
 		let r1_99 = Round1Broadcast::new(ssid, 99, ghost_hash);
 		let r2_99 = Round2Broadcast::new(ssid, 99, r2_1.commitment_data.clone());
 
-		s0.round2_reveal(&ssid, b"reset", b"", core::slice::from_ref(&r1_99)).unwrap();
+		// Run an honest Round 2 (party 99 would now be rejected), then plant
+		// the ghost in the frozen session state: swap the frozen commitment
+		// map and active-participant list to name party 99 instead of 1.
+		s0.round2_reveal(&ssid, b"reset", b"", core::slice::from_ref(&r1_1)).unwrap();
+		{
+			let round2_data = s0.state.round2_data.as_mut().unwrap();
+			round2_data.round1_commitments.clear();
+			round2_data.round1_commitments.insert(99, ghost_hash);
+			round2_data.active_participants = ParticipantList::new(&[0, 99]).unwrap();
+		}
 
 		let err = s0
 			.round3_respond(&ssid, core::slice::from_ref(&r1_99), core::slice::from_ref(&r2_99))

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -146,7 +146,7 @@ use crate::{
 	broadcast::{Round1Broadcast, Round2Broadcast, Round3Broadcast, Signature, SSID_SIZE},
 	participants::{ParticipantId, ParticipantList},
 	protocol::signing::compute_ssid,
-	signer::ThresholdSigner,
+	signer::{ThresholdSigner, SINGLE_COMMITMENT_SIZE},
 };
 
 // ============================================================================
@@ -175,6 +175,14 @@ pub enum Action<T> {
 /// near-mpc's transport frames up to 100 MiB (`MAX_MESSAGE_SIZE_BYTES`), so this is well within the
 /// network layer's budget.
 pub const MAX_SIGNING_MESSAGE_SIZE: usize = 12 * 1024 * 1024;
+
+/// Fixed header of every serialized [`SigningMessage`]: the 1-byte Borsh enum
+/// variant tag followed by the [`SSID_SIZE`]-byte session identifier (every
+/// variant's first field is `ssid`; pinned by the
+/// `signing_frame_header_layout_pins_ssid` test). This lets wrong-session
+/// frames be discarded from the header alone, before deserializing their
+/// (attacker-controlled) variable-length payloads.
+const FRAME_HEADER_LEN: usize = 1 + SSID_SIZE;
 
 // ============================================================================
 // Error Types
@@ -801,6 +809,21 @@ impl DilithiumSignProtocol {
 		borsh::to_vec(msg).map_err(|e| SignProtocolError::SerializationError(e.to_string()))
 	}
 
+	/// Largest legitimate serialized frame for *this session's* configuration.
+	///
+	/// The dominant frame is the Round 2 commitment broadcast: a variant tag
+	/// (1 byte), the SSID (32), party_id (4), a length prefix (4), and
+	/// `k_iterations` commitments of [`SINGLE_COMMITMENT_SIZE`] bytes each.
+	/// Every other round is smaller (Round 3 responses are 4480 bytes per
+	/// iteration; Round 1 and Round 4 are fixed-size). Using the per-config
+	/// `k` instead of the global [`MAX_SIGNING_MESSAGE_SIZE`] keeps small
+	/// sessions from inheriting the (4,6) worst-case (k=1600, ~9.4 MB)
+	/// allocation budget.
+	fn max_frame_size(&self) -> usize {
+		let k = self.signer.config().k_iterations() as usize;
+		FRAME_HEADER_LEN + 4 + 4 + k * SINGLE_COMMITMENT_SIZE
+	}
+
 	/// Deserialize a message from network bytes.
 	fn deserialize_message(&self, data: &[u8]) -> Result<SigningMessage, SignProtocolError> {
 		if data.is_empty() {
@@ -813,6 +836,18 @@ impl DilithiumSignProtocol {
 				"Message size {} exceeds maximum {}",
 				data.len(),
 				MAX_SIGNING_MESSAGE_SIZE
+			)));
+		}
+
+		// Reject frames larger than anything this session's configuration can
+		// legitimately produce, still before any parsing or allocation.
+		let max_frame = self.max_frame_size();
+		if data.len() > max_frame {
+			return Err(SignProtocolError::SerializationError(format!(
+				"Message size {} exceeds maximum {} for this configuration (k={})",
+				data.len(),
+				max_frame,
+				self.signer.config().k_iterations()
 			)));
 		}
 
@@ -1078,6 +1113,24 @@ impl DilithiumSignProtocol {
 			return Ok(());
 		}
 
+		// Cheap fixed-header SSID check *before* deserialization. Round 2/3
+		// payloads can be multi-megabyte, so parsing before this check would
+		// let wrong-session frames (guaranteed to be dropped) drive avoidable
+		// allocation and CPU work on every receiver. Frames outside the size
+		// budget or too short to carry a header fall through to the
+		// deserializer, whose O(1) length checks reject them as malformed
+		// before parsing.
+		if data.len() >= FRAME_HEADER_LEN &&
+			data.len() <= self.max_frame_size() &&
+			data[1..FRAME_HEADER_LEN] != self.ssid
+		{
+			warn!(
+				"Signing: Rejecting message from {} - SSID mismatch (cross-session replay attempt?)",
+				from
+			);
+			return Ok(()); // SSID mismatch, ignore (not an error, likely cross-session replay)
+		}
+
 		// Deserialize and route the message
 		let msg = match self.deserialize_message(&data) {
 			Ok(m) => m,
@@ -1086,7 +1139,9 @@ impl DilithiumSignProtocol {
 			},
 		};
 
-		// Verify SSID matches for all message types
+		// Verify SSID matches for all message types (defense in depth behind
+		// the header check above; also covers any future variant whose layout
+		// diverges from the pinned header).
 		let msg_ssid = msg.ssid();
 		if *msg_ssid != self.ssid {
 			warn!(
@@ -2461,6 +2516,110 @@ mod tests {
 		);
 
 		assert!(result.is_ok(), "Should accept 255-byte context");
+	}
+
+	/// Build a fresh 2-of-3 protocol for party 0 with participants {0, 1}.
+	fn frame_test_protocol() -> DilithiumSignProtocol {
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[42u8; 32], config).unwrap();
+		let signer = ThresholdSigner::new(shares[0].clone(), pk, config).unwrap();
+		DilithiumSignProtocol::new(
+			signer,
+			b"test message".to_vec(),
+			b"context".to_vec(),
+			vec![0, 1],
+			0,
+			[0xAA; 32],
+			[0xBB; 32],
+		)
+		.unwrap()
+	}
+
+	/// Wrong-session traffic must be discarded from the fixed frame header
+	/// (tag byte + SSID) alone, before any deserialization: Round 2/3 payloads
+	/// are multi-megabyte, so parsing before the SSID check lets guaranteed-to-
+	/// be-dropped frames drive avoidable allocation and CPU work on every
+	/// receiver. Observable contract: a wrong-SSID frame is ignored (`Ok`)
+	/// regardless of how malformed its body is — it must never reach the
+	/// deserializer, whose truncated-payload error would surface as
+	/// `MalformedMessage`.
+	#[test]
+	fn wrong_ssid_frame_ignored_without_deserialization() {
+		let mut protocol = frame_test_protocol();
+
+		// Round 2 frame for a *different* session, claiming a ~9 MB payload
+		// but delivering a few bytes. If this reaches borsh, deserialization
+		// does chunked-allocation work and then fails with an error.
+		let mut frame = Vec::new();
+		frame.push(1u8); // SigningMessage::Round2 tag
+		frame.extend_from_slice(&[0xEEu8; SSID_SIZE]); // wrong ssid
+		frame.extend_from_slice(&1u32.to_le_bytes()); // party_id
+		frame.extend_from_slice(&9_000_000u32.to_le_bytes()); // claimed payload len
+		frame.extend_from_slice(&[0u8; 16]); // truncated body
+
+		let result = protocol.message(1, frame);
+		assert!(
+			result.is_ok(),
+			"wrong-SSID frame must be ignored from the header, not parsed: {result:?}"
+		);
+		assert!(protocol.r2_broadcasts.is_empty(), "nothing may be stored");
+		assert!(protocol.message_buffer.is_empty(), "nothing may be buffered");
+	}
+
+	/// A frame larger than any legitimate message for *this session's*
+	/// configuration must be rejected before parsing. The global cap is sized
+	/// for the (4,6) worst case (k=1600, ~12 MiB); a 2-of-3 session (k=5,
+	/// largest honest frame ~29 KB) must not accept and buffer megabytes of
+	/// junk that only fails at combine-time length validation.
+	#[test]
+	fn oversized_frame_for_config_rejected_before_parse() {
+		let mut protocol = frame_test_protocol();
+		let ssid = *protocol.ssid();
+
+		// Correct SSID, valid Round 2 shape, fully-delivered 1 MB payload:
+		// within the global caps, far beyond anything a k=5 session can emit.
+		let payload_len = 1_000_000usize;
+		let mut frame = Vec::new();
+		frame.push(1u8); // SigningMessage::Round2 tag
+		frame.extend_from_slice(&ssid);
+		frame.extend_from_slice(&1u32.to_le_bytes()); // party_id
+		frame.extend_from_slice(&(payload_len as u32).to_le_bytes());
+		frame.resize(frame.len() + payload_len, 0);
+
+		let result = protocol.message(1, frame);
+		assert!(
+			result.is_err(),
+			"frame exceeding this configuration's budget must be rejected before parse"
+		);
+		assert!(protocol.message_buffer.is_empty(), "oversized junk must not be buffered");
+	}
+
+	/// The cheap header check relies on every `SigningMessage` variant
+	/// serializing as `[tag u8][ssid; 32]...`. Pin that layout so a field
+	/// reorder cannot silently make the header check drop valid messages.
+	#[test]
+	fn signing_frame_header_layout_pins_ssid() {
+		use crate::broadcast::SIGNATURE_SIZE;
+
+		let ssid = [0xC7u8; SSID_SIZE];
+		let variants = vec![
+			SigningMessage::Round1(Round1Broadcast::new(ssid, 3, [9u8; 32])),
+			SigningMessage::Round2(Round2Broadcast { ssid, party_id: 3, commitment_data: vec![1] }),
+			SigningMessage::Round3(Round3Broadcast { ssid, party_id: 3, response: vec![2] }),
+			SigningMessage::Round4Complete(Round4Broadcast::new(
+				ssid,
+				Signature::from_bytes(&[7u8; SIGNATURE_SIZE]).unwrap(),
+			)),
+		];
+		for msg in variants {
+			let bytes = borsh::to_vec(&msg).unwrap();
+			assert_eq!(
+				&bytes[1..1 + SSID_SIZE],
+				&ssid[..],
+				"SSID must sit immediately after the variant tag (round {})",
+				msg.round()
+			);
+		}
 	}
 
 	/// A Round 4 message whose signature field is not exactly `SIGNATURE_SIZE`

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -1288,8 +1288,14 @@ impl DilithiumSignProtocol {
 	/// - We have no Round 1 from the claimed party (replay before any Round 1, or Round 2 from a
 	///   non-participant — already filtered earlier, but cheap to re-verify), or
 	/// - The commitment_data is empty (every participant must contribute), or
+	/// - The commitment_data is not exactly the size this session's configuration produces (a
+	///   wrong-length reveal can never pass Round 3's exact-length check, so buffering it would
+	///   only let a peer occupy the party's r2 slot with data guaranteed to fail later), or
 	/// - The hash does not match (the reveal does not correspond to that commitment, most likely a
 	///   replay from an earlier protocol instance).
+	///
+	/// The length checks run before the hash check so a hash-bound but mis-sized
+	/// reveal is dropped in O(1) instead of after SHAKE256 over the payload.
 	fn round2_matches_stored_round1(&self, r2: &Round2Broadcast) -> bool {
 		let Some(r1) = self.r1_broadcasts.get(&r2.party_id) else {
 			return false;
@@ -1300,6 +1306,10 @@ impl DilithiumSignProtocol {
 		// 2. Observing other parties' Round 2 reveals
 		// 3. Sending empty Round 2 to bypass hash verification while still counting as participant
 		if r2.commitment_data.is_empty() {
+			return false;
+		}
+		let expected_len = self.signer.config().k_iterations() as usize * SINGLE_COMMITMENT_SIZE;
+		if r2.commitment_data.len() != expected_len {
 			return false;
 		}
 		crate::protocol::signing::verify_commitment_hash(
@@ -2323,6 +2333,51 @@ mod tests {
 			"Buffered Round 2 with mismatched commitment hash must be dropped, not promoted"
 		);
 		assert!(protocol.message_buffer.round2.is_empty());
+	}
+
+	/// A Round 2 reveal whose commitment_data is not exactly the size this
+	/// session's configuration produces must be dropped at intake, even when
+	/// it is hash-bound to the stored Round 1 commitment (a peer can always
+	/// pre-commit to garbage). A wrong-length reveal can never pass Round 3's
+	/// exact-length check, so buffering it only lets a malicious peer occupy
+	/// the party's r2 slot with data that is guaranteed to fail later.
+	#[test]
+	fn test_round2_with_wrong_length_but_matching_hash_is_dropped() {
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[42u8; 32], config).unwrap();
+
+		let signer = ThresholdSigner::new(shares[0].clone(), pk, config).unwrap();
+		let mut protocol = DilithiumSignProtocol::new(
+			signer,
+			b"test".to_vec(),
+			b"ctx".to_vec(),
+			vec![0, 1],
+			0,
+			[0xAA; 32],
+			[0xBB; 32], // attempt_nonce
+		)
+		.unwrap();
+
+		let _ = protocol.poke().unwrap();
+		let ssid = *protocol.ssid();
+
+		// The peer pre-committed (Round 1) to a wrong-length blob, so the
+		// Round 2 reveal is genuinely hash-bound — only the length is off.
+		let wrong_len_data = vec![0xA5u8; 64];
+		let bound_hash =
+			crate::protocol::signing::compute_commitment_hash(&ssid, 1, &wrong_len_data);
+		protocol.r1_broadcasts.insert(1, Round1Broadcast::new(ssid, 1, bound_hash));
+		protocol.state = SignProtocolState::Round2Waiting;
+
+		let r2 = Round2Broadcast::new(ssid, 1, wrong_len_data);
+		let msg = SigningMessage::Round2(r2);
+		let data = protocol.serialize_message(&msg).unwrap();
+		protocol.message(1, data).unwrap();
+
+		assert!(
+			!protocol.r2_broadcasts.contains_key(&1),
+			"hash-bound but wrong-length Round 2 reveal must be dropped at intake"
+		);
 	}
 
 	/// Empty commitment_data in Round 2 must be rejected.

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -1116,10 +1116,16 @@ impl DilithiumSignProtocol {
 		// Cheap fixed-header SSID check *before* deserialization. Round 2/3
 		// payloads can be multi-megabyte, so parsing before this check would
 		// let wrong-session frames (guaranteed to be dropped) drive avoidable
-		// allocation and CPU work on every receiver. Frames outside the size
-		// budget or too short to carry a header fall through to the
-		// deserializer, whose O(1) length checks reject them as malformed
-		// before parsing.
+		// allocation and CPU work on every receiver.
+		//
+		// The size gate does not change what is ultimately rejected — it
+		// picks the failure mode. A well-sized frame with a foreign SSID is
+		// silently ignored (`Ok(())`): most likely cross-session traffic or
+		// a replay, not this session's problem. A frame outside the size
+		// budget (or too short to carry a header) skips the SSID early-out
+		// and falls to the deserializer, whose O(1) length checks reject it
+		// as `MalformedMessage`: oversize is sender misbehavior worth
+		// surfacing regardless of which session the frame claims.
 		if data.len() >= FRAME_HEADER_LEN &&
 			data.len() <= self.max_frame_size() &&
 			data[1..FRAME_HEADER_LEN] != self.ssid

--- a/threshold/tests/derivation_tests.rs
+++ b/threshold/tests/derivation_tests.rs
@@ -11,10 +11,45 @@
 
 use qp_rusty_crystals_dilithium::fips202;
 use qp_rusty_crystals_threshold::{
-	derive_dkg_contribution, generate_with_dealer, verify_signature, DerivedKeyId, PrivateKeyShare,
-	ThresholdConfig, ThresholdSigner,
+	derive_dkg_contribution, generate_with_dealer,
+	keygen::dkg::{run_local_dkg, TranscriptSigner},
+	verify_signature, DerivedKeyId, PrivateKeyShare, ThresholdConfig, ThresholdSigner,
 };
 use std::collections::HashMap;
+
+/// Simple test signer for DKG transcript signing.
+#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
+struct TestSigner {
+	id: u32,
+}
+
+impl TranscriptSigner for TestSigner {
+	type Signature = Vec<u8>;
+	type PublicKey = u32;
+
+	fn sign(&self, hash: &[u8; 32]) -> Self::Signature {
+		let mut sig = vec![0u8; 36];
+		sig[..4].copy_from_slice(&self.id.to_le_bytes());
+		sig[4..36].copy_from_slice(hash);
+		sig
+	}
+
+	fn verify(pk: &Self::PublicKey, hash: &[u8; 32], sig: &Self::Signature) -> bool {
+		Self::verify_bytes(pk, hash, sig)
+	}
+
+	fn verify_bytes(pk: &Self::PublicKey, hash: &[u8; 32], sig: &[u8]) -> bool {
+		if sig.len() < 36 {
+			return false;
+		}
+		let sig_id = u32::from_le_bytes(sig[..4].try_into().unwrap());
+		sig_id == *pk && &sig[4..36] == hash
+	}
+
+	fn public_key(&self) -> Self::PublicKey {
+		self.id
+	}
+}
 
 /// Helper to create a test tweak (simulates what the contract would compute).
 /// This is for testing purposes only - production code should use the contract's
@@ -112,15 +147,19 @@ fn test_dkg_contribution_key_isolation() {
 fn test_derived_key_id() {
 	let tweak1 = test_tweak("alice.near", "ethereum");
 	let tweak2 = test_tweak("bob.near", "ethereum");
+	let key_hash_a = [0xA1u8; 64];
+	let key_hash_b = [0xB2u8; 64];
 
-	let id1 = DerivedKeyId::new(0, tweak1);
-	let id2 = DerivedKeyId::new(0, tweak1);
-	let id3 = DerivedKeyId::new(0, tweak2);
-	let id4 = DerivedKeyId::new(1, tweak1);
+	let id1 = DerivedKeyId::from_key_hash(0, tweak1, key_hash_a);
+	let id2 = DerivedKeyId::from_key_hash(0, tweak1, key_hash_a);
+	let id3 = DerivedKeyId::from_key_hash(0, tweak2, key_hash_a);
+	let id4 = DerivedKeyId::from_key_hash(1, tweak1, key_hash_a);
+	let id5 = DerivedKeyId::from_key_hash(0, tweak1, key_hash_b);
 
 	assert_eq!(id1, id2, "Same inputs should produce same ID");
 	assert_ne!(id1, id3, "Different tweaks should produce different IDs");
 	assert_ne!(id1, id4, "Different domains should produce different IDs");
+	assert_ne!(id1, id5, "Different derived keys should produce different IDs");
 }
 
 /// Test that DerivedKeyId can be used as HashMap key
@@ -130,9 +169,10 @@ fn test_derived_key_id_as_hashmap_key() {
 
 	let tweak_alice = test_tweak("alice.near", "ethereum");
 	let tweak_bob = test_tweak("bob.near", "ethereum");
+	let key_hash = [0xC3u8; 64];
 
-	let id1 = DerivedKeyId::new(0, tweak_alice);
-	let id2 = DerivedKeyId::new(0, tweak_bob);
+	let id1 = DerivedKeyId::from_key_hash(0, tweak_alice, key_hash);
+	let id2 = DerivedKeyId::from_key_hash(0, tweak_bob, key_hash);
 
 	map.insert(id1.clone(), "alice_eth_key".to_string());
 	map.insert(id2.clone(), "bob_eth_key".to_string());
@@ -141,8 +181,51 @@ fn test_derived_key_id_as_hashmap_key() {
 	assert_eq!(map.get(&id2), Some(&"bob_eth_key".to_string()));
 
 	// Lookup with freshly created ID should work
-	let id1_fresh = DerivedKeyId::new(0, tweak_alice);
+	let id1_fresh = DerivedKeyId::from_key_hash(0, tweak_alice, key_hash);
 	assert_eq!(map.get(&id1_fresh), Some(&"alice_eth_key".to_string()));
+}
+
+/// Two DKG attempts for the same `(domain, tweak)` — differing only in the
+/// mandatory fresh `session_nonce`, e.g. a retry after a stalled session —
+/// produce different, non-recomputable derived keys. The storage identifier
+/// must distinguish those attempts' outputs: if both collide under one
+/// `DerivedKeyId`, a repeated-request or retry race lets one session's shares
+/// overwrite (or split across nodes) another's, while the rest of the system
+/// registered a public key that no longer matches the stored shares.
+#[test]
+fn derived_key_id_distinguishes_dkg_attempts() {
+	let signers: Vec<TestSigner> = (0..3).map(|id| TestSigner { id }).collect();
+	let verifying_keys: Vec<u32> = (0..3).collect();
+	// Same per-party seed material for both attempts, as in a real retry for
+	// the same (master_key, tweak): only the session nonce is fresh.
+	let seed = [7u8; 32];
+
+	let attempt1 =
+		run_local_dkg(2, 3, signers.clone(), verifying_keys.clone(), seed, &[0x01u8; 32])
+			.expect("first DKG attempt");
+	let attempt2 = run_local_dkg(2, 3, signers, verifying_keys, seed, &[0x02u8; 32])
+		.expect("second DKG attempt (retry with fresh nonce)");
+
+	let pk1 = &attempt1[0].public_key;
+	let pk2 = &attempt2[0].public_key;
+	// Documented behaviour: a retry with a fresh nonce yields a different key.
+	assert_ne!(
+		pk1.as_bytes()[..],
+		pk2.as_bytes()[..],
+		"retry with a fresh session nonce must produce a fresh derived key"
+	);
+
+	let tweak = test_tweak("alice.near", "ethereum");
+	let id_attempt1 = DerivedKeyId::new(0, tweak, pk1);
+	let id_attempt2 = DerivedKeyId::new(0, tweak, pk2);
+	assert_ne!(
+		id_attempt1, id_attempt2,
+		"storage identifiers must not collide across distinct DKG attempts"
+	);
+
+	// A fresh lookup built from the registered key hash finds the same record.
+	let lookup = DerivedKeyId::from_key_hash(0, tweak, id_attempt1.public_key_hash);
+	assert_eq!(lookup, id_attempt1);
 }
 
 /// Simulate the full derived key generation flow:

--- a/threshold/tests/heap_zeroization.rs
+++ b/threshold/tests/heap_zeroization.rs
@@ -32,7 +32,7 @@ use qp_rusty_crystals_dilithium::fips202;
 use qp_rusty_crystals_threshold::{
 	derive_dkg_contribution, generate_with_dealer,
 	keygen::dkg::{
-		compute_dkg_ssid, Dkg, DkgConfig, DkgMessage, Round1Private, TranscriptSigner,
+		compute_dkg_ssid, Dkg, DkgAction, DkgConfig, DkgMessage, Round1Private, TranscriptSigner,
 	},
 	resharing::{Action, ResharingConfig},
 	PrivateKeyShare, ThresholdConfig, ThresholdSigner,
@@ -252,6 +252,77 @@ fn run_local_reshare() -> (PrivateKeyShare, [u8; 32]) {
 	(share, round4_tail.expect("a Round 4 private frame was exchanged"))
 }
 
+/// Run a deterministic 2-of-3 DKG locally and return a subset shared secret
+/// K_S, captured as the last 32 bytes of the first Round 1 private frame (a
+/// subset leader delivering K_S to another member; subsets have size
+/// n-t+1 = 2 here, so privates are exchanged). All randomness is
+/// SHAKE-derived from the fixed per-party seeds and session nonce, so two
+/// invocations produce byte-identical secrets — a first (unscanned) run
+/// reveals the K_S a second, scanned run must wipe.
+fn run_local_dkg_2of3() -> [u8; 32] {
+	let threshold_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let participants: Vec<u32> = vec![0, 1, 2];
+	let pk_map: BTreeMap<u32, u32> = participants.iter().map(|&p| (p, p)).collect();
+	let session_nonce = [0x3Eu8; 32];
+
+	let mut dkgs: Vec<_> = participants
+		.iter()
+		.map(|&party_id| {
+			let config = DkgConfig::new(
+				threshold_config,
+				party_id,
+				participants.clone(),
+				TestSigner { id: party_id },
+				pk_map.clone(),
+			)
+			.expect("valid DKG config");
+			let mut seed = [0x90u8; 32];
+			seed[0] = party_id as u8;
+			Dkg::new(config, seed, &session_nonce)
+		})
+		.collect();
+
+	let mut queues: Vec<Vec<(u32, Vec<u8>)>> = vec![Vec::new(); participants.len()];
+	let mut ks_tail: Option<[u8; 32]> = None;
+	let mut done = vec![false; participants.len()];
+	for _ in 0..1000 {
+		if done.iter().all(|&d| d) {
+			break;
+		}
+		for i in 0..dkgs.len() {
+			if done[i] {
+				continue;
+			}
+			for (from, data) in std::mem::take(&mut queues[i]) {
+				dkgs[i].message(from, data).expect("message is processed");
+			}
+			match dkgs[i].poke().expect("poke succeeds") {
+				DkgAction::Wait => {},
+				DkgAction::SendMany(data) => {
+					for (j, queue) in queues.iter_mut().enumerate() {
+						if j != i {
+							queue.push((i as u32, data.clone()));
+						}
+					}
+				},
+				DkgAction::SendPrivate(to, mut data) => {
+					// Round 1 private frames carry K_S; the serialized tail
+					// is the secret itself.
+					if ks_tail.is_none() && data.len() >= 32 {
+						ks_tail = Some(data[data.len() - 32..].try_into().unwrap());
+					}
+					queues[to as usize].push((i as u32, std::mem::take(&mut *data)));
+				},
+				DkgAction::Return(_output) => {
+					done[i] = true;
+				},
+			}
+		}
+	}
+	assert!(done.iter().all(|&d| d), "DKG must complete");
+	ks_tail.expect("a Round 1 private frame was exchanged")
+}
+
 #[test]
 fn secret_intermediates_are_wiped_before_their_heap_memory_is_freed() {
 	// Scenario 1: hash_secret_shares linearization buffer.
@@ -362,6 +433,25 @@ fn secret_intermediates_are_wiped_before_their_heap_memory_is_freed() {
 		|| {
 			let (share, _) = run_local_reshare();
 			drop(share);
+		},
+	);
+
+	// Scenario 6: DKG K_S relocation out of Copy-typed containers.
+	// The subset shared secret K_S is a Copy `[u8; 32]`, so moving it out of
+	// a container leaves the source bytes intact: `transition_to_round2`
+	// consumed `received_shared_secrets` and freed the map nodes unwiped
+	// (past the reach of `DkgState::zeroize`, which finds the field already
+	// None), and `pending_privates.pop()` left the queued `Round1Private`
+	// bytes in the Vec buffer beyond the shrunken length, where the drop-time
+	// wipe (which only covers live elements) cannot reach them. The run is
+	// deterministic, so a first unscanned run reveals the K_S the scanned run
+	// must have wiped from every freed block.
+	let dkg_ks_pattern = run_local_dkg_2of3();
+	assert_no_secret_bearing_free(
+		"DKG K_S containers (received_shared_secrets map, pending_privates queue)",
+		dkg_ks_pattern,
+		|| {
+			let _ = run_local_dkg_2of3();
 		},
 	);
 }

--- a/threshold/tests/heap_zeroization.rs
+++ b/threshold/tests/heap_zeroization.rs
@@ -8,7 +8,9 @@
 //! - `Dkg::message` receives Round 1 private frames whose bytes contain the
 //!   serialized subset secret K_S;
 //! - `sample_hyperball` (via `ThresholdSigner::round1_commit_with_seed`)
-//!   squeezes the per-signature mask randomness into a scratch `Vec<u8>`.
+//!   squeezes the per-signature mask randomness into a scratch `Vec<u8>`;
+//! - the resharing protocol's `party_key` derivation linearizes the new
+//!   committee share's polynomial coefficients into a reusable `Vec<u8>`.
 //!
 //! Ordinary vectors do not overwrite their backing allocation when cleared or
 //! dropped, so each of these left secrets in allocator memory after the
@@ -32,8 +34,11 @@ use qp_rusty_crystals_threshold::{
 	keygen::dkg::{
 		compute_dkg_ssid, Dkg, DkgConfig, DkgMessage, Round1Private, TranscriptSigner,
 	},
+	resharing::{Action, ResharingConfig},
 	PrivateKeyShare, ThresholdConfig, ThresholdSigner,
 };
+
+mod common;
 
 /// The 32-byte pattern the allocator currently scans for. Updated between
 /// scenarios (only while scanning is off, so `try_lock` in the hook never
@@ -41,6 +46,7 @@ use qp_rusty_crystals_threshold::{
 static PATTERN: Mutex<[u8; 32]> = Mutex::new([0u8; 32]);
 static SCANNING: AtomicBool = AtomicBool::new(false);
 static SECRET_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+static LEAK_SIZE: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
 
 struct SecretScanningAllocator;
 
@@ -55,6 +61,7 @@ unsafe impl GlobalAlloc for SecretScanningAllocator {
 				let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
 				if block.windows(32).any(|w| w == *pattern) {
 					SECRET_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+					LEAK_SIZE.store(layout.size(), Ordering::SeqCst);
 				}
 			}
 		}
@@ -75,8 +82,9 @@ fn assert_no_secret_bearing_free(scenario: &str, pattern: [u8; 32], f: impl FnOn
 	SCANNING.store(false, Ordering::SeqCst);
 	assert!(
 		!SECRET_FREED_UNCLEARED.load(Ordering::SeqCst),
-		"{scenario}: a heap block still containing secret material was freed \
-		 without being zeroized"
+		"{scenario}: a heap block ({} bytes) still containing secret material was freed \
+		 without being zeroized",
+		LEAK_SIZE.load(Ordering::SeqCst)
 	);
 }
 
@@ -162,6 +170,88 @@ fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
 	pattern
 }
 
+/// Run a deterministic 2-of-2 -> 2-of-2 resharing locally and return the new
+/// share of party 0 plus the last 32 bytes of the first Round 4 transport
+/// frame (raw sub-share s2 coefficients). All seeds are fixed, and the leader
+/// is given the full expected active set, so two invocations produce
+/// byte-identical shares and frames — which lets the caller learn the secret
+/// coefficients from a first (unscanned) run and scan for them during a
+/// second run.
+fn run_local_reshare() -> (PrivateKeyShare, [u8; 32]) {
+	let config = ThresholdConfig::new(2, 2).expect("valid config");
+	let (pk, old_shares) = generate_with_dealer(&[0x51u8; 32], config).expect("keygen succeeds");
+	let participants = vec![0u32, 1u32];
+	let session_nonce = [0x7Bu8; 32];
+
+	let mut protocols: Vec<_> = participants
+		.iter()
+		.map(|&party_id| {
+			let rcfg = ResharingConfig::new(
+				Some(old_shares[party_id as usize].clone()),
+				2,
+				participants.clone(),
+				2,
+				participants.clone(),
+				party_id,
+				pk.clone(),
+			)
+			.expect("valid resharing config");
+			let mut seed = [0x60u8; 32];
+			seed[0] = party_id as u8;
+			common::new_test_protocol(rcfg, seed, &session_nonce)
+		})
+		.collect();
+
+	// The leader proposes as soon as both old members commit; no transport
+	// timeout is needed, keeping the run fully deterministic.
+	protocols[0].set_expected_active_set(&participants).expect("leader accepts expected set");
+
+	let mut queues: Vec<Vec<(u32, Vec<u8>)>> = vec![Vec::new(); participants.len()];
+	// Tail of the first private (Round 4) frame observed: the final s2
+	// coefficients of a raw sub-share, captured to a stack array so the
+	// caller can later scan freed heap blocks for them.
+	let mut round4_tail: Option<[u8; 32]> = None;
+	for _ in 0..1000 {
+		if protocols.iter().all(|p| p.is_done()) {
+			break;
+		}
+		for i in 0..protocols.len() {
+			if protocols[i].is_done() {
+				continue;
+			}
+			for (from, data) in std::mem::take(&mut queues[i]) {
+				protocols[i].message(from, data).expect("message is processed");
+			}
+			match protocols[i].poke().expect("poke succeeds") {
+				Action::Wait | Action::Return(_) => {},
+				Action::SendMany(data) => {
+					for (j, queue) in queues.iter_mut().enumerate() {
+						if j != i {
+							queue.push((i as u32, data.clone()));
+						}
+					}
+				},
+				Action::SendPrivate(to, mut data) => {
+					// The only private frames in this protocol are Round 4
+					// sub-share deliveries.
+					if round4_tail.is_none() && data.len() >= 32 {
+						round4_tail = Some(data[data.len() - 32..].try_into().unwrap());
+					}
+					queues[to as usize].push((i as u32, std::mem::take(&mut *data)));
+				},
+			}
+		}
+	}
+	assert!(protocols.iter().all(|p| p.is_done()), "resharing must complete");
+
+	let share = protocols[0]
+		.take_output()
+		.expect("party 0 has an output")
+		.private_share
+		.expect("new committee member carries a share");
+	(share, round4_tail.expect("a Round 4 private frame was exchanged"))
+}
+
 #[test]
 fn secret_intermediates_are_wiped_before_their_heap_memory_is_freed() {
 	// Scenario 1: hash_secret_shares linearization buffer.
@@ -230,6 +320,48 @@ fn secret_intermediates_are_wiped_before_their_heap_memory_is_freed() {
 			signer
 				.round1_commit_with_seed(&sign_ssid, &round1_seed)
 				.expect("round 1 commit succeeds");
+		},
+	);
+	drop(signer);
+
+	// Scenario 4: resharing party_key linearization buffer.
+	// build_private_key_share serializes every new share coefficient into a
+	// scratch Vec to derive party_key; a plain Vec leaves those coefficients
+	// in freed allocator memory (and its incremental growth frees unwiped
+	// intermediate blocks). The run is deterministic, so a first unscanned
+	// run reveals the coefficients the second, scanned run must wipe: the
+	// pattern is the tail of the serialized share (the last s2 coefficients
+	// of the highest subset mask), which is exactly the tail of the scratch
+	// buffer's final contents.
+	// The reference blob holds the real share, so wipe it before it is freed:
+	// dropping it plain would plant the pattern in recycled allocator memory
+	// and make the scanner flag stale bytes instead of a live leak.
+	let (reference_share, round4_tail) = run_local_reshare();
+	let blob = zeroize::Zeroizing::new(borsh::to_vec(&reference_share).expect("share serializes"));
+	let mut reshare_pattern = [0u8; 32];
+	reshare_pattern.copy_from_slice(&blob[blob.len() - 32..]);
+	drop(blob);
+	drop(reference_share);
+
+	assert_no_secret_bearing_free(
+		"resharing build_private_key_share (party-key buffer)",
+		reshare_pattern,
+		|| {
+			let (share, _) = run_local_reshare();
+			drop(share);
+		},
+	);
+
+	// Scenario 5: resharing Round 4 transport frames.
+	// The private frames carry raw sub-share coefficients; the frame buffer
+	// must be wiped when the receiving protocol has consumed it (and the
+	// sender-side serialization must not free unwiped intermediates).
+	assert_no_secret_bearing_free(
+		"resharing transport frames (Round 4 sub-shares)",
+		round4_tail,
+		|| {
+			let (share, _) = run_local_reshare();
+			drop(share);
 		},
 	);
 }

--- a/threshold/tests/heap_zeroization.rs
+++ b/threshold/tests/heap_zeroization.rs
@@ -1,0 +1,235 @@
+//! Regression tests (security review): secret-bearing intermediates must never
+//! be freed while still containing key material.
+//!
+//! Several code paths copy secrets into ordinary heap-backed buffers:
+//!
+//! - `hash_secret_shares` (via `derive_dkg_contribution`) linearizes secret
+//!   share polynomial coefficients into a reusable `Vec<u8>`;
+//! - `Dkg::message` receives Round 1 private frames whose bytes contain the
+//!   serialized subset secret K_S;
+//! - `sample_hyperball` (via `ThresholdSigner::round1_commit_with_seed`)
+//!   squeezes the per-signature mask randomness into a scratch `Vec<u8>`.
+//!
+//! Ordinary vectors do not overwrite their backing allocation when cleared or
+//! dropped, so each of these left secrets in allocator memory after the
+//! structured zeroizing types had been wiped.
+//!
+//! The test installs a global allocator that scans every freed block for the
+//! current scenario's secret pattern at `dealloc` time (the block is still
+//! valid inside the hook, so the scan is sound). This file contains exactly
+//! one test so no unrelated concurrent allocations can race the scanner.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	collections::BTreeMap,
+	sync::Mutex,
+};
+
+use qp_rusty_crystals_dilithium::fips202;
+use qp_rusty_crystals_threshold::{
+	derive_dkg_contribution, generate_with_dealer,
+	keygen::dkg::{
+		compute_dkg_ssid, Dkg, DkgConfig, DkgMessage, Round1Private, TranscriptSigner,
+	},
+	PrivateKeyShare, ThresholdConfig, ThresholdSigner,
+};
+
+/// The 32-byte pattern the allocator currently scans for. Updated between
+/// scenarios (only while scanning is off, so `try_lock` in the hook never
+/// contends and never misses).
+static PATTERN: Mutex<[u8; 32]> = Mutex::new([0u8; 32]);
+static SCANNING: AtomicBool = AtomicBool::new(false);
+static SECRET_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+
+struct SecretScanningAllocator;
+
+unsafe impl GlobalAlloc for SecretScanningAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		if SCANNING.load(Ordering::SeqCst) && layout.size() >= 32 {
+			if let Ok(pattern) = PATTERN.try_lock() {
+				let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+				if block.windows(32).any(|w| w == *pattern) {
+					SECRET_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+				}
+			}
+		}
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: SecretScanningAllocator = SecretScanningAllocator;
+
+/// Run `f` with the allocator scanning for `pattern`, and assert no freed
+/// block still contained it.
+fn assert_no_secret_bearing_free(scenario: &str, pattern: [u8; 32], f: impl FnOnce()) {
+	*PATTERN.lock().unwrap() = pattern;
+	SECRET_FREED_UNCLEARED.store(false, Ordering::SeqCst);
+	SCANNING.store(true, Ordering::SeqCst);
+	f();
+	SCANNING.store(false, Ordering::SeqCst);
+	assert!(
+		!SECRET_FREED_UNCLEARED.load(Ordering::SeqCst),
+		"{scenario}: a heap block still containing secret material was freed \
+		 without being zeroized"
+	);
+}
+
+/// Simple test signer for DKG transcript signing.
+#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
+struct TestSigner {
+	id: u32,
+}
+
+impl TranscriptSigner for TestSigner {
+	type Signature = Vec<u8>;
+	type PublicKey = u32;
+
+	fn sign(&self, hash: &[u8; 32]) -> Self::Signature {
+		let mut sig = vec![0u8; 36];
+		sig[..4].copy_from_slice(&self.id.to_le_bytes());
+		sig[4..36].copy_from_slice(hash);
+		sig
+	}
+
+	fn verify(pk: &Self::PublicKey, hash: &[u8; 32], sig: &Self::Signature) -> bool {
+		Self::verify_bytes(pk, hash, sig)
+	}
+
+	fn verify_bytes(pk: &Self::PublicKey, hash: &[u8; 32], sig: &[u8]) -> bool {
+		if sig.len() < 36 {
+			return false;
+		}
+		let sig_id = u32::from_le_bytes(sig[..4].try_into().unwrap());
+		sig_id == *pk && &sig[4..36] == hash
+	}
+
+	fn public_key(&self) -> Self::PublicKey {
+		self.id
+	}
+}
+
+/// Coefficient pattern for the share-digest scenario: eight i32 coefficients
+/// whose little-endian bytes form a distinctive 32-byte sequence. Each value
+/// is 0x003C5A4x (< Q), so the planted share passes the (-Q, Q) import check.
+fn share_coefficient_pattern() -> [u8; 32] {
+	let mut pattern = [0u8; 32];
+	for i in 0..8 {
+		pattern[4 * i..4 * i + 4].copy_from_slice(&[0x41 + i as u8, 0x5A, 0x3C, 0x00]);
+	}
+	pattern
+}
+
+/// A `PrivateKeyShare` whose last eight s2 coefficients are the pattern above:
+/// serialize a dealer share, overwrite the trailing coefficient bytes, and
+/// re-import through the public Borsh boundary.
+fn share_with_planted_coefficients() -> PrivateKeyShare {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let (_pk, shares) = generate_with_dealer(&[0x42u8; 32], config).expect("keygen succeeds");
+
+	let mut blob = borsh::to_vec(&shares[0]).expect("share serializes");
+	let tail = blob.len() - 32;
+	blob[tail..].copy_from_slice(&share_coefficient_pattern());
+	borsh::from_slice(&blob).expect("planted share re-imports")
+}
+
+/// First 32 bytes of the SHAKE256 stream `sample_hyperball` squeezes into its
+/// scratch buffer for iteration 0 of `round1_commit_with_seed(ssid, seed)`.
+/// Recomputed here through the public fips202 API, mirroring the derivation in
+/// `protocol/signing.rs` (iteration 0 leaves the seed unmodified).
+fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, seed);
+	fips202::shake256_absorb(&mut state, ssid);
+	fips202::shake256_absorb(&mut state, b"rho_prime");
+	fips202::shake256_absorb(&mut state, &[0u8]);
+	fips202::shake256_finalize(&mut state);
+	let mut iter_rho_prime = [0u8; 64];
+	fips202::shake256_squeeze(&mut iter_rho_prime, &mut state);
+
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, b"H");
+	fips202::shake256_absorb(&mut state, &iter_rho_prime);
+	fips202::shake256_absorb(&mut state, &0u16.to_le_bytes());
+	fips202::shake256_finalize(&mut state);
+	let mut pattern = [0u8; 32];
+	fips202::shake256_squeeze(&mut pattern, &mut state);
+	pattern
+}
+
+#[test]
+fn secret_intermediates_are_wiped_before_their_heap_memory_is_freed() {
+	// Scenario 1: hash_secret_shares linearization buffer.
+	// The buffer holds every secret share coefficient in serialized form; it
+	// used to be a plain Vec that was clear()ed and dropped unwiped.
+	let share = share_with_planted_coefficients();
+	assert_no_secret_bearing_free(
+		"derive_dkg_contribution (share-digest buffer)",
+		share_coefficient_pattern(),
+		|| {
+			let contribution = derive_dkg_contribution(&share, &[0x11u8; 32]);
+			assert_ne!(contribution, [0u8; 32]);
+		},
+	);
+	drop(share);
+
+	// Scenario 2: incoming DKG transport frame carrying K_S.
+	// An attacker cannot choose K_S, but the receiving node's own heap must
+	// not retain the secret after Dkg::message returns, whatever the message's
+	// fate (here: dropped for SSID mismatch, the earliest-exit path).
+	let ks_pattern = *b"dkg-round1-private-ks-pattern-32";
+	let threshold_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let participants: Vec<u32> = vec![0, 1, 2];
+	let pk_map: BTreeMap<u32, u32> = participants.iter().map(|&p| (p, p)).collect();
+	let config = DkgConfig::new(
+		threshold_config,
+		0,
+		participants.clone(),
+		TestSigner { id: 0 },
+		pk_map,
+	)
+	.expect("valid DKG config");
+	let session_nonce = [0xA5u8; 32];
+	let ssid = compute_dkg_ssid(2, 3, &participants, &session_nonce);
+	let mut dkg = Dkg::new(config, [0x77u8; 32], &session_nonce);
+
+	let frame = borsh::to_vec(&DkgMessage::Round1Private(Round1Private {
+		ssid: [0u8; 32], // wrong session: message is deserialized, then dropped
+		from_party_id: 1,
+		subset_mask: 0b011,
+		shared_secret: ks_pattern,
+	}))
+	.expect("round1 private serializes");
+	assert!(ssid != [0u8; 32], "test setup: frame must not match the real ssid");
+
+	assert_no_secret_bearing_free("Dkg::message (Round 1 private frame)", ks_pattern, || {
+		dkg.message(1, frame).expect("well-formed frame is processed");
+	});
+	drop(dkg);
+
+	// Scenario 3: hyperball sampling scratch buffer.
+	// The raw SHAKE stream that becomes the per-signature mask y was squeezed
+	// into a plain Vec; leaking y alongside the published response z = y + c*s1
+	// recovers the secret share.
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let (pk, shares) = generate_with_dealer(&[7u8; 32], config).expect("keygen succeeds");
+	let mut signer =
+		ThresholdSigner::new(shares.into_iter().next().unwrap(), pk, config).expect("signer");
+	let sign_ssid = [0x5Cu8; 32];
+	let round1_seed = [0x33u8; 32];
+
+	assert_no_secret_bearing_free(
+		"round1_commit_with_seed (hyperball XOF buffer)",
+		hyperball_stream_pattern(&sign_ssid, &round1_seed),
+		|| {
+			signer
+				.round1_commit_with_seed(&sign_ssid, &round1_seed)
+				.expect("round 1 commit succeeds");
+		},
+	);
+}

--- a/threshold/tests/heap_zeroization.rs
+++ b/threshold/tests/heap_zeroization.rs
@@ -3,14 +3,14 @@
 //!
 //! Several code paths copy secrets into ordinary heap-backed buffers:
 //!
-//! - `hash_secret_shares` (via `derive_dkg_contribution`) linearizes secret
-//!   share polynomial coefficients into a reusable `Vec<u8>`;
-//! - `Dkg::message` receives Round 1 private frames whose bytes contain the
-//!   serialized subset secret K_S;
-//! - `sample_hyperball` (via `ThresholdSigner::round1_commit_with_seed`)
-//!   squeezes the per-signature mask randomness into a scratch `Vec<u8>`;
-//! - the resharing protocol's `party_key` derivation linearizes the new
-//!   committee share's polynomial coefficients into a reusable `Vec<u8>`.
+//! - `hash_secret_shares` (via `derive_dkg_contribution`) linearizes secret share polynomial
+//!   coefficients into a reusable `Vec<u8>`;
+//! - `Dkg::message` receives Round 1 private frames whose bytes contain the serialized subset
+//!   secret K_S;
+//! - `sample_hyperball` (via `ThresholdSigner::round1_commit_with_seed`) squeezes the per-signature
+//!   mask randomness into a scratch `Vec<u8>`;
+//! - the resharing protocol's `party_key` derivation linearizes the new committee share's
+//!   polynomial coefficients into a reusable `Vec<u8>`.
 //!
 //! Ordinary vectors do not overwrite their backing allocation when cleared or
 //! dropped, so each of these left secrets in allocator memory after the
@@ -204,7 +204,9 @@ fn run_local_reshare() -> (PrivateKeyShare, [u8; 32]) {
 
 	// The leader proposes as soon as both old members commit; no transport
 	// timeout is needed, keeping the run fully deterministic.
-	protocols[0].set_expected_active_set(&participants).expect("leader accepts expected set");
+	protocols[0]
+		.set_expected_active_set(&participants)
+		.expect("leader accepts expected set");
 
 	let mut queues: Vec<Vec<(u32, Vec<u8>)>> = vec![Vec::new(); participants.len()];
 	// Tail of the first private (Round 4) frame observed: the final s2
@@ -224,13 +226,12 @@ fn run_local_reshare() -> (PrivateKeyShare, [u8; 32]) {
 			}
 			match protocols[i].poke().expect("poke succeeds") {
 				Action::Wait | Action::Return(_) => {},
-				Action::SendMany(data) => {
+				Action::SendMany(data) =>
 					for (j, queue) in queues.iter_mut().enumerate() {
 						if j != i {
 							queue.push((i as u32, data.clone()));
 						}
-					}
-				},
+					},
 				Action::SendPrivate(to, mut data) => {
 					// The only private frames in this protocol are Round 4
 					// sub-share deliveries.
@@ -298,13 +299,12 @@ fn run_local_dkg_2of3() -> [u8; 32] {
 			}
 			match dkgs[i].poke().expect("poke succeeds") {
 				DkgAction::Wait => {},
-				DkgAction::SendMany(data) => {
+				DkgAction::SendMany(data) =>
 					for (j, queue) in queues.iter_mut().enumerate() {
 						if j != i {
 							queue.push((i as u32, data.clone()));
 						}
-					}
-				},
+					},
 				DkgAction::SendPrivate(to, mut data) => {
 					// Round 1 private frames carry K_S; the serialized tail
 					// is the secret itself.
@@ -347,14 +347,9 @@ fn secret_intermediates_are_wiped_before_their_heap_memory_is_freed() {
 	let threshold_config = ThresholdConfig::new(2, 3).expect("valid config");
 	let participants: Vec<u32> = vec![0, 1, 2];
 	let pk_map: BTreeMap<u32, u32> = participants.iter().map(|&p| (p, p)).collect();
-	let config = DkgConfig::new(
-		threshold_config,
-		0,
-		participants.clone(),
-		TestSigner { id: 0 },
-		pk_map,
-	)
-	.expect("valid DKG config");
+	let config =
+		DkgConfig::new(threshold_config, 0, participants.clone(), TestSigner { id: 0 }, pk_map)
+			.expect("valid DKG config");
 	let session_nonce = [0xA5u8; 32];
 	let ssid = compute_dkg_ssid(2, 3, &participants, &session_nonce);
 	let mut dkg = Dkg::new(config, [0x77u8; 32], &session_nonce);

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -245,7 +245,7 @@ fn run_resharing_protocol_full(
 						}
 					}
 				},
-				Ok(Action::SendPrivate(to, data)) => {
+				Ok(Action::SendPrivate(to, mut data)) => {
 					any_activity = true;
 					// Send to specific party. We deliberately do NOT loop self-private
 					// messages back: the protocol must handle self-deals locally and
@@ -256,9 +256,12 @@ fn run_resharing_protocol_full(
 						 self-deals must be handled locally",
 						party_id
 					);
-					let payload = match tamper.as_mut() {
-						Some(f) => f(party_id, Some(to), data),
-						None => data,
+					let payload = {
+						let raw = std::mem::take(&mut *data);
+						match tamper.as_mut() {
+							Some(f) => f(party_id, Some(to), raw),
+							None => raw,
+						}
 					};
 					// Messages to offline parties are dropped (dead node).
 					if let Some(queue) = message_queues.get_mut(&to) {
@@ -1814,9 +1817,12 @@ fn run_resharing_protocol_with_seeds(
 								.push((party_id, data.clone()));
 						}
 					},
-				Ok(Action::SendPrivate(to, data)) => {
+				Ok(Action::SendPrivate(to, mut data)) => {
 					assert_ne!(to, party_id);
-					message_queues.get_mut(&to).unwrap().push((party_id, data));
+					message_queues
+						.get_mut(&to)
+						.unwrap()
+						.push((party_id, std::mem::take(&mut *data)));
 				},
 				Ok(Action::Return(_)) => {},
 				Err(e) => {


### PR DESCRIPTION
This PR addresses the fourth round of security review findings across the `dilithium`, `hdwallet`, and `threshold` crates. Every fix follows the same discipline: the finding was first reproduced with a failing regression test, then fixed, then re-verified (test red on the old code, green with the fix). 19 commits, 28 files, ~2600 insertions.

## Secret hygiene (zeroization)

**Heap intermediates are wiped before their memory is freed.** A new `threshold/tests/heap_zeroization.rs` suite installs a scanning global allocator that inspects every freed block for the scenario's secret pattern at `dealloc` time. It caught, and now guards, six scenarios:

- `derive_dkg_contribution`'s share-digest linearization buffer, incoming DKG Round 1 private frames carrying K_S, and the hyperball sampling scratch buffer (`7d63cf9`);
- the resharing protocol's `party_key` derivation buffer, Round 4 transport frames (both directions — `Action::SendPrivate` now carries `Zeroizing<Vec<u8>>`), sub-share derivation output, and per-polynomial hashing scratch buffers (`ce8175f`);
- DKG K_S relocation out of Copy-typed containers: `transition_to_round2` freed the `received_shared_secrets` map nodes with the secrets still in them (the state zeroizer runs too late — the field is already `None`), `pending_privates.pop()` left queued `Round1Private` bytes beyond the `Vec`'s shrunken length, and the buffered-privates drain consumed its map the same way (`4e6cb6d`);
- the wormhole Poseidon preimage (`preimage_felts`) was `clear()`ed but never wiped; covered by a dedicated allocator-instrumented test in `hdwallet/tests/wormhole_zeroization.rs` (`7d63cf9`).

**Stack copies of the ML-DSA-87 secret key are wiped in import/serialize paths.** `Keypair::from_bytes`, `SecretKey::from_bytes`, and `Keypair::to_bytes` left plaintext `[u8; SECRETKEYBYTES]` copies in dead stack frames because `[u8; N]` is `Copy`. All three now stage the secret in `Zeroizing` locals. A painted-stack probe test (`dilithium/tests/import_stack_zeroization.rs`, release-mode only — debug builds create compiler temporaries no source fix can wipe) verifies no copy survives (`2197133`).

**Debug output no longer leaks key material.** The resharing `Action::SendPrivate` payload (serialized sub-shares) is redacted from the manual `Debug` impl (`df8dee3`).

## Bounded, validating deserialization

- `ResharingActProposal::active_set` length is bounded at deserialize; a hostile length prefix can no longer drive unbounded allocation (`62f736e`).
- `PrivateKeyShare` metadata (threshold, party counts, participant list, share-map shape) is cross-checked at Borsh import and at `ThresholdSigner` construction (`345c7aa`).
- ML-DSA-87 secret keys whose `s1`/`s2` coefficients decode outside `[-ETA, ETA]` are rejected at import: `eta_unpack` and `unpack_sk` now return a canonicality flag (`#[must_use]`) that `public_key_from_secret` enforces, so non-canonical 3-bit slots (5–7) can no longer cross the boundary (`19e2bf0`).
- `SubsetContribution` (exported, previously derive-deserialized into unbounded `Vec<[i32; N]>`) now has a manual deserializer enforcing exactly `L`/`K` polynomials — length prefix checked before any allocation — and η-bounded coefficients, mirroring `SecretShareData` (`3ec5b15`).
- Invalid `DkgConfig` values are unconstructible: fields are private with accessors, and `all_broadcasts_received` uses total quorum arithmetic that cannot underflow on an empty participant list (`e1df0ca`).

## DoS hardening (no work before validation)

- The signing protocol checks the fixed-header SSID and a **per-config** frame budget (`k_iterations`-derived, ~23 KB for a (2,2) session instead of the global 12 MiB) before deserializing anything (`0428526`).
- `ExtendedPrivKey::derive` parses and validates the derivation path first and bounds the seed to the BIP32 master-seed range (16..=64 bytes, new `Error::InvalidSeedLength`) before doing any HMAC work (`bf9b646`).
- Round 2 reveals are rejected on the exact per-config length **before** the SHAKE256 commitment hash runs, so a peer who pre-committed to an oversized blob (up to the 10.5 MB global deserializer bound) cannot force megabytes of hashing in a session whose legitimate reveal is kilobytes; protocol intake drops hash-bound but mis-sized reveals in O(1) (`36e1079`).

## Protocol state-machine correctness

- Aborted resharing sessions no longer strand the old share: recovery restores it so the party can rejoin a retried session (`5e5c7ef`).
- `round3_respond` failures **after** the peers' reveals were folded into the commitment aggregate (e.g. `recover_share` rejecting an active party outside the DKG set — only detectable at that point) now reset the session instead of leaving a poisoned aggregate in the "cleanly retryable" `AfterRound2` state, where a retry would double-count every peer's commitment. Pre-commit-point failures still leave the session clean for corrected retries (`243bb0d`).
- `DerivedKeyId` is bound to the DKG output public key, preventing cross-key derivation-ID collisions (`5599c69`).

## API contract enforcement

- `poly::shiftl`'s unchecked left shift is no longer reachable through public API with out-of-contract coefficients: it is crate-private and the `k_shiftl` docs state the real `2^(31-D)` bound (`6fe967c`).
- `KeccakState` encodes the SHAKE rate as a const-generic parameter, making the absorb/squeeze phase-and-rate mismatches flagged by review unrepresentable, and squeeze chunking canonical (`225e629`).
- `uniform_eta`'s rejection-sampling retry loop is documented as not a timing channel: two fixed blocks yield 544 nibbles at 15/16 acceptance, so a third block is a < 2^-600 event, and rejection counts are independent of the accepted values under standard XOF assumptions (`ec388fe`).

## Compatibility notes

Behavioral tightenings downstream consumers may notice:

- `hdwallet`: seeds outside 16..=64 bytes are now rejected by `ExtendedPrivKey::derive` (new `Error::InvalidSeedLength` variant). The Quantus SDK's `derive_hd_path` passes 64-byte BIP39 seeds and is unaffected.
- `threshold`: resharing `Action::SendPrivate` now carries `Zeroizing<Vec<u8>>`; `DkgConfig` fields are private (use the accessors); `SubsetContribution` and secret-key/share imports reject blobs that previously deserialized.
- `dilithium`: `packing::unpack_sk` returns a `bool` canonicality flag; `poly::shiftl` is crate-private.

## Test plan

- [x] Each finding reproduced red before the fix and green after (error-variant or allocator/stack-probe assertions pin the mechanism, not just the outcome)
- [x] `cargo test --workspace` green (dilithium, hdwallet, threshold; unit + integration + e2e suites)
- [x] New regression suites: `threshold/tests/heap_zeroization.rs` (scanning allocator, 6 scenarios), `dilithium/tests/import_stack_zeroization.rs` (painted-stack probe, release builds), `hdwallet/tests/wormhole_zeroization.rs`
- [x] Release-mode runs for the stack-zeroization suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch authentication-adjacent key import, DKG/signing/resharing state machines, and secret zeroization; behavioral tightenings may break callers relying on previously accepted malformed keys or private struct fields.
> 
> **Overview**
> Fourth security-review pass hardens **secret handling**, **import/deserialize boundaries**, and **threshold protocol state** across `dilithium`, `hdwallet`, and `threshold`.
> 
> **ML-DSA / dilithium:** `KeccakState` is now rate-typed (`Shake128State` / `Shake256State`) with absorb/squeeze phase tracking and canonical squeeze chunking. Secret-key import/serialize uses `Zeroizing` locals so `Copy` stack arrays are not left behind; `unpack_sk` / `eta_unpack` return canonicality and reject out-of-range η coefficients at import; `shiftl` is crate-private.
> 
> **hdwallet:** BIP32 `derive` bounds seed length and validates paths before HMAC; wormhole derivation wipes felt-encoded preimages before heap free.
> 
> **threshold:** Widespread `Zeroizing` on buffers and transport frames (DKG K_S, resharing Round 4, hyperball sampling); `DerivedKeyId` includes the derived public key TR hash; aborted resharing can recover the old share via `take_existing_share`; signing resets the session if Round 3 fails after commitments are aggregated; stricter Borsh/constructor checks on `PrivateKeyShare`, `SubsetContribution`, and `DkgConfig`; DoS guards (reveal length before hash, bounded `active_set`, etc.). Regression tests add heap/stack scanning allocators where relevant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243bb0d9c256a5ce915559bc6c16a20e28f85b1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->