### PR TITLE
Zeroization and further hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "hmac",
+ "psm",
  "qp-poseidon-core",
  "qp-rusty-crystals-dilithium",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ resolver = "2"
 
 [workspace.dependencies]
 bincode = { version = "=1.3.3", default-features = false }
-bip39 = { version = "=2.2.2", default-features = false }
+# `zeroize` is required: without it, dropped `Mnemonic` values leave their
+# word-index buffer (from which the phrase is reconstructible) in dead memory.
+bip39 = { version = "=2.2.2", default-features = false, features = ["zeroize"] }
 borsh = { version = "=1.6.1", default-features = false, features = ["derive"] }
 criterion = { version = "=0.5.1", features = ["html_reports"] }
 getrandom = { version = "=0.2.17", features = ["js"] }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This implementation provides enterprise-grade memory security:
 // Secure by design - entropy is zeroized after conversion
 let mut entropy = [0u8; 32];
 getrandom::getrandom(&mut entropy).unwrap();
-let keypair = ml_dsa_87::Keypair::generate((&mut entropy).into());
+let keypair = ml_dsa_87::Keypair::generate(&mut (&mut entropy).into());
 // entropy is now [0,0,0,...] - no sensitive data left in memory
 
 // If you genuinely need a second copy of a keypair, you must opt in explicitly:
@@ -56,7 +56,7 @@ let mut entropy = [0u8; 32];
 getrandom::getrandom(&mut entropy).expect("Failed to generate entropy");
 
 // Generate keypair
-let keypair = ml_dsa_87::Keypair::generate((&mut entropy).into());
+let keypair = ml_dsa_87::Keypair::generate(&mut (&mut entropy).into());
 
 // Sign message
 let message = b"Hello, post-quantum world!";

--- a/dilithium/README.md
+++ b/dilithium/README.md
@@ -40,7 +40,7 @@ use qp_rusty_crystals_dilithium::ml_dsa_87;
 // Generate a keypair with secure random entropy
 let mut entropy = [0u8; 32];
 getrandom::getrandom(&mut entropy).expect("Failed to generate entropy");
-let keypair = ml_dsa_87::Keypair::generate((&mut entropy).into());
+let keypair = ml_dsa_87::Keypair::generate(&mut (&mut entropy).into());
 
 // Sign a message
 let message = b"Hello, post-quantum world!";
@@ -58,7 +58,7 @@ use qp_rusty_crystals_dilithium::ml_dsa_87;
 
 let mut entropy = [0u8; 32];
 getrandom::getrandom(&mut entropy).expect("Failed to generate entropy");
-let keypair = ml_dsa_87::Keypair::generate((&mut entropy).into());
+let keypair = ml_dsa_87::Keypair::generate(&mut (&mut entropy).into());
 
 let message = b"Important message";
 let context = b"email-signature-v1"; // Domain separation
@@ -75,7 +75,7 @@ use qp_rusty_crystals_dilithium::ml_dsa_87;
 
 let mut entropy = [0u8; 32];
 getrandom::getrandom(&mut entropy).expect("Failed to generate entropy");
-let keypair = ml_dsa_87::Keypair::generate((&mut entropy).into());
+let keypair = ml_dsa_87::Keypair::generate(&mut (&mut entropy).into());
 
 let message = b"Message to sign";
 

--- a/dilithium/benches/dilithium_benchmarks.rs
+++ b/dilithium/benches/dilithium_benchmarks.rs
@@ -25,14 +25,14 @@ macro_rules! bench_ml_dsa {
 		#[cfg(feature = $feature)]
 		{
 			use qp_rusty_crystals_dilithium::$mod_name::Keypair;
-			let keypair = Keypair::generate((&mut [2u8; 32]).into());
+			let keypair = Keypair::generate(&mut (&mut [2u8; 32]).into());
 			let msg = b"";
 			let sig = keypair.sign(msg, None, None).expect("Signing should succeed");
 			bench_variant(
 				$c,
 				$label,
 				|| {
-					let _ = Keypair::generate((&mut [1u8; 32]).into());
+					let _ = Keypair::generate(&mut (&mut [1u8; 32]).into());
 				},
 				|| {
 					let _ = keypair.sign(msg, None, None);

--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -210,7 +210,7 @@ fn sign_sk_expansion(runner: &mut CtRunner, rng: &mut BenchRng) {
 	let gen_sk = |rng: &mut BenchRng| -> [u8; params::SECRETKEYBYTES] {
 		let mut entropy = [0u8; 32];
 		rng.fill_bytes(&mut entropy);
-		let keypair = Keypair::generate((&mut entropy).into());
+		let keypair = Keypair::generate(&mut (&mut entropy).into());
 		// Bench-only throwaway keys: copy out of the self-wiping buffer.
 		*keypair.secret().to_bytes()
 	};

--- a/dilithium/examples/stack_probe.rs
+++ b/dilithium/examples/stack_probe.rs
@@ -45,13 +45,13 @@ fn kb(bytes: usize) -> String {
 
 fn main() {
 	// Prepare inputs on the normal stack.
-	let kp = ml_dsa_87::Keypair::generate((&mut [7u8; 32]).into());
+	let kp = ml_dsa_87::Keypair::generate(&mut (&mut [7u8; 32]).into());
 	let kp_bytes = kp.to_bytes();
 	let msg: &[u8] = b"stack probe message";
 	let sig = kp.sign(msg, None, None).expect("sign");
 
 	let keygen = peak_stack(|| {
-		let _ = ml_dsa_87::Keypair::generate((&mut [1u8; 32]).into());
+		let _ = ml_dsa_87::Keypair::generate(&mut (&mut [1u8; 32]).into());
 	});
 
 	// `to_bytes` now returns a self-wiping `Zeroizing` buffer, which is not

--- a/dilithium/examples/stack_usage_demo.rs
+++ b/dilithium/examples/stack_usage_demo.rs
@@ -137,8 +137,8 @@ fn main() {
 	println!("=== ML-DSA Stack Usage Analysis ===\n");
 
 	// Pre-generate test data for all variants
-	let entropy = get_random_bytes();
-	let ml87_keypair = ml_dsa_87::Keypair::generate(entropy);
+	let mut entropy = get_random_bytes();
+	let ml87_keypair = ml_dsa_87::Keypair::generate(&mut entropy);
 	let ml87_keypair_bytes = ml87_keypair.to_bytes();
 
 	let test_msg = b"stack usage test message";
@@ -166,7 +166,7 @@ fn main() {
 	for &size_kb in &stack_sizes {
 		// Test ML-DSA-87
 		let ml87_keygen = test_keygen_with_stack_size(size_kb, "ml-dsa-87", move || {
-			let _kp = ml_dsa_87::Keypair::generate((&mut [1u8; 32]).into());
+			let _kp = ml_dsa_87::Keypair::generate(&mut (&mut [1u8; 32]).into());
 			true
 		});
 
@@ -245,7 +245,7 @@ mod tests {
 	fn test_all_variants_4kb_stack() {
 		assert!(
 			test_keygen_with_stack_size(4, "ml-dsa-87", || {
-				let _kp = ml_dsa_87::Keypair::generate((&mut [1u8; 32]).into());
+				let _kp = ml_dsa_87::Keypair::generate(&mut (&mut [1u8; 32]).into());
 				true
 			}),
 			"ML-DSA-87 key generation should work with 4KB stack"

--- a/dilithium/src/acvp.rs
+++ b/dilithium/src/acvp.rs
@@ -88,7 +88,7 @@ macro_rules! acvp_for {
 						crate::sign::keypair_var::<K, L, ETA, PUBLICKEYBYTES, SECRETKEYBYTES>(
 							&mut pk,
 							&mut sk,
-							sensitive_seed,
+							&sensitive_seed,
 						);
 
 						assert_eq!(

--- a/dilithium/src/frontend.rs
+++ b/dilithium/src/frontend.rs
@@ -111,14 +111,18 @@ macro_rules! define_ml_dsa {
 			/// * 'entropy' - bytes for determining the generation process (must be at least 32
 			///   bytes)
 			///
-			/// Note: The entropy is moved here and zeroized after use, along with the derived
-			/// secret key.
-			pub fn generate(entropy: SensitiveBytes32) -> Keypair {
+			/// The entropy is borrowed mutably and zeroized in place after use
+			/// (security review): taking it by value would move — i.e. copy —
+			/// it through parameter slots that are dead but never dropped, so
+			/// `ZeroizeOnDrop` could not wipe them. The caller's value is
+			/// consumed in the practical sense: it is all zeros afterwards.
+			pub fn generate(entropy: &mut SensitiveBytes32) -> Keypair {
 				let mut pk = [0u8; PUBLICKEYBYTES];
 				let mut sk = [0u8; SECRETKEYBYTES];
 				$crate::sign::keypair_var::<K, L, ETA, PUBLICKEYBYTES, SECRETKEYBYTES>(
 					&mut pk, &mut sk, entropy,
 				);
+				entropy.as_mut_bytes().zeroize();
 				let keypair = Keypair {
 					// Constructed directly rather than via `SecretKey::from_bytes`:
 					// a freshly generated key is consistent by construction, and the
@@ -451,7 +455,7 @@ macro_rules! basic_variant_tests {
 		fn self_verify_roundtrip() {
 			use super::{Keypair, PUBLICKEYBYTES, SECRETKEYBYTES, SIGNBYTES};
 
-			let keys = Keypair::generate(basic_test_entropy());
+			let keys = Keypair::generate(&mut basic_test_entropy());
 			let msg = b"variant smoke test";
 			let sig = keys.sign(msg, None, None).unwrap();
 			assert!(keys.verify(msg, &sig, None));
@@ -465,7 +469,7 @@ macro_rules! basic_variant_tests {
 		fn hedged_and_context() {
 			use super::Keypair;
 
-			let keys = Keypair::generate(basic_test_entropy());
+			let keys = Keypair::generate(&mut basic_test_entropy());
 			let msg = b"ctx";
 			let h1 = basic_test_entropy();
 			let h2 = basic_test_entropy();
@@ -481,7 +485,7 @@ macro_rules! basic_variant_tests {
 			use super::{Keypair, MAX_MESSAGE_SIZE, SIGNBYTES};
 			use $crate::errors::SignatureError;
 
-			let keys = Keypair::generate(basic_test_entropy());
+			let keys = Keypair::generate(&mut basic_test_entropy());
 			let big = alloc::vec![0u8; MAX_MESSAGE_SIZE + 1];
 			assert!(matches!(keys.sign(&big, None, None), Err(SignatureError::MessageTooLong)));
 			assert!(!keys.verify(&big, &[0u8; SIGNBYTES], None));
@@ -524,8 +528,8 @@ macro_rules! adversarial_import_tests {
 			use super::{Keypair, KEYPAIRBYTES, SECRETKEYBYTES};
 			use $crate::errors::KeyParsingError;
 
-			let keys_a = Keypair::generate(adversarial_entropy());
-			let keys_b = Keypair::generate(adversarial_entropy());
+			let keys_a = Keypair::generate(&mut adversarial_entropy());
+			let keys_b = Keypair::generate(&mut adversarial_entropy());
 
 			// Genuine keypair bytes must round-trip.
 			let good = keys_a.to_bytes();
@@ -553,8 +557,8 @@ macro_rules! adversarial_import_tests {
 			use super::{Keypair, SecretKey};
 			use $crate::errors::KeyParsingError;
 
-			let keys_a = Keypair::generate(adversarial_entropy());
-			let keys_b = Keypair::generate(adversarial_entropy());
+			let keys_a = Keypair::generate(&mut adversarial_entropy());
+			let keys_b = Keypair::generate(&mut adversarial_entropy());
 
 			let secret_a = SecretKey::from_bytes(keys_a.secret().to_bytes().as_slice()).unwrap();
 			assert!(
@@ -585,7 +589,7 @@ macro_rules! adversarial_import_tests {
 				params::{POLYT0_PACKEDBYTES, SEEDBYTES, TR_BYTES},
 			};
 
-			let keys = Keypair::generate(adversarial_entropy());
+			let keys = Keypair::generate(&mut adversarial_entropy());
 			let good = keys.to_bytes();
 			assert!(
 				Keypair::from_bytes(good.as_slice()).is_ok(),
@@ -628,7 +632,7 @@ macro_rules! adversarial_import_tests {
 				params::{POLYT0_PACKEDBYTES, SEEDBYTES, TR_BYTES},
 			};
 
-			let keys = Keypair::generate(adversarial_entropy());
+			let keys = Keypair::generate(&mut adversarial_entropy());
 			let good = keys.secret().to_bytes();
 			assert!(
 				SecretKey::from_bytes(good.as_slice()).is_ok(),
@@ -717,7 +721,7 @@ macro_rules! adversarial_import_tests {
 			// Start from an honest key and re-derive everything after
 			// planting the out-of-range coefficient, so the forged blob is
 			// fully self-consistent (valid t0, tr, and matching public key).
-			let keys = Keypair::generate(adversarial_entropy());
+			let keys = Keypair::generate(&mut adversarial_entropy());
 			let sk_bytes = keys.secret().to_bytes();
 
 			let mut rho = [0u8; params::SEEDBYTES];
@@ -802,7 +806,7 @@ macro_rules! adversarial_import_tests {
 			assert!(matches!(PublicKey::from_bytes(&pk), Err(KeyParsingError::BadPublicKey)));
 
 			// A genuine public key must still round-trip through from_bytes.
-			let keys = Keypair::generate(adversarial_entropy());
+			let keys = Keypair::generate(&mut adversarial_entropy());
 			let good = keys.public().to_bytes();
 			assert!(PublicKey::from_bytes(&good).is_ok());
 		}

--- a/dilithium/src/lib.rs
+++ b/dilithium/src/lib.rs
@@ -49,6 +49,22 @@ impl SensitiveBytes32 {
 		result
 	}
 
+	/// All-zero value, intended to be filled in place via [`Self::as_mut_bytes`].
+	///
+	/// Writing the secret directly into the wrapper's interior avoids ever
+	/// materializing it in a separate buffer that `new`/`from` would have to
+	/// copy from (Rust moves and copies leave unwiped duplicates in dead
+	/// stack slots).
+	pub fn zeroed() -> Self {
+		Self([0u8; 32])
+	}
+
+	/// Mutable access to the wrapped bytes, for in-place construction
+	/// (see [`Self::zeroed`]). The value keeps sole ownership of the secret.
+	pub fn as_mut_bytes(&mut self) -> &mut [u8; 32] {
+		&mut self.0
+	}
+
 	pub fn as_bytes(&self) -> &[u8; 32] {
 		&self.0
 	}

--- a/dilithium/src/lib.rs
+++ b/dilithium/src/lib.rs
@@ -83,6 +83,22 @@ impl SensitiveBytes64 {
 		result
 	}
 
+	/// All-zero value, intended to be filled in place via [`Self::as_mut_bytes`].
+	///
+	/// Writing the secret directly into the wrapper's interior avoids ever
+	/// materializing it in a separate buffer that `new`/`from` would have to
+	/// copy from (Rust moves and copies leave unwiped duplicates in dead
+	/// stack slots).
+	pub fn zeroed() -> Self {
+		Self([0u8; 64])
+	}
+
+	/// Mutable access to the wrapped bytes, for in-place construction
+	/// (see [`Self::zeroed`]). The value keeps sole ownership of the secret.
+	pub fn as_mut_bytes(&mut self) -> &mut [u8; 64] {
+		&mut self.0
+	}
+
 	pub fn as_bytes(&self) -> &[u8; 64] {
 		&self.0
 	}

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -29,8 +29,8 @@ mod tests {
 	#[test]
 	fn self_verify_hedged() {
 		let msg = get_random_msg();
-		let entropy = get_random_bytes();
-		let keys = Keypair::generate(entropy);
+		let mut entropy = get_random_bytes();
+		let keys = Keypair::generate(&mut entropy);
 		let hedge = get_random_bytes();
 		let sig = keys.sign(&msg, None, Some(hedge.0)).unwrap();
 		assert!(keys.verify(&msg, &sig, None));
@@ -39,8 +39,8 @@ mod tests {
 	#[test]
 	fn self_verify() {
 		let msg = get_random_msg();
-		let entropy = get_random_bytes();
-		let keys = Keypair::generate(entropy);
+		let mut entropy = get_random_bytes();
+		let keys = Keypair::generate(&mut entropy);
 		let hedge = get_random_bytes();
 		let sig = keys.sign(&msg, None, Some(hedge.0)).unwrap();
 		assert!(keys.verify(&msg, &sig, None));
@@ -49,8 +49,8 @@ mod tests {
 	#[test]
 	fn verify_fails_with_different_context() {
 		let msg = get_random_msg();
-		let entropy = get_random_bytes();
-		let keys = Keypair::generate(entropy);
+		let mut entropy = get_random_bytes();
+		let keys = Keypair::generate(&mut entropy);
 		let hedge = get_random_bytes();
 
 		// Sign with context "test1"
@@ -67,7 +67,7 @@ mod tests {
 
 	#[test]
 	fn sign_rejects_oversized_message() {
-		let keys = Keypair::generate(get_random_bytes());
+		let keys = Keypair::generate(&mut get_random_bytes());
 		let big_msg = vec![0u8; MAX_MESSAGE_SIZE + 1];
 		let result = keys.sign(&big_msg, None, None);
 		assert!(matches!(result, Err(SignatureError::MessageTooLong)));
@@ -75,7 +75,7 @@ mod tests {
 
 	#[test]
 	fn verify_rejects_oversized_message() {
-		let keys = Keypair::generate(get_random_bytes());
+		let keys = Keypair::generate(&mut get_random_bytes());
 		let big_msg = vec![0u8; MAX_MESSAGE_SIZE + 1];
 		assert!(!keys.verify(&big_msg, &[0u8; SIGNBYTES], None));
 	}

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -440,6 +440,10 @@ pub(crate) fn t0_pack(r: &mut [u8], a: &Poly) {
 		r[13 * i + 11] |= (t[7] << 3) as u8;
 		r[13 * i + 12] = (t[7] >> 5) as u8;
 	}
+
+	// The staging array holds `D_SHL - t0[i]`, a trivially invertible
+	// transform of secret t0 coefficients; wipe it before returning.
+	t.zeroize();
 }
 
 /// Unpack polynomial t0 with coefficients in ]-2^{D-1}, 2^{D-1}].
@@ -783,6 +787,10 @@ pub(crate) fn eta_pack<const ETA: usize>(r: &mut [u8], a: &Poly) {
 			r[3 * i + 1] = (t[2] >> 2) | (t[3] << 1) | (t[4] << 4) | (t[5] << 7);
 			r[3 * i + 2] = (t[5] >> 1) | (t[6] << 2) | (t[7] << 5);
 		}
+
+		// The staging array holds `ETA - s[i]`, a trivially invertible
+		// transform of secret s1/s2 coefficients; wipe it before returning.
+		t.zeroize();
 	} else {
 		for i in 0..N / 2 {
 			let t0 = (ETA as i32 - a.coeffs[2 * i + 0]) as u8;
@@ -2122,5 +2130,133 @@ mod tests {
 		}
 		check::<39, 32>(0xA1); // ML-DSA-44: TAU = 39, c~ is 32 bytes
 		check::<49, 48>(0xB2); // ML-DSA-65: TAU = 49, c~ is 48 bytes
+	}
+}
+
+/// Regression tests (security review): the `t` staging arrays in `t0_pack`
+/// and `eta_pack` hold `D_SHL - t0[i]` / `ETA - s[i]` — trivially invertible
+/// transforms of secret-key coefficients — and must not survive in dead
+/// stack memory after packing returns.
+///
+/// Detection uses the same painted-stack technique as the workspace's
+/// `*_stack_zeroization` integration tests; these live here as unit tests
+/// because the packers are `pub(crate)`. The assertion is about codegen, so
+/// it is only compiled for optimized builds (`cargo test --release`).
+#[cfg(all(test, not(debug_assertions)))]
+mod pack_stack_zeroization_tests {
+	extern crate std;
+	use std::alloc::{alloc, dealloc, Layout};
+	use std::vec::Vec;
+
+	use super::*;
+
+	const PAINT: u8 = 0xAA;
+	// The packers only need a few KiB; keep the scanned region small.
+	const STACK_BYTES: usize = 256 * 1024;
+	const ALIGN: usize = 4096;
+
+	/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+	/// `pattern` and return whether it was found.
+	fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
+		let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+		unsafe {
+			let base = alloc(layout);
+			assert!(!base.is_null(), "probe stack allocation failed");
+			std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+			psm::on_stack(base, STACK_BYTES, f);
+
+			let region = std::slice::from_raw_parts(base, STACK_BYTES);
+			let offsets: Vec<usize> = region
+				.windows(pattern.len())
+				.enumerate()
+				.filter(|(_, w)| w == &pattern)
+				.map(|(i, _)| i)
+				.collect();
+			std::eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+			let found = !offsets.is_empty();
+			dealloc(base, layout);
+			found
+		}
+	}
+
+	#[test]
+	fn t0_pack_staging_buffer_leaves_no_residue() {
+		// Varied t0-range coefficients; stride 37 is coprime to the modulus
+		// walk so all eight final-iteration t values are distinct.
+		let mut a = Poly::default();
+		for (j, c) in a.coeffs.iter_mut().enumerate() {
+			*c = ((j * 37 + 11) % 8191) as i32 - 4095;
+		}
+
+		// The residue candidate is the staging array's final state: the last
+		// iteration's eight i32 values, in memory order.
+		let mut pattern = [0u8; 32];
+		for j in 0..8 {
+			let v = D_SHL - a.coeffs[N - 8 + j];
+			pattern[4 * j..4 * j + 4].copy_from_slice(&v.to_le_bytes());
+		}
+
+		// Sanity: the technique detects a deliberately leaked copy.
+		assert!(
+			probe_stack_for(&pattern, || {
+				let mut leaked = [0i32; 8];
+				for j in 0..8 {
+					leaked[j] = D_SHL - a.coeffs[N - 8 + j];
+				}
+				core::hint::black_box(&leaked);
+			}),
+			"probe self-check: a deliberately leaked staging copy was not detected"
+		);
+
+		let leaked = probe_stack_for(&pattern, || {
+			let mut packed = [0u8; 13 * N / 8];
+			t0_pack(&mut packed, &a);
+			core::hint::black_box(&packed);
+		});
+		assert!(
+			!leaked,
+			"t0_pack's staging buffer (D_SHL - t0 coefficients) survived in dead \
+			 stack memory after packing"
+		);
+	}
+
+	#[test]
+	fn eta_pack_staging_buffer_leaves_no_residue() {
+		// Coefficients in [-2, 1] so every staged byte ETA - c lies in 1..=4:
+		// the pattern then contains no 0x00/0xFF and cannot be mimicked by the
+		// i32 coefficient bytes of `a` or by the packed output (whose bytes
+		// are all >= 36 for staged values >= 1).
+		let mut a = Poly::default();
+		for (j, c) in a.coeffs.iter_mut().enumerate() {
+			*c = (j % 4) as i32 - 2;
+		}
+
+		let mut pattern = [0u8; 8];
+		for j in 0..8 {
+			pattern[j] = (2 - a.coeffs[N - 8 + j]) as u8;
+		}
+
+		assert!(
+			probe_stack_for(&pattern, || {
+				let mut leaked = [0u8; 8];
+				for j in 0..8 {
+					leaked[j] = (2 - a.coeffs[N - 8 + j]) as u8;
+				}
+				core::hint::black_box(&leaked);
+			}),
+			"probe self-check: a deliberately leaked staging copy was not detected"
+		);
+
+		let leaked = probe_stack_for(&pattern, || {
+			let mut packed = [0u8; 3 * N / 8];
+			eta_pack::<2>(&mut packed, &a);
+			core::hint::black_box(&packed);
+		});
+		assert!(
+			!leaked,
+			"eta_pack's staging buffer (ETA - s coefficients) survived in dead \
+			 stack memory after packing"
+		);
 	}
 }

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -2145,8 +2145,10 @@ mod tests {
 #[cfg(all(test, not(debug_assertions)))]
 mod pack_stack_zeroization_tests {
 	extern crate std;
-	use std::alloc::{alloc, dealloc, Layout};
-	use std::vec::Vec;
+	use std::{
+		alloc::{alloc, dealloc, Layout},
+		vec::Vec,
+	};
 
 	use super::*;
 

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -59,6 +59,12 @@ fn derive_public_components<const K: usize, const L: usize>(
 }
 
 /// Generate public and private key for an arbitrary ML-DSA parameter set.
+///
+/// The seed is borrowed rather than taken by value (security review): a
+/// by-value `SensitiveBytes32` is moved — i.e. copied — through parameter
+/// slots that are dead but never dropped, so `ZeroizeOnDrop` cannot wipe
+/// them. The borrow keeps the seed in the caller's wiping guard; the only
+/// in-frame copy lives in `preimage`, which is zeroized before returning.
 pub(crate) fn keypair_var<
 	const K: usize,
 	const L: usize,
@@ -68,13 +74,12 @@ pub(crate) fn keypair_var<
 >(
 	pk: &mut [u8; PK],
 	sk: &mut [u8; SK],
-	seed: SensitiveBytes32,
+	seed: &SensitiveBytes32,
 ) {
 	const {
 		assert!(PK == params::publickeybytes(K));
 		assert!(SK == params::secretkeybytes(K, L, ETA));
 	}
-	let mut seed_bytes = seed.into_bytes();
 	const SEEDBUF_LEN: usize = 2 * params::SEEDBYTES + params::CRHBYTES;
 	let mut seedbuf = [0u8; SEEDBUF_LEN];
 	// Build preimage = seed || K || L in a fixed stack buffer. A growable
@@ -83,7 +88,7 @@ pub(crate) fn keypair_var<
 	// realloc), freeing a seed-bearing heap block that zeroize() can no
 	// longer reach.
 	let mut preimage = [0u8; params::SEEDBYTES + 2];
-	preimage[..params::SEEDBYTES].copy_from_slice(&seed_bytes);
+	preimage[..params::SEEDBYTES].copy_from_slice(seed.as_bytes());
 	preimage[params::SEEDBYTES] = K as u8;
 	preimage[params::SEEDBYTES + 1] = L as u8;
 	fips202::shake256(&mut seedbuf, &preimage);
@@ -116,7 +121,6 @@ pub(crate) fn keypair_var<
 	// secret polynomials; now that they're packed into `sk` the working copies
 	// must not linger on the stack. (`rho`/`tr`/`t1` are public.)
 	seedbuf.zeroize();
-	seed_bytes.zeroize();
 	preimage.zeroize();
 	rhoprime.zeroize();
 	key.zeroize();
@@ -731,7 +735,7 @@ fn keypair(
 		{ params::ETA },
 		{ params::PUBLICKEYBYTES },
 		{ params::SECRETKEYBYTES },
-	>(pk, sk, seed)
+	>(pk, sk, &seed)
 }
 
 #[cfg(test)]

--- a/dilithium/tests/import_stack_zeroization.rs
+++ b/dilithium/tests/import_stack_zeroization.rs
@@ -89,7 +89,7 @@ macro_rules! import_stack_zeroization_tests {
 
 			#[test]
 			fn key_import_and_serialize_leave_no_secret_copies_on_the_stack() {
-				let keypair = Keypair::generate((&mut [0x5Au8; 32]).into());
+				let keypair = Keypair::generate(&mut (&mut [0x5Au8; 32]).into());
 				let kp_bytes = keypair.to_bytes();
 				let sk_bytes = keypair.secret().to_bytes();
 				let pattern = sk_pattern(sk_bytes.as_slice());

--- a/dilithium/tests/keygen_zeroization.rs
+++ b/dilithium/tests/keygen_zeroization.rs
@@ -58,11 +58,11 @@ macro_rules! check_variant {
 		use qp_rusty_crystals_dilithium::$mod_name::Keypair;
 
 		let mut seed = SEED_PATTERN;
-		let sensitive = SensitiveBytes32::new(&mut seed);
+		let mut sensitive = SensitiveBytes32::new(&mut seed);
 
 		SEED_FREED_UNCLEARED.store(false, Ordering::SeqCst);
 		SCANNING.store(true, Ordering::SeqCst);
-		let keypair = Keypair::generate(sensitive);
+		let keypair = Keypair::generate(&mut sensitive);
 		SCANNING.store(false, Ordering::SeqCst);
 
 		assert!(

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -30,8 +30,10 @@ hex.workspace = true
 serde.workspace = true
 zeroize = { workspace = true, features = ["alloc"] }
 
-# Dependencies for hderive module (ported from nam-tiny-hderive)
-hmac = { version = "0.12", default-features = false }
+# Dependency for hderive module (ported from nam-tiny-hderive). The HMAC
+# construction is implemented in-crate with zeroizing buffers; the `hmac`
+# crate's non-zeroizing state objects leaked secrets into dead stack memory
+# (security review), so it is intentionally not used here.
 sha2 = { version = "0.10", default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
@@ -41,6 +43,9 @@ getrandom = { workspace = true, features = ["js"] }
 hex-literal.workspace = true
 rand.workspace = true
 rand_core.workspace = true
+# Reference HMAC implementation for the stack-zeroization regression test.
+hmac = { version = "0.12", default-features = false }
+psm = "=0.1.31"
 
 [features]
 default = ["ml-dsa-87", "std"]

--- a/hdwallet/README.md
+++ b/hdwallet/README.md
@@ -75,10 +75,13 @@ derive many keys), use the seed entrypoints. Seeds are passed by move as
 self-zeroizing types:
 
 ```rust
-use qp_rusty_crystals_hdwallet::{derive_key_from_seed, mnemonic_to_seed};
+use qp_rusty_crystals_hdwallet::{derive_key_from_seed, mnemonic_to_seed, SensitiveBytes64};
 
-let mut seed = mnemonic_to_seed(mnemonic, None)?; // consumes the mnemonic
-let keypair = derive_key_from_seed((&mut seed).into(), "m/44'/189189'/0'/0'/0'")?;
+// The seed is written into a caller-provided self-zeroizing buffer;
+// the mnemonic string is consumed and zeroized.
+let mut seed = SensitiveBytes64::zeroed();
+mnemonic_to_seed(mnemonic, None, &mut seed)?;
+let keypair = derive_key_from_seed(seed, "m/44'/189189'/0'/0'/0'")?;
 ```
 
 ### Wormhole pairs

--- a/hdwallet/README.md
+++ b/hdwallet/README.md
@@ -8,7 +8,7 @@ Hierarchical Deterministic (HD) wallet implementation for post-quantum ML-DSA ke
 - **BIP-32 HD Derivation** - Hierarchical deterministic key derivation
 - **BIP-44 Compatible** - Standard derivation paths
 - **Post-Quantum** - Uses ML-DSA (Dilithium) signatures
-- **Hardened First 3 Levels** - Require hardened `purpose'`, `coin_type'`, `account'`; later levels optional
+- **Hardened Derivation Only** - Every path level must be hardened (e.g. `m/44'/189189'/0'/0'/0'`)
 
 ## Parameter sets
 
@@ -35,7 +35,7 @@ and the wormhole module work regardless of which ML-DSA features are enabled.
 
 ## Standard expected derivation path
 We use 44 for purpose, 189189 for coin type (Quantus), and account index for account
-Example: "m/44'/189189'/{account_index}'/0/0"
+Example: "m/44'/189189'/{account_index}'/0'/0'"
 
 ## Usage
 
@@ -98,9 +98,9 @@ println!("Address: {}", hex::encode(pair.address));
 
 ### Derivation Paths
 
-Standard BIP-44 derivation paths are supported:
+BIP-44-shaped derivation paths are supported, with every level hardened:
 ```
-m / purpose' / coin_type' / account' / change / address_index
+m / purpose' / coin_type' / account' / change' / address_index'
 ```
 
 Example paths:
@@ -108,11 +108,11 @@ Example paths:
 - `m/44'/189189'/1'/0'/0'` - First address of second account
 - `m/44'/189189'/0'/1'/0'` - First change address
 
-**Note**: For security, the first three indices must be hardened (`purpose'`, `coin_type'`, `account'`). Subsequent indices (`change`, `address_index`) may be unhardened.
+**Note**: Every index must be hardened. A path with an unhardened segment (e.g. `m/44'/189189'/0'/0/0`) is rejected with a `NotHardened` error before any derivation runs.
 
 ## Why Hardened Keys Only?
 
-Non-hardened key derivation relies on elliptic curve properties not present in lattice-based cryptography. For security, this implementation requires hardened derivation for the first three indices and permits flexibility for deeper levels.
+Non-hardened (public) child derivation relies on elliptic curve properties that lattice-based cryptography does not have, so an "unhardened" level cannot provide the public-derivability it implies. Like SLIP-10's ed25519 hierarchy, this implementation therefore requires hardened derivation at every level.
 
 ## Testing
 

--- a/hdwallet/src/hderive.rs
+++ b/hdwallet/src/hderive.rs
@@ -250,12 +250,30 @@ pub struct ExtendedPrivKey {
 }
 
 impl ExtendedPrivKey {
-	/// Attempts to derive an extended private key from a path.
+	/// All-zero key, intended to be filled by [`Self::derive`].
+	pub fn zeroed() -> ExtendedPrivKey {
+		ExtendedPrivKey {
+			secret_key: SensitiveBytes32::zeroed(),
+			chain_code: SensitiveBytes32::zeroed(),
+		}
+	}
+
+	/// Derives the extended private key at `path`, writing it into the
+	/// caller-provided `out`.
 	///
 	/// The path is parsed and validated first and the seed length is bounded
 	/// to [`MIN_SEED_BYTES`]`..=`[`MAX_SEED_BYTES`], so malformed requests are
-	/// rejected before any HMAC work is spent on the seed.
-	pub fn derive<Path>(seed: &[u8], path: Path) -> Result<ExtendedPrivKey, Error>
+	/// rejected before any HMAC work is spent on the seed. On error, `out` is
+	/// untouched.
+	///
+	/// The key is written in place rather than returned by value (security
+	/// review): Rust moves are copies that leave the moved-from stack slot
+	/// dead and unwiped (`ZeroizeOnDrop` only wipes the value's final resting
+	/// place), so a by-value return would leave the secret key and chain code
+	/// in a dead `Result` slot. With an out-parameter the key material only
+	/// ever exists inside the caller's self-zeroizing value; the
+	/// stack-residue regression test pins this.
+	pub fn derive<Path>(seed: &[u8], path: Path, out: &mut ExtendedPrivKey) -> Result<(), Error>
 	where
 		Path: IntoDerivationPath,
 	{
@@ -265,46 +283,50 @@ impl ExtendedPrivKey {
 		}
 
 		// `result` holds secret_key || chain_code; the self-wiping buffer is
-		// zeroized on drop, after the halves are copied into the
+		// zeroized on drop, after the halves are copied into `out`'s
 		// self-zeroizing `SensitiveBytes32` fields.
 		let mut result = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
 		hmac_sha512(b"Dilithium seed", &[seed], &mut result);
-		let (secret_key, chain_code) = result.split_at(32);
-
-		let mut sk = ExtendedPrivKey {
-			secret_key: SensitiveBytes32::from(&mut secret_key.try_into().unwrap()),
-			chain_code: SensitiveBytes32::from(&mut chain_code.try_into().unwrap()),
-		};
+		out.secret_key.as_mut_bytes().copy_from_slice(&result[..32]);
+		out.chain_code.as_mut_bytes().copy_from_slice(&result[32..]);
 
 		for child in path.as_ref() {
-			sk = sk.child(*child)?;
+			out.child_in_place(*child);
 		}
 
-		Ok(sk)
+		Ok(())
 	}
 
-	pub fn secret(&self) -> [u8; 32] {
-		*self.secret_key.as_bytes()
+	/// Borrow the derived secret key.
+	///
+	/// Returns a reference to the internal self-zeroizing storage rather
+	/// than a raw `[u8; 32]` copy (security review): the raw accessor
+	/// silently materialized an unguarded duplicate of the private key that
+	/// every caller had to remember to wipe. No copy is made here; a caller
+	/// that needs an owned copy must create it deliberately, inside a
+	/// self-zeroizing wrapper (e.g. fill a `SensitiveBytes32` in place).
+	pub fn secret(&self) -> &SensitiveBytes32 {
+		&self.secret_key
 	}
 
-	pub fn child(&self, child: ChildNumber) -> Result<ExtendedPrivKey, Error> {
-		// Feed the HMAC directly from the stored secret rather than
-		// `self.secret()`, which would materialize a throwaway `[u8; 32]` copy
-		// on the stack that is never wiped. See `derive` for the lifecycle of
-		// the self-wiping `result` buffer.
+	/// Overwrites this key with its child key at `child`, in place.
+	///
+	/// This replaces the by-value `child()` (security review): returning a
+	/// fresh `ExtendedPrivKey` moved the child's secret key and chain code
+	/// through a dead `Result` slot on every derivation step (see
+	/// [`Self::derive`]). Stepping in place keeps the key material inside
+	/// this value's self-zeroizing fields; the parent's bytes are destroyed
+	/// by being overwritten with the child's.
+	pub fn child_in_place(&mut self, child: ChildNumber) {
+		// See `derive` for the lifecycle of the self-wiping `result` buffer.
 		let mut result = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
 		hmac_sha512(
 			self.chain_code.as_bytes(),
 			&[&[0], self.secret_key.as_bytes(), &child.to_bytes()],
 			&mut result,
 		);
-		let (secret_key, chain_code) = result.split_at(32);
-
-		let child = ExtendedPrivKey {
-			secret_key: SensitiveBytes32::from(&mut secret_key.try_into().unwrap()),
-			chain_code: SensitiveBytes32::from(&mut chain_code.try_into().unwrap()),
-		};
-		Ok(child)
+		self.secret_key.as_mut_bytes().copy_from_slice(&result[..32]);
+		self.chain_code.as_mut_bytes().copy_from_slice(&result[32..]);
 	}
 }
 
@@ -329,9 +351,10 @@ mod tests {
 		let mnemonic = Mnemonic::parse_in_normalized(Language::English, phrase).unwrap();
 		let seed = mnemonic.to_seed_normalized("");
 
-		let account = ExtendedPrivKey::derive(&seed, "m/44'/60'/0'/0'/0'").unwrap();
+		let mut account = ExtendedPrivKey::zeroed();
+		ExtendedPrivKey::derive(&seed, "m/44'/60'/0'/0'/0'", &mut account).unwrap();
 
-		assert_eq!(expected_secret_key, &account.secret(), "Secret key is invalid");
+		assert_eq!(expected_secret_key, account.secret().as_bytes(), "Secret key is invalid");
 	}
 
 	// The in-crate zeroizing HMAC must be a correct HMAC-SHA512. Pin it to the
@@ -503,15 +526,16 @@ mod tests {
 	#[test]
 	fn seed_length_bounds_enforced() {
 		let path = "m/44'/60'/0'";
+		let mut out = ExtendedPrivKey::zeroed();
 		for ok_len in [16usize, 32, 64] {
 			assert!(
-				ExtendedPrivKey::derive(&vec![7u8; ok_len], path).is_ok(),
+				ExtendedPrivKey::derive(&vec![7u8; ok_len], path, &mut out).is_ok(),
 				"seed of {ok_len} bytes must be accepted"
 			);
 		}
 		for bad_len in [0usize, 15, 65, 1 << 20] {
 			assert_eq!(
-				ExtendedPrivKey::derive(&vec![7u8; bad_len], path).unwrap_err(),
+				ExtendedPrivKey::derive(&vec![7u8; bad_len], path, &mut out).unwrap_err(),
 				Error::InvalidSeedLength(bad_len),
 				"seed of {bad_len} bytes must be rejected"
 			);
@@ -525,8 +549,9 @@ mod tests {
 	#[test]
 	fn invalid_path_rejected_before_seed_is_touched() {
 		let huge_seed = vec![7u8; 1 << 20];
+		let mut out = ExtendedPrivKey::zeroed();
 		assert_eq!(
-			ExtendedPrivKey::derive(&huge_seed, "not-a-path").unwrap_err(),
+			ExtendedPrivKey::derive(&huge_seed, "not-a-path", &mut out).unwrap_err(),
 			Error::InvalidDerivationPath,
 			"path validation must run (and fail) before the seed is processed"
 		);

--- a/hdwallet/src/hderive.rs
+++ b/hdwallet/src/hderive.rs
@@ -24,6 +24,29 @@ const HARDENED_BIT: u32 = 1 << 31;
 const HMAC_BLOCK_BYTES: usize = 128;
 const HMAC_OUTPUT_BYTES: usize = 64;
 
+/// SHA-512 over `first` followed by the concatenation of `rest`, writing the
+/// digest into `out` and volatile-wiping the hasher state in place afterwards.
+///
+/// This is the only function in the crate containing `unsafe`; every other
+/// primitive that hashes secret material is built on it. It exists because
+/// `sha2` 0.10 has no zeroizing drop semantics: a plainly dropped `Sha512`
+/// leaves its block buffer — still holding input bytes verbatim — in a dead
+/// stack frame (security review). The hasher here is only driven through
+/// `&mut` methods (never moved), so wiping it in place erases every copy.
+fn sha512_wiped(first: &[u8], rest: &[&[u8]], out: &mut [u8; HMAC_OUTPUT_BYTES]) {
+	let mut hasher = Sha512::new();
+	hasher.update(first);
+	for part in rest {
+		hasher.update(part);
+	}
+	hasher.finalize_into_reset(GenericArray::from_mut_slice(&mut out[..]));
+
+	// SAFETY: `Sha512` is a flat struct (word state, length counter, block
+	// buffer, position), containing no pointers or Drop glue, so writing
+	// zeros over it is sound and it may be dropped afterwards.
+	unsafe { zeroize::zeroize_flat_type(&mut hasher) };
+}
+
 /// HMAC-SHA512 over `key` and the concatenation of `message_parts`, writing
 /// the tag into `out`.
 ///
@@ -33,12 +56,10 @@ const HMAC_OUTPUT_BYTES: usize = 64;
 /// frame, its block buffer holds message bytes verbatim, and its consuming
 /// `finalize(self)` moves all of that around the stack unwiped. Here every
 /// secret-bearing buffer is under our control: the ipad/opad key blocks are
-/// self-wiping, the hashers are only driven through `&mut` methods (never
-/// moved), and their flat state — which includes a block buffer still holding
-/// message bytes verbatim — is volatile-wiped in place before drop.
+/// self-wiping and both hash passes go through [`sha512_wiped`].
 ///
 /// Only keys up to one block are supported (the longer-key hashing step of
-/// RFC 2104 is intentionally omitted); both callers pass 14 or 32 bytes.
+/// RFC 2104 is intentionally omitted); callers pass 14, 32, or 64 bytes.
 fn hmac_sha512(key: &[u8], message_parts: &[&[u8]], out: &mut [u8; HMAC_OUTPUT_BYTES]) {
 	debug_assert!(key.len() <= HMAC_BLOCK_BYTES, "keys longer than one block are unsupported");
 
@@ -51,25 +72,53 @@ fn hmac_sha512(key: &[u8], message_parts: &[&[u8]], out: &mut [u8; HMAC_OUTPUT_B
 
 	// The pads are always passed as slices: passing the (Copy) arrays by
 	// value would leave unwiped copies of key material on the stack.
-	let mut inner = Sha512::new();
-	inner.update(ipad.as_slice());
-	for part in message_parts {
-		inner.update(part);
-	}
 	let mut inner_hash = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
-	inner.finalize_into_reset(GenericArray::from_mut_slice(&mut inner_hash[..]));
+	sha512_wiped(ipad.as_slice(), message_parts, &mut inner_hash);
+	sha512_wiped(opad.as_slice(), &[inner_hash.as_slice()], out);
+}
 
-	let mut outer = Sha512::new();
-	outer.update(opad.as_slice());
-	outer.update(inner_hash.as_slice());
-	outer.finalize_into_reset(GenericArray::from_mut_slice(&mut out[..]));
+/// PBKDF2-HMAC-SHA512 restricted to a single 64-byte output block (all this
+/// crate needs: BIP39 seed stretching), built on the zeroizing [`hmac_sha512`].
+///
+/// This replaces `bip39::Mnemonic::to_seed_normalized`, which returns the
+/// stretched seed as a plain `[u8; 64]` from a non-inlinable external
+/// function: its internal seed local is dropped unwiped in a dead stack
+/// frame, out of reach of any caller-side hygiene (security review). Here the
+/// caller provides the output buffer and every intermediate is self-wiping.
+pub(crate) fn pbkdf2_hmac_sha512(
+	password: &[u8],
+	salt_parts: &[&[u8]],
+	rounds: u32,
+	out: &mut [u8; HMAC_OUTPUT_BYTES],
+) {
+	// HMAC keys longer than one block are pre-hashed, exactly as RFC 2104
+	// prescribes (and as any HMAC implementation would do internally), so
+	// `hmac_sha512`'s one-block key limit holds. A 24-word mnemonic phrase —
+	// the PBKDF2 password — is typically longer than 128 bytes.
+	let mut hashed_key = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
+	let key: &[u8] = if password.len() > HMAC_BLOCK_BYTES {
+		sha512_wiped(password, &[], &mut hashed_key);
+		&hashed_key[..]
+	} else {
+		password
+	};
 
-	// SAFETY: `Sha512` is a flat struct (word state, length counter, block
-	// buffer, position), containing no pointers or Drop glue, so writing
-	// zeros over it is sound and it may be dropped afterwards.
-	unsafe {
-		zeroize::zeroize_flat_type(&mut inner);
-		zeroize::zeroize_flat_type(&mut outer);
+	// U1 = HMAC(P, salt || INT_32_BE(1)); the single output block is
+	// U1 ^ U2 ^ ... ^ Uc with U_i = HMAC(P, U_{i-1}).
+	let mut u = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
+	let mut next = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
+	let mut first_parts: Vec<&[u8]> = salt_parts.to_vec();
+	let block_index = 1u32.to_be_bytes();
+	first_parts.push(&block_index);
+	hmac_sha512(key, &first_parts, &mut u);
+	out.copy_from_slice(&*u);
+
+	for _ in 1..rounds {
+		hmac_sha512(key, &[&u[..]], &mut next);
+		u.copy_from_slice(&*next);
+		for (o, v) in out.iter_mut().zip(u.iter()) {
+			*o ^= v;
+		}
 	}
 }
 

--- a/hdwallet/src/hderive.rs
+++ b/hdwallet/src/hderive.rs
@@ -1,8 +1,10 @@
 use alloc::vec::Vec;
 use core::{ops::Deref, str::FromStr};
-use hmac::{Hmac, Mac};
-use sha2::Sha512;
-use zeroize::Zeroize;
+use sha2::{
+	digest::{generic_array::GenericArray, Digest},
+	Sha512,
+};
+use zeroize::Zeroizing;
 
 use crate::{SensitiveBytes32, MAX_DERIVATION_DEPTH, MAX_DERIVATION_PATH_BYTES};
 
@@ -17,6 +19,59 @@ pub enum Error {
 }
 
 const HARDENED_BIT: u32 = 1 << 31;
+
+/// SHA-512 block and output sizes (bytes), fixed by the hash function.
+const HMAC_BLOCK_BYTES: usize = 128;
+const HMAC_OUTPUT_BYTES: usize = 64;
+
+/// HMAC-SHA512 over `key` and the concatenation of `message_parts`, writing
+/// the tag into `out`.
+///
+/// This replaces the `hmac` crate, whose 0.12 state objects have no zeroizing
+/// drop semantics (security review): its key-schedule local leaves
+/// `key ^ opad` — and, depending on codegen, the raw key — in a dead stack
+/// frame, its block buffer holds message bytes verbatim, and its consuming
+/// `finalize(self)` moves all of that around the stack unwiped. Here every
+/// secret-bearing buffer is under our control: the ipad/opad key blocks are
+/// self-wiping, the hashers are only driven through `&mut` methods (never
+/// moved), and their flat state — which includes a block buffer still holding
+/// message bytes verbatim — is volatile-wiped in place before drop.
+///
+/// Only keys up to one block are supported (the longer-key hashing step of
+/// RFC 2104 is intentionally omitted); both callers pass 14 or 32 bytes.
+fn hmac_sha512(key: &[u8], message_parts: &[&[u8]], out: &mut [u8; HMAC_OUTPUT_BYTES]) {
+	debug_assert!(key.len() <= HMAC_BLOCK_BYTES, "keys longer than one block are unsupported");
+
+	let mut ipad = Zeroizing::new([0x36u8; HMAC_BLOCK_BYTES]);
+	let mut opad = Zeroizing::new([0x5cu8; HMAC_BLOCK_BYTES]);
+	for (i, b) in key.iter().enumerate() {
+		ipad[i] ^= *b;
+		opad[i] ^= *b;
+	}
+
+	// The pads are always passed as slices: passing the (Copy) arrays by
+	// value would leave unwiped copies of key material on the stack.
+	let mut inner = Sha512::new();
+	inner.update(ipad.as_slice());
+	for part in message_parts {
+		inner.update(part);
+	}
+	let mut inner_hash = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
+	inner.finalize_into_reset(GenericArray::from_mut_slice(&mut inner_hash[..]));
+
+	let mut outer = Sha512::new();
+	outer.update(opad.as_slice());
+	outer.update(inner_hash.as_slice());
+	outer.finalize_into_reset(GenericArray::from_mut_slice(&mut out[..]));
+
+	// SAFETY: `Sha512` is a flat struct (word state, length counter, block
+	// buffer, position), containing no pointers or Drop glue, so writing
+	// zeros over it is sound and it may be dropped afterwards.
+	unsafe {
+		zeroize::zeroize_flat_type(&mut inner);
+		zeroize::zeroize_flat_type(&mut outer);
+	}
+}
 
 /// Master-seed length bounds (bytes), per BIP32 (128..=512 bits). The
 /// higher-level wrappers always pass a fixed 64-byte BIP39 seed; this bound
@@ -160,21 +215,17 @@ impl ExtendedPrivKey {
 			return Err(Error::InvalidSeedLength(seed.len()));
 		}
 
-		let mut hmac: Hmac<Sha512> =
-			Hmac::new_from_slice(b"Dilithium seed").expect("seed is always correct; qed");
-		hmac.update(seed);
-
-		// `into_bytes()` yields a 64-byte buffer holding secret_key || chain_code.
-		// It is not a zeroizing type, so wipe it once the halves are copied into
-		// the self-zeroizing `SensitiveBytes32` fields.
-		let mut result = hmac.finalize().into_bytes();
+		// `result` holds secret_key || chain_code; the self-wiping buffer is
+		// zeroized on drop, after the halves are copied into the
+		// self-zeroizing `SensitiveBytes32` fields.
+		let mut result = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
+		hmac_sha512(b"Dilithium seed", &[seed], &mut result);
 		let (secret_key, chain_code) = result.split_at(32);
 
 		let mut sk = ExtendedPrivKey {
 			secret_key: SensitiveBytes32::from(&mut secret_key.try_into().unwrap()),
 			chain_code: SensitiveBytes32::from(&mut chain_code.try_into().unwrap()),
 		};
-		result.as_mut_slice().zeroize();
 
 		for child in path.as_ref() {
 			sk = sk.child(*child)?;
@@ -188,27 +239,22 @@ impl ExtendedPrivKey {
 	}
 
 	pub fn child(&self, child: ChildNumber) -> Result<ExtendedPrivKey, Error> {
-		let mut hmac: Hmac<Sha512> = Hmac::new_from_slice(self.chain_code.as_bytes())
-			.map_err(|_| Error::InvalidChildNumber)?;
-
-		hmac.update(&[0]);
 		// Feed the HMAC directly from the stored secret rather than
 		// `self.secret()`, which would materialize a throwaway `[u8; 32]` copy
-		// on the stack that is never wiped.
-		hmac.update(self.secret_key.as_bytes());
-
-		hmac.update(&child.to_bytes());
-
-		// See `derive`: wipe the 64-byte secret_key || chain_code buffer once
-		// its halves are copied into the self-zeroizing fields below.
-		let mut result = hmac.finalize().into_bytes();
+		// on the stack that is never wiped. See `derive` for the lifecycle of
+		// the self-wiping `result` buffer.
+		let mut result = Zeroizing::new([0u8; HMAC_OUTPUT_BYTES]);
+		hmac_sha512(
+			self.chain_code.as_bytes(),
+			&[&[0], self.secret_key.as_bytes(), &child.to_bytes()],
+			&mut result,
+		);
 		let (secret_key, chain_code) = result.split_at(32);
 
 		let child = ExtendedPrivKey {
 			secret_key: SensitiveBytes32::from(&mut secret_key.try_into().unwrap()),
 			chain_code: SensitiveBytes32::from(&mut chain_code.try_into().unwrap()),
 		};
-		result.as_mut_slice().zeroize();
 		Ok(child)
 	}
 }
@@ -237,6 +283,95 @@ mod tests {
 		let account = ExtendedPrivKey::derive(&seed, "m/44'/60'/0'/0'/0'").unwrap();
 
 		assert_eq!(expected_secret_key, &account.secret(), "Secret key is invalid");
+	}
+
+	// The in-crate zeroizing HMAC must be a correct HMAC-SHA512. Pin it to the
+	// official RFC 4231 test vectors (cases 1-4; the remaining cases use
+	// truncated outputs or keys longer than one block, which this
+	// implementation intentionally does not support).
+	#[test]
+	fn hmac_sha512_matches_rfc4231_vectors() {
+		use hex_literal::hex;
+
+		let cases: &[(&[u8], &[u8], [u8; 64])] = &[
+			(
+				&[0x0b; 20],
+				b"Hi There",
+				hex!(
+					"87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cde"
+					"daa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854"
+				),
+			),
+			(
+				b"Jefe",
+				b"what do ya want for nothing?",
+				hex!(
+					"164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea250554"
+					"9758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737"
+				),
+			),
+			(
+				&[0xaa; 20],
+				&[0xdd; 50],
+				hex!(
+					"fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39"
+					"bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb"
+				),
+			),
+			(
+				&hex!("0102030405060708090a0b0c0d0e0f10111213141516171819"),
+				&[0xcd; 50],
+				hex!(
+					"b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3db"
+					"a91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd"
+				),
+			),
+		];
+
+		for (i, (key, data, expected)) in cases.iter().enumerate() {
+			let mut out = [0u8; 64];
+			hmac_sha512(key, &[data], &mut out);
+			assert_eq!(&out, expected, "RFC 4231 test case {} failed", i + 1);
+		}
+	}
+
+	// Cross-check against the `hmac` crate (the previous implementation, kept
+	// as a dev-dependency) across key lengths up to a full block and across
+	// message-part splits, including boundary-straddling ones. This covers the
+	// exact shapes used by `derive` (14-byte key, one part) and `child`
+	// (32-byte key, three parts) and everything in between.
+	#[test]
+	fn hmac_sha512_matches_reference_implementation() {
+		use hmac::{Hmac, Mac};
+
+		let msg: Vec<u8> = (0..200u32).map(|i| (i.wrapping_mul(31) ^ 0x5f) as u8).collect();
+		for key_len in [0usize, 1, 14, 32, 63, 64, 65, 127, 128] {
+			let key: Vec<u8> = (0..key_len as u32).map(|i| (i.wrapping_mul(7) + 3) as u8).collect();
+
+			let mut reference: Hmac<sha2::Sha512> = Hmac::new_from_slice(&key).unwrap();
+			reference.update(&msg);
+			let expected = reference.finalize().into_bytes();
+
+			let splits: &[&[&[u8]]] = &[
+				&[&msg],
+				&[&msg[..1], &msg[1..]],
+				&[&msg[..37], &msg[37..37], &msg[37..]],
+				// straddles the first SHA-512 block boundary of the inner
+				// hash (128-byte ipad block + 64 message bytes)
+				&[&msg[..64], &msg[64..]],
+				&[&msg[..128], &msg[128..]],
+			];
+			for parts in splits {
+				let mut out = [0u8; 64];
+				hmac_sha512(&key, parts, &mut out);
+				assert_eq!(
+					out[..],
+					expected[..],
+					"mismatch vs reference for key_len={key_len}, {} part(s)",
+					parts.len()
+				);
+			}
+		}
 	}
 
 	#[test]

--- a/hdwallet/src/hderive.rs
+++ b/hdwallet/src/hderive.rs
@@ -461,9 +461,20 @@ mod tests {
 		);
 	}
 
+	// Hardened-only is the documented contract (README "Why Hardened Keys
+	// Only?"): lattice keys have no public-derivability, so an unhardened
+	// level cannot mean what BIP-32 implies. This pins both sides of the
+	// contract — the documented standard path parses, and any unhardened
+	// spelling of it is rejected before derivation.
 	#[test]
 	fn non_hardened_path_rejected() {
+		assert!("m/44'/189189'/0'/0'/0'".parse::<DerivationPath>().is_ok());
+
 		assert_eq!("m/44'/60'/0".parse::<DerivationPath>().unwrap_err(), Error::NotHardened);
+		assert_eq!(
+			"m/44'/189189'/0'/0/0".parse::<DerivationPath>().unwrap_err(),
+			Error::NotHardened
+		);
 		assert_eq!("0".parse::<ChildNumber>().unwrap_err(), Error::NotHardened);
 	}
 

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -246,10 +246,15 @@ fn derive_entropy_from_seed(
 	check_derivation_path(path)?;
 
 	// Derive entropy at the specified path
-	let xpriv = ExtendedPrivKey::derive(seed.as_bytes(), path)
+	let mut xpriv = ExtendedPrivKey::zeroed();
+	ExtendedPrivKey::derive(seed.as_bytes(), path, &mut xpriv)
 		.map_err(|_e| HDLatticeError::KeyDerivationFailed(path.to_string()))?;
-	let mut secret = xpriv.secret();
-	Ok(SensitiveBytes32::from(&mut secret))
+	// Deliberate guarded copy: filled in place inside the self-zeroizing
+	// wrapper, so the secret never exists outside a wiping guard (`xpriv`
+	// wipes its own storage when it drops below).
+	let mut entropy = SensitiveBytes32::zeroed();
+	entropy.as_mut_bytes().copy_from_slice(xpriv.secret().as_bytes());
+	Ok(entropy)
 
 	// seed is automatically zeroized when it drops
 }

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -108,37 +108,45 @@ pub const MAX_MNEMONIC_BYTES: usize = 1024;
 /// passphrase is a CPU/memory DoS vector. 1 KiB far exceeds any realistic use.
 pub const MAX_PASSPHRASE_BYTES: usize = 1024;
 
-/// Convert a BIP39 mnemonic phrase to a seed
+/// Convert a BIP39 mnemonic phrase to a seed, writing it into the
+/// caller-provided self-zeroizing [`SensitiveBytes64`].
 ///
 /// This function takes ownership of the mnemonic string for security.
 /// Users must explicitly choose to move or copy their mnemonic:
 ///
 /// ```rust
-/// use qp_rusty_crystals_hdwallet::mnemonic_to_seed;
-/// let mnemonic = "word word word...".to_string();
+/// use qp_rusty_crystals_hdwallet::{mnemonic_to_seed, SensitiveBytes64};
+/// let mnemonic = "legal winner thank year wave sausage worth useful legal winner thank yellow".to_string();
 ///
 /// // Move the mnemonic (recommended for single use)
-/// let seed = mnemonic_to_seed(mnemonic, None);
-/// // mnemonic is now consumed and zeroized
-///
-/// // Or explicitly copy for multiple uses
-/// let mnemonic = "word word word...".to_string();
-/// let seed1 = mnemonic_to_seed(mnemonic.clone(), None);
-/// let seed2 = mnemonic_to_seed(mnemonic, None); // consumes original
+/// let mut seed = SensitiveBytes64::zeroed();
+/// mnemonic_to_seed(mnemonic, None, &mut seed).unwrap();
+/// // mnemonic is now consumed and zeroized; seed wipes itself on drop
 /// ```
 ///
 /// # Security Note
 /// This function performs expensive PBKDF2 key stretching (2048 iterations).
 /// The mnemonic string is zeroized before returning.
-/// The returned seed contains sensitive cryptographic material and should be
-/// zeroized when no longer needed.
+///
+/// The seed is written in place into the caller's [`SensitiveBytes64`]
+/// rather than returned by value (security review). A raw `[u8; 64]` return
+/// would require every caller to remember to wipe a complete BIP39 seed
+/// manually — and even a self-zeroizing return value would be *moved* out,
+/// and Rust moves are copies that leave the moved-from stack slot dead and
+/// unwiped (`ZeroizeOnDrop` only wipes the value's final resting place).
+/// With an out-parameter the secret only ever exists inside the caller's
+/// wiping guard; the stack-residue regression test pins this.
+///
+/// On error, `seed_out` is untouched.
 pub fn mnemonic_to_seed(
 	mnemonic: String,
 	passphrase: Option<&str>,
-) -> Result<[u8; 64], HDLatticeError> {
-	// Drop guard: zeroizes the mnemonic on every exit path (success, parse error, unwind).
+	seed_out: &mut SensitiveBytes64,
+) -> Result<(), HDLatticeError> {
+	// Drop guard: zeroizes the mnemonic on every exit path (success, parse
+	// error, unwind).
 	let mnemonic = Zeroizing::new(mnemonic);
-	parse_mnemonic_to_seed(mnemonic.as_str(), passphrase)
+	parse_mnemonic_to_seed_into(mnemonic.as_str(), passphrase, seed_out.as_mut_bytes())
 }
 
 /// NFKD-normalize a potentially secret string. Returns `None` when the input is already
@@ -166,10 +174,17 @@ fn nfkd_owned(s: &str) -> Option<Zeroizing<String>> {
 /// Both inputs are size-capped ([`MAX_MNEMONIC_BYTES`], [`MAX_PASSPHRASE_BYTES`])
 /// *before* normalization, so attacker-controlled text cannot drive unbounded
 /// allocation, normalization scans, or PBKDF2 work prior to rejection.
-fn parse_mnemonic_to_seed(
+///
+/// The stretched seed is written through `seed_out` rather than returned by
+/// value: a by-value seed would be moved (i.e. copied) across function
+/// boundaries, leaving unwiped copies in dead stack slots. Callers pass the
+/// interior of a self-zeroizing `SensitiveBytes64`, so the seed only ever
+/// lives inside a wiping guard. On error, `seed_out` is untouched.
+fn parse_mnemonic_to_seed_into(
 	mnemonic: &str,
 	passphrase: Option<&str>,
-) -> Result<[u8; 64], HDLatticeError> {
+	seed_out: &mut [u8; 64],
+) -> Result<(), HDLatticeError> {
 	if mnemonic.len() > MAX_MNEMONIC_BYTES {
 		return Err(HDLatticeError::MnemonicTooLong(mnemonic.len()));
 	}
@@ -188,7 +203,29 @@ fn parse_mnemonic_to_seed(
 
 	let parsed_mnemonic = Mnemonic::parse_in_normalized(Language::English, mnemonic)
 		.map_err(|e| HDLatticeError::Bip39Error(e.to_string()))?;
-	Ok(parsed_mnemonic.to_seed_normalized(passphrase))
+
+	// Seed stretching is done in-crate rather than via
+	// `Mnemonic::to_seed_normalized`, which returns the seed as a plain
+	// `[u8; 64]` from a non-inlinable external function and leaves an
+	// unwiped copy of it in a dead stack frame (security review). The PBKDF2
+	// password is the canonical phrase — the validated words joined by
+	// single spaces — matching `to_seed_normalized` byte for byte (pinned by
+	// the golden-vector tests and a direct cross-check against bip39).
+	let mut password = Zeroizing::new(String::with_capacity(mnemonic.len()));
+	for (i, word) in parsed_mnemonic.words().enumerate() {
+		if i > 0 {
+			password.push(' ');
+		}
+		password.push_str(word);
+	}
+
+	hderive::pbkdf2_hmac_sha512(
+		password.as_bytes(),
+		&[b"mnemonic", passphrase.as_bytes()],
+		2048,
+		seed_out,
+	);
+	Ok(())
 }
 
 /// Derive the 32 bytes of keypair entropy at the given BIP44 path.
@@ -260,8 +297,9 @@ macro_rules! mldsa_variant_module {
 				path: &str,
 			) -> Result<Keypair, HDLatticeError> {
 				crate::check_derivation_path(path)?;
-				let mut seed = crate::parse_mnemonic_to_seed(mnemonic, passphrase)?;
-				derive_key_from_seed(SensitiveBytes64::from(&mut seed), path)
+				let mut seed = SensitiveBytes64::zeroed();
+				crate::parse_mnemonic_to_seed_into(mnemonic, passphrase, seed.as_mut_bytes())?;
+				derive_key_from_seed(seed, path)
 			}
 		}
 	};
@@ -323,8 +361,9 @@ pub fn derive_wormhole_from_mnemonic(
 	path: &str,
 ) -> Result<WormholePair, HDLatticeError> {
 	check_wormhole_path(path)?;
-	let mut seed = parse_mnemonic_to_seed(mnemonic, passphrase)?;
-	generate_wormhole_from_seed(SensitiveBytes64::from(&mut seed), path)
+	let mut seed = SensitiveBytes64::zeroed();
+	parse_mnemonic_to_seed_into(mnemonic, passphrase, seed.as_mut_bytes())?;
+	generate_wormhole_from_seed(seed, path)
 }
 
 /// Generate a wormhole pair from a seed at the given path

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -228,20 +228,24 @@ fn parse_mnemonic_to_seed_into(
 	Ok(())
 }
 
-/// Derive the 32 bytes of keypair entropy at the given BIP44 path.
+/// Derive the 32 bytes of keypair entropy at the given BIP44 path, writing
+/// them into the caller-provided `out`.
 ///
 /// This is the parameter-set-independent half of key derivation: path
-/// validation plus HMAC-SHA512 tree derivation. The returned entropy is what
+/// validation plus HMAC-SHA512 tree derivation. The derived entropy is what
 /// each variant's `Keypair::generate` consumes (FIPS 204 domain-separates the
 /// subsequent seed expansion by `(k, ℓ)`, so feeding the same entropy to
 /// different parameter sets yields independent keys).
 ///
-/// The seed is taken by move and zeroized on drop; the returned entropy is
-/// itself a self-zeroizing type.
+/// The entropy is written in place rather than returned by value (security
+/// review): a by-value return is moved — i.e. copied — through dead stack
+/// slots that are never dropped, so `ZeroizeOnDrop` could not wipe them.
+/// On error, `out` is untouched.
 fn derive_entropy_from_seed(
-	seed: SensitiveBytes64,
+	seed: &SensitiveBytes64,
 	path: &str,
-) -> Result<SensitiveBytes32, HDLatticeError> {
+	out: &mut SensitiveBytes32,
+) -> Result<(), HDLatticeError> {
 	// Validate the derivation path
 	check_derivation_path(path)?;
 
@@ -249,14 +253,11 @@ fn derive_entropy_from_seed(
 	let mut xpriv = ExtendedPrivKey::zeroed();
 	ExtendedPrivKey::derive(seed.as_bytes(), path, &mut xpriv)
 		.map_err(|_e| HDLatticeError::KeyDerivationFailed(path.to_string()))?;
-	// Deliberate guarded copy: filled in place inside the self-zeroizing
-	// wrapper, so the secret never exists outside a wiping guard (`xpriv`
-	// wipes its own storage when it drops below).
-	let mut entropy = SensitiveBytes32::zeroed();
-	entropy.as_mut_bytes().copy_from_slice(xpriv.secret().as_bytes());
-	Ok(entropy)
-
-	// seed is automatically zeroized when it drops
+	// Deliberate guarded copy: filled in place inside the caller's
+	// self-zeroizing wrapper, so the secret never exists outside a wiping
+	// guard (`xpriv` wipes its own storage when it drops below).
+	out.as_mut_bytes().copy_from_slice(xpriv.secret().as_bytes());
+	Ok(())
 }
 
 /// Stamp a per-variant key-derivation module mirroring the dilithium crate's
@@ -270,7 +271,7 @@ macro_rules! mldsa_variant_module {
 		pub mod $mod_name {
 			pub use qp_rusty_crystals_dilithium::$mod_name::Keypair;
 
-			use crate::{HDLatticeError, SensitiveBytes64};
+			use crate::{HDLatticeError, SensitiveBytes32, SensitiveBytes64};
 
 			#[doc = concat!("Derive an ", $doc_name, " keypair from a seed at the given BIP44 path.")]
 			///
@@ -281,9 +282,11 @@ macro_rules! mldsa_variant_module {
 				seed: SensitiveBytes64,
 				path: &str,
 			) -> Result<Keypair, HDLatticeError> {
-				let derived_entropy = crate::derive_entropy_from_seed(seed, path)?;
-				// derived_entropy is automatically zeroized when it drops
-				Ok(Keypair::generate(derived_entropy))
+				// The entropy is filled in place and lent to `generate`,
+				// which wipes it; it never crosses a boundary by value.
+				let mut entropy = SensitiveBytes32::zeroed();
+				crate::derive_entropy_from_seed(&seed, path, &mut entropy)?;
+				Ok(Keypair::generate(&mut entropy))
 			}
 
 			#[doc = concat!("Derive an ", $doc_name, " keypair from a mnemonic with passphrase.")]
@@ -386,8 +389,9 @@ pub fn generate_wormhole_from_seed(
 	// consumer of the entropy differs. (`derive_entropy_from_seed` re-runs
 	// the generic path validation `check_wormhole_path` already performed —
 	// cheap and idempotent.) Seed and entropy are self-zeroizing.
-	let derived_entropy = derive_entropy_from_seed(seed, path)?;
-	Ok(WormholePair::generate_new(derived_entropy))
+	let mut entropy = SensitiveBytes32::zeroed();
+	derive_entropy_from_seed(&seed, path, &mut entropy)?;
+	Ok(WormholePair::generate_new(&mut entropy))
 }
 
 /// Validate a wormhole derivation path: generic path checks plus the

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -5,7 +5,7 @@ mod hdwallet_tests {
 		hderive::{ChildNumber, ExtendedPrivKey},
 		mnemonic_to_seed,
 		test_vectors::get_test_vectors,
-		HDLatticeError,
+		HDLatticeError, SensitiveBytes64,
 	};
 	use alloc::{
 		borrow::ToOwned,
@@ -25,25 +25,32 @@ mod hdwallet_tests {
 	#[cfg(test)]
 	use std::println;
 
+	/// Test helper: stretch a known-valid mnemonic into a fresh seed.
+	fn seed_from(mnemonic: String, passphrase: Option<&str>) -> SensitiveBytes64 {
+		let mut seed = SensitiveBytes64::zeroed();
+		mnemonic_to_seed(mnemonic, passphrase, &mut seed).expect("valid mnemonic");
+		seed
+	}
+
 	#[test]
 	fn test_from_seed() {
 		// Single use pattern - mnemonic gets consumed
 		let mnemonic1 =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed1 = mnemonic_to_seed(mnemonic1, None).unwrap();
+		let seed1 = seed_from(mnemonic1, None);
 
 		// Multi-use pattern - explicitly clone when needed
 		let mnemonic2 =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed2 = mnemonic_to_seed(mnemonic2.clone(), None).unwrap();
+		let seed2 = seed_from(mnemonic2.clone(), None);
 		// mnemonic2 still available here, gets consumed when dropped
 
 		// Seeds from same mnemonic should be identical
-		assert_eq!(seed1, seed2);
+		assert_eq!(seed1.as_bytes(), seed2.as_bytes());
 
 		// Should be able to derive same keys from same seed
-		let key1 = derive_key_from_seed((&mut seed1).into(), "m/44'/0'/0'/0'/0'").unwrap();
-		let key2 = derive_key_from_seed((&mut seed2).into(), "m/44'/0'/0'/0'/0'").unwrap();
+		let key1 = derive_key_from_seed(seed1, "m/44'/0'/0'/0'/0'").unwrap();
+		let key2 = derive_key_from_seed(seed2, "m/44'/0'/0'/0'/0'").unwrap();
 		assert_eq!(key1.secret().to_bytes(), key2.secret().to_bytes());
 	}
 
@@ -56,19 +63,23 @@ mod hdwallet_tests {
 		assert_eq!(mnemonic.split_whitespace().count(), 24);
 
 		// Test creating seeds from mnemonic - demonstrate explicit copying
-		let mut seed1 = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-		let mut seed2 = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-		let mut seed3 = mnemonic_to_seed(mnemonic.clone(), Some("password")).unwrap();
+		let seed1 = seed_from(mnemonic.clone(), None);
+		let seed2 = seed_from(mnemonic.clone(), None);
+		let seed3 = seed_from(mnemonic.clone(), Some("password"));
 
 		// Seeds from same mnemonic should be identical
-		assert_eq!(seed1, seed2, "seeds from same mnemonic should be identical");
+		assert_eq!(
+			seed1.as_bytes(),
+			seed2.as_bytes(),
+			"seeds from same mnemonic should be identical"
+		);
 
 		// Different passphrase should produce different seed
-		assert_ne!(seed1, seed3, "password should affect seed");
+		assert_ne!(seed1.as_bytes(), seed3.as_bytes(), "password should affect seed");
 
-		let master_key1 = derive_key_from_seed((&mut seed1).into(), "m/44'/0'/0'/0'/0'").unwrap();
-		let master_key2 = derive_key_from_seed((&mut seed2).into(), "m/44'/0'/0'/0'/0'").unwrap();
-		let master_key3 = derive_key_from_seed((&mut seed3).into(), "m/44'/0'/0'/0'/0'").unwrap();
+		let master_key1 = derive_key_from_seed(seed1, "m/44'/0'/0'/0'/0'").unwrap();
+		let master_key2 = derive_key_from_seed(seed2, "m/44'/0'/0'/0'/0'").unwrap();
+		let master_key3 = derive_key_from_seed(seed3, "m/44'/0'/0'/0'/0'").unwrap();
 
 		// Keys from same seed should be identical
 		assert_eq!(
@@ -85,9 +96,8 @@ mod hdwallet_tests {
 		);
 
 		// Derive a different path - need a fresh seed since seed1 was already consumed
-		let mut seed_for_derive = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-		let derived_key =
-			derive_key_from_seed((&mut seed_for_derive).into(), "m/0'/2147483647'/1'").unwrap();
+		let seed_for_derive = seed_from(mnemonic.clone(), None);
+		let derived_key = derive_key_from_seed(seed_for_derive, "m/0'/2147483647'/1'").unwrap();
 		assert_ne!(
 			master_key1.secret().to_bytes(),
 			derived_key.secret().to_bytes(),
@@ -113,11 +123,11 @@ mod hdwallet_tests {
 				"rocket primary way job input cactus submit menu zoo burger rent impose"
 					.to_string();
 
-			let mut seed1 = mnemonic_to_seed(mnemonic1, None).unwrap();
-			let mut seed2 = mnemonic_to_seed(mnemonic2, None).unwrap();
+			let seed1 = seed_from(mnemonic1, None);
+			let seed2 = seed_from(mnemonic2, None);
 
-			let k1 = derive_key_from_seed((&mut seed1).into(), p).unwrap();
-			let k2 = derive_key_from_seed((&mut seed2).into(), p).unwrap();
+			let k1 = derive_key_from_seed(seed1, p).unwrap();
+			let k2 = derive_key_from_seed(seed2, p).unwrap();
 
 			assert_eq!(k1.secret().to_bytes(), k2.secret().to_bytes());
 			assert_eq!(k1.public().to_bytes(), k2.public().to_bytes());
@@ -133,8 +143,8 @@ mod hdwallet_tests {
 				rng.fill_bytes(&mut seed);
 				let mnemonic = generate_mnemonic((&mut seed).into()).unwrap();
 				let path = generate_random_path();
-				let mut seed = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-				let k = derive_key_from_seed((&mut seed).into(), &path).unwrap();
+				let seed = seed_from(mnemonic.clone(), None);
+				let k = derive_key_from_seed(seed, &path).unwrap();
 				(k, mnemonic, path)
 			})
 			.collect()
@@ -143,12 +153,12 @@ mod hdwallet_tests {
 	#[test]
 	fn test_derive_seed() {
 		for (expected_keys, mnemonic_str, derivation_path) in get_test_vectors() {
-			let mut seed = mnemonic_to_seed(mnemonic_str.to_string(), None).unwrap();
+			let seed = seed_from(mnemonic_str.to_string(), None);
 			let generated_keys = if derivation_path.is_empty() || derivation_path == "m" {
 				// Use a default path for empty or "m" path
-				derive_key_from_seed((&mut seed).into(), "m/44'/0'/0'/0'/0'").unwrap()
+				derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").unwrap()
 			} else {
-				derive_key_from_seed((&mut seed).into(), derivation_path).unwrap()
+				derive_key_from_seed(seed, derivation_path).unwrap()
 			};
 
 			// Compare secret keys
@@ -223,10 +233,10 @@ mod hdwallet_tests {
 	fn test_derive_invalid_path() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed = seed_from(mnemonic, None);
 
 		// Attempt to derive a key with an invalid path
-		let result = derive_key_from_seed((&mut seed).into(), "abc");
+		let result = derive_key_from_seed(seed, "abc");
 
 		assert_eq!(
 			result.err().unwrap(),
@@ -239,10 +249,10 @@ mod hdwallet_tests {
 	fn test_derive_invalid_index() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed = seed_from(mnemonic, None);
 
 		// Attempt to derive a key with an invalid index
-		let result = derive_key_from_seed((&mut seed).into(), "m/2147483648'"); // Index exceeds HARDENED_OFFSET (2^31)
+		let result = derive_key_from_seed(seed, "m/2147483648'"); // Index exceeds HARDENED_OFFSET (2^31)
 
 		assert!(result.is_err());
 		assert_eq!(
@@ -256,10 +266,10 @@ mod hdwallet_tests {
 	fn test_derive_with_non_integer_path() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed = seed_from(mnemonic, None);
 
 		// Invalid derivation path with non-integer components
-		let result = derive_key_from_seed((&mut seed).into(), "1/a/2");
+		let result = derive_key_from_seed(seed, "1/a/2");
 
 		assert!(result.is_err());
 		assert_eq!(
@@ -273,13 +283,13 @@ mod hdwallet_tests {
 	fn test_derive_master_path() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
+		let seed = seed_from(mnemonic.clone(), None);
 
 		// Test deriving at master path "m"
-		let key1 = derive_key_from_seed((&mut seed).into(), "m/44'/0'/0'/0'/0'").unwrap();
+		let key1 = derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").unwrap();
 
-		let mut seed2 = mnemonic_to_seed(mnemonic, None).unwrap();
-		let key2 = derive_key_from_seed((&mut seed2).into(), "m/44'/0'/0'/0'/0'").unwrap();
+		let seed2 = seed_from(mnemonic, None);
+		let key2 = derive_key_from_seed(seed2, "m/44'/0'/0'/0'/0'").unwrap();
 
 		// Keys derived from same path should be identical
 		assert_eq!(
@@ -347,18 +357,18 @@ mod hdwallet_tests {
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
 
 		// Test invalid wormhole path (wrong chain ID)
-		let mut seed1 = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-		let result = generate_wormhole_from_seed((&mut seed1).into(), "m/44'/60'/0'");
+		let seed1 = seed_from(mnemonic.clone(), None);
+		let result = generate_wormhole_from_seed(seed1, "m/44'/60'/0'");
 		assert!(result.is_err());
 
 		// Test valid wormhole path
-		let mut seed2 = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-		let result2 = generate_wormhole_from_seed((&mut seed2).into(), "m/44'/189189189'/0'");
+		let seed2 = seed_from(mnemonic.clone(), None);
+		let result2 = generate_wormhole_from_seed(seed2, "m/44'/189189189'/0'");
 		assert!(result2.is_ok());
 
 		// Test another valid wormhole path
-		let mut seed3 = mnemonic_to_seed(mnemonic, None).unwrap();
-		let result3 = generate_wormhole_from_seed((&mut seed3).into(), "m/44'/189189189'/1'");
+		let seed3 = seed_from(mnemonic, None);
+		let result3 = generate_wormhole_from_seed(seed3, "m/44'/189189189'/1'");
 		assert!(result3.is_ok());
 	}
 
@@ -366,12 +376,12 @@ mod hdwallet_tests {
 	fn test_master_key_derivation() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed1 = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-		let mut seed2 = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed1 = seed_from(mnemonic.clone(), None);
+		let seed2 = seed_from(mnemonic, None);
 
 		// Derive keys from master path - should be deterministic
-		let key1 = derive_key_from_seed((&mut seed1).into(), "m/44'/0'/0'/0'/0'").unwrap();
-		let key2 = derive_key_from_seed((&mut seed2).into(), "m/44'/0'/0'/0'/0'").unwrap();
+		let key1 = derive_key_from_seed(seed1, "m/44'/0'/0'/0'/0'").unwrap();
+		let key2 = derive_key_from_seed(seed2, "m/44'/0'/0'/0'/0'").unwrap();
 
 		assert_eq!(
 			key1.secret().to_bytes(),
@@ -385,21 +395,21 @@ mod hdwallet_tests {
 		// Single-use pattern
 		let mnemonic1 =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let seed1 = mnemonic_to_seed(mnemonic1, None).unwrap();
+		let seed1 = seed_from(mnemonic1, None);
 
 		let mnemonic2 =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let seed2 = mnemonic_to_seed(mnemonic2, None).unwrap();
+		let seed2 = seed_from(mnemonic2, None);
 
 		// Same mnemonic should produce same seed
-		assert_eq!(seed1, seed2);
-		assert_eq!(seed1.len(), 64);
+		assert_eq!(seed1.as_bytes(), seed2.as_bytes());
+		assert_eq!(seed1.as_bytes().len(), 64);
 
 		// Different passphrase should produce different seed
 		let mnemonic3 =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let seed3 = mnemonic_to_seed(mnemonic3, Some("password")).unwrap();
-		assert_ne!(seed1, seed3);
+		let seed3 = seed_from(mnemonic3, Some("password"));
+		assert_ne!(seed1.as_bytes(), seed3.as_bytes());
 	}
 
 	#[test]
@@ -412,10 +422,11 @@ mod hdwallet_tests {
 		let decomposed = "cafe\u{0301}";
 		assert_ne!(composed.as_bytes(), decomposed.as_bytes());
 
-		let seed_composed = mnemonic_to_seed(mnemonic.to_string(), Some(composed)).unwrap();
-		let seed_decomposed = mnemonic_to_seed(mnemonic.to_string(), Some(decomposed)).unwrap();
+		let seed_composed = seed_from(mnemonic.to_string(), Some(composed));
+		let seed_decomposed = seed_from(mnemonic.to_string(), Some(decomposed));
 		assert_eq!(
-			seed_composed, seed_decomposed,
+			seed_composed.as_bytes(),
+			seed_decomposed.as_bytes(),
 			"canonically equivalent passphrases must derive the same seed"
 		);
 
@@ -424,7 +435,7 @@ mod hdwallet_tests {
 		let reference = bip39::Mnemonic::parse_in_normalized(bip39::Language::English, mnemonic)
 			.unwrap()
 			.to_seed_normalized(decomposed);
-		assert_eq!(seed_composed, reference);
+		assert_eq!(seed_composed.as_bytes(), &reference);
 
 		// Same guarantee through the borrowing derivation helpers.
 		let key_composed =
@@ -445,27 +456,27 @@ mod hdwallet_tests {
 		let nbsp = ascii.replace(' ', "\u{00a0}");
 		assert_ne!(ascii.as_bytes(), nbsp.as_bytes());
 
-		let seed_ascii = mnemonic_to_seed(ascii.to_string(), None).unwrap();
-		let seed_nbsp = mnemonic_to_seed(nbsp, None)
+		let seed_ascii = seed_from(ascii.to_string(), None);
+		let mut seed_nbsp = SensitiveBytes64::zeroed();
+		mnemonic_to_seed(nbsp, None, &mut seed_nbsp)
 			.expect("NFKD-equivalent mnemonic must parse after normalization");
-		assert_eq!(seed_ascii, seed_nbsp);
+		assert_eq!(seed_ascii.as_bytes(), seed_nbsp.as_bytes());
 	}
 
 	#[test]
 	fn test_derive_key_from_seed_different_paths() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let seed = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed = seed_from(mnemonic, None);
 
 		// Derive keys at different paths - need separate seeds since they get consumed
-		let mut seed1 = seed;
-		let mut seed2 = mnemonic_to_seed(
+		let seed1 = seed;
+		let seed2 = seed_from(
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string(),
 			None,
-		)
-		.unwrap();
-		let key1 = derive_key_from_seed((&mut seed1).into(), "m/44'/0'/0'/0'/0'").unwrap();
-		let key2 = derive_key_from_seed((&mut seed2).into(), "m/44'/0'/0'/0'/1'").unwrap();
+		);
+		let key1 = derive_key_from_seed(seed1, "m/44'/0'/0'/0'/0'").unwrap();
+		let key2 = derive_key_from_seed(seed2, "m/44'/0'/0'/0'/1'").unwrap();
 
 		// Keys should be different
 		assert_ne!(key1.secret().to_bytes(), key2.secret().to_bytes());
@@ -481,11 +492,11 @@ mod hdwallet_tests {
 		let mnemonic2 =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
 
-		let mut seed1 = mnemonic_to_seed(mnemonic1, None).unwrap();
-		let mut seed2 = mnemonic_to_seed(mnemonic2, None).unwrap();
+		let seed1 = seed_from(mnemonic1, None);
+		let seed2 = seed_from(mnemonic2, None);
 
-		let key1 = derive_key_from_seed((&mut seed1).into(), path).unwrap();
-		let key2 = derive_key_from_seed((&mut seed2).into(), path).unwrap();
+		let key1 = derive_key_from_seed(seed1, path).unwrap();
+		let key2 = derive_key_from_seed(seed2, path).unwrap();
 
 		// Same seed and path should produce same keys
 		assert_eq!(key1.secret().to_bytes(), key2.secret().to_bytes());
@@ -496,10 +507,9 @@ mod hdwallet_tests {
 	fn test_generate_wormhole_from_seed() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed = seed_from(mnemonic, None);
 
-		let wormhole =
-			generate_wormhole_from_seed((&mut seed).into(), "m/44'/189189189'/0'").unwrap();
+		let wormhole = generate_wormhole_from_seed(seed, "m/44'/189189189'/0'").unwrap();
 
 		// Verify wormhole pair has expected structure
 		assert_eq!(wormhole.secret.as_bytes().len(), 32);
@@ -513,10 +523,10 @@ mod hdwallet_tests {
 	fn test_wormhole_invalid_path() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed = seed_from(mnemonic, None);
 
 		// Should fail with invalid wormhole chain ID
-		let result = generate_wormhole_from_seed((&mut seed).into(), "m/44'/60'/0'");
+		let result = generate_wormhole_from_seed(seed, "m/44'/60'/0'");
 		assert!(result.is_err());
 		assert_eq!(
 			result.err().unwrap(),
@@ -528,9 +538,9 @@ mod hdwallet_tests {
 	fn test_invalid_derivation_path() {
 		let mnemonic =
 			"rocket primary way job input cactus submit menu zoo burger rent impose".to_string();
-		let mut seed = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed = seed_from(mnemonic, None);
 
-		let result = derive_key_from_seed((&mut seed).into(), "m/44/60/0");
+		let result = derive_key_from_seed(seed, "m/44/60/0");
 		assert!(result.is_err());
 		assert_eq!(
 			result.err().unwrap(),
@@ -545,12 +555,12 @@ mod hdwallet_tests {
 		let path = "m/44'/0'/0'/0'/0'";
 
 		// First derivation
-		let mut seed1 = mnemonic_to_seed(mnemonic.to_string(), None).unwrap();
-		let key1 = derive_key_from_seed((&mut seed1).into(), path).unwrap();
+		let seed1 = seed_from(mnemonic.to_string(), None);
+		let key1 = derive_key_from_seed(seed1, path).unwrap();
 
 		// Second derivation
-		let mut seed2 = mnemonic_to_seed(mnemonic.to_string(), None).unwrap();
-		let key2 = derive_key_from_seed((&mut seed2).into(), path).unwrap();
+		let seed2 = seed_from(mnemonic.to_string(), None);
+		let key2 = derive_key_from_seed(seed2, path).unwrap();
 
 		// Should produce identical results
 		assert_eq!(key1.secret().to_bytes(), key2.secret().to_bytes());
@@ -572,7 +582,7 @@ mod hdwallet_tests {
 
 		// Use the wrapped data - this should move it
 		let mnemonic = generate_mnemonic(sensitive_entropy).unwrap();
-		let seed_from_mnemonic = mnemonic_to_seed(mnemonic, None).unwrap();
+		let seed_from_mnemonic = seed_from(mnemonic, None);
 		let _key = derive_key_from_seed(sensitive_seed, "m/44'/0'/0'/0'/0'").unwrap();
 
 		// After this point, sensitive_entropy and sensitive_seed should be consumed
@@ -584,7 +594,7 @@ mod hdwallet_tests {
 		let _key2 = derive_key_from_seed((&mut raw_seed).into(), "m/44'/0'/0'/0'/0'").unwrap();
 		// raw_seed was zeroized by the conversion
 
-		assert_eq!(seed_from_mnemonic.len(), 64);
+		assert_eq!(seed_from_mnemonic.as_bytes().len(), 64);
 	}
 
 	// For reference and in case test vectors need to be regenerated
@@ -628,12 +638,12 @@ mod hdwallet_tests {
 		}
 		assert!(oversized.len() > MAX_DERIVATION_PATH_BYTES);
 
-		let mut seed1 = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-		let err1 = derive_key_from_seed((&mut seed1).into(), &oversized).unwrap_err();
+		let seed1 = seed_from(mnemonic.clone(), None);
+		let err1 = derive_key_from_seed(seed1, &oversized).unwrap_err();
 		assert!(matches!(err1, HDLatticeError::PathTooLong(_)), "got {err1:?}");
 
-		let mut seed2 = mnemonic_to_seed(mnemonic, None).unwrap();
-		match generate_wormhole_from_seed((&mut seed2).into(), &oversized) {
+		let seed2 = seed_from(mnemonic, None);
+		match generate_wormhole_from_seed(seed2, &oversized) {
 			Err(HDLatticeError::PathTooLong(_)) => {},
 			Err(other) => panic!("expected PathTooLong, got {other:?}"),
 			Ok(_) => panic!("expected PathTooLong, got Ok"),
@@ -651,12 +661,12 @@ mod hdwallet_tests {
 			too_deep.push_str("/1'");
 		}
 
-		let mut seed1 = mnemonic_to_seed(mnemonic.clone(), None).unwrap();
-		let err1 = derive_key_from_seed((&mut seed1).into(), &too_deep).unwrap_err();
+		let seed1 = seed_from(mnemonic.clone(), None);
+		let err1 = derive_key_from_seed(seed1, &too_deep).unwrap_err();
 		assert!(matches!(err1, HDLatticeError::PathTooDeep(_)), "got {err1:?}");
 
-		let mut seed2 = mnemonic_to_seed(mnemonic, None).unwrap();
-		match generate_wormhole_from_seed((&mut seed2).into(), &too_deep) {
+		let seed2 = seed_from(mnemonic, None);
+		match generate_wormhole_from_seed(seed2, &too_deep) {
 			Err(HDLatticeError::PathTooDeep(_)) => {},
 			Err(other) => panic!("expected PathTooDeep, got {other:?}"),
 			Ok(_) => panic!("expected PathTooDeep, got Ok"),
@@ -716,10 +726,12 @@ mod hdwallet_tests {
 
 		let valid = "rocket primary way job input cactus submit menu zoo burger rent impose";
 
+		let mut seed = SensitiveBytes64::zeroed();
+
 		// A valid mnemonic paired with an oversized passphrase must be rejected
 		// up front instead of deriving a seed over attacker-sized input.
 		let huge_passphrase = "p".repeat(MAX_PASSPHRASE_BYTES + 1);
-		let err = mnemonic_to_seed(valid.to_string(), Some(&huge_passphrase))
+		let err = mnemonic_to_seed(valid.to_string(), Some(&huge_passphrase), &mut seed)
 			.expect_err("oversized passphrase must be rejected");
 		assert!(matches!(err, HDLatticeError::PassphraseTooLong(_)), "got {err:?}");
 
@@ -727,8 +739,8 @@ mod hdwallet_tests {
 		// Use a non-NFKD char so the pre-fix code path would also allocate a
 		// normalized copy of the whole input.
 		let huge_mnemonic = "\u{00e9} ".repeat(MAX_MNEMONIC_BYTES / 2 + 1);
-		let err =
-			mnemonic_to_seed(huge_mnemonic, None).expect_err("oversized mnemonic must be rejected");
+		let err = mnemonic_to_seed(huge_mnemonic, None, &mut seed)
+			.expect_err("oversized mnemonic must be rejected");
 		assert!(matches!(err, HDLatticeError::MnemonicTooLong(_)), "got {err:?}");
 
 		// The borrowed-mnemonic helpers share the same parser and must enforce
@@ -739,18 +751,19 @@ mod hdwallet_tests {
 
 		// Inputs at exactly the caps must still be accepted.
 		let max_passphrase = "p".repeat(MAX_PASSPHRASE_BYTES);
-		mnemonic_to_seed(valid.to_string(), Some(&max_passphrase))
+		mnemonic_to_seed(valid.to_string(), Some(&max_passphrase), &mut seed)
 			.expect("passphrase at exactly MAX_PASSPHRASE_BYTES must be accepted");
 	}
 
 	#[test]
 	fn test_mnemonic_to_seed_zeroizes_on_parse_failure() {
 		let bogus = "not a valid bip39 mnemonic phrase at all".to_string();
-		let result = mnemonic_to_seed(bogus, None);
-		match result {
-			Err(HDLatticeError::Bip39Error(_)) => {},
-			other => panic!("expected Bip39Error, got {other:?}"),
-		}
+		let mut seed = SensitiveBytes64::zeroed();
+		let err =
+			mnemonic_to_seed(bogus, None, &mut seed).expect_err("bogus mnemonic must be rejected");
+		assert!(matches!(err, HDLatticeError::Bip39Error(_)), "got {err:?}");
+		// On error the seed buffer is untouched (still all zeros).
+		assert_eq!(seed.as_bytes(), &[0u8; 64]);
 	}
 
 	#[test]
@@ -764,8 +777,8 @@ mod hdwallet_tests {
 			max_depth.push_str("/1'");
 		}
 
-		let mut seed = mnemonic_to_seed(mnemonic, None).unwrap();
-		derive_key_from_seed((&mut seed).into(), &max_depth)
+		let seed = seed_from(mnemonic, None);
+		derive_key_from_seed(seed, &max_depth)
 			.expect("path at exactly MAX_DERIVATION_DEPTH must succeed");
 	}
 }

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -304,12 +304,15 @@ mod hdwallet_tests {
 		// Test that nam-tiny-hderive works with our seed format
 		let seed: &[u8] = &[42; 64];
 		let path = "m/44'/60'/0'/0'/0'";
-		let ext = ExtendedPrivKey::derive(seed, path).unwrap();
-		assert_eq!(&ext.secret(), b"\xfc\x29\xd9\xfc\x63\x5b\x32\x72\x63\x1b\x43\x02\xf7\x9b\xe4\x07\xa7\xf6\x77\xef\x73\x4a\xf2\xc4\x52\x7c\x90\x88\x97\xcd\xaa\x86");
+		let mut ext = ExtendedPrivKey::zeroed();
+		ExtendedPrivKey::derive(seed, path, &mut ext).unwrap();
+		assert_eq!(ext.secret().as_bytes(), b"\xfc\x29\xd9\xfc\x63\x5b\x32\x72\x63\x1b\x43\x02\xf7\x9b\xe4\x07\xa7\xf6\x77\xef\x73\x4a\xf2\xc4\x52\x7c\x90\x88\x97\xcd\xaa\x86");
 
-		let base_ext = ExtendedPrivKey::derive(seed, "m/44'/60'/0'/0'").unwrap();
-		let child_ext = base_ext.child(ChildNumber::from_str("0'").unwrap()).unwrap();
-		assert_eq!(ext.secret(), child_ext.secret());
+		// Stepping the parent in place must agree with the full-path derivation.
+		let mut stepped = ExtendedPrivKey::zeroed();
+		ExtendedPrivKey::derive(seed, "m/44'/60'/0'/0'", &mut stepped).unwrap();
+		stepped.child_in_place(ChildNumber::from_str("0'").unwrap());
+		assert_eq!(ext.secret().as_bytes(), stepped.secret().as_bytes());
 	}
 
 	// End-to-end known-answer test: pins the full mnemonic -> seed -> wormhole pipeline.

--- a/hdwallet/src/tests_variants.rs
+++ b/hdwallet/src/tests_variants.rs
@@ -9,18 +9,21 @@ use alloc::string::ToString;
 const MNEMONIC: &str = "rocket primary way job input cactus submit menu zoo burger rent impose";
 const PATH: &str = "m/44'/189189'/0'/0'/0'";
 
+/// Test helper: stretch [`MNEMONIC`] into a fresh seed.
+fn test_seed() -> crate::SensitiveBytes64 {
+	let mut seed = crate::SensitiveBytes64::zeroed();
+	crate::mnemonic_to_seed(MNEMONIC.to_string(), None, &mut seed).expect("valid mnemonic");
+	seed
+}
+
 /// Per-variant coverage: derivation is deterministic, mnemonic and seed
 /// entrypoints agree, and the derived keypair signs and verifies.
 macro_rules! variant_tests {
 	($mod_name:ident, $feature:literal) => {
 		#[cfg(feature = $feature)]
 		mod $mod_name {
-			use super::{MNEMONIC, PATH};
-			use crate::{mnemonic_to_seed, $mod_name::derive_key_from_mnemonic};
-			// Not inherited from the parent module: `use` items don't
-			// propagate into child modules, and this file must build without
-			// `std` (CI always enables it, so the breakage was latent).
-			use alloc::string::ToString;
+			use super::{test_seed, MNEMONIC, PATH};
+			use crate::$mod_name::derive_key_from_mnemonic;
 
 			#[test]
 			fn derivation_is_deterministic_and_matches_seed_entrypoint() {
@@ -29,9 +32,7 @@ macro_rules! variant_tests {
 				assert_eq!(key1.secret().to_bytes(), key2.secret().to_bytes());
 				assert_eq!(key1.public().bytes, key2.public().bytes);
 
-				let mut seed = mnemonic_to_seed(MNEMONIC.to_string(), None).unwrap();
-				let key3 =
-					crate::$mod_name::derive_key_from_seed((&mut seed).into(), PATH).unwrap();
+				let key3 = crate::$mod_name::derive_key_from_seed(test_seed(), PATH).unwrap();
 				assert_eq!(key1.secret().to_bytes(), key3.secret().to_bytes());
 			}
 
@@ -97,14 +98,11 @@ fn top_level_api_is_ml_dsa_87() {
 /// on builds with no ML-DSA feature at all.
 #[test]
 fn variant_independent_surface_available() {
-	let mut seed = crate::mnemonic_to_seed(MNEMONIC.to_string(), None).unwrap();
-	let pair = crate::generate_wormhole_from_seed((&mut seed).into(), "m/44'/189189189'/0'/0'/0'")
-		.unwrap();
+	let pair =
+		crate::generate_wormhole_from_seed(test_seed(), "m/44'/189189189'/0'/0'/0'").unwrap();
 	// Determinism of the variant-independent path.
-	let mut seed2 = crate::mnemonic_to_seed(MNEMONIC.to_string(), None).unwrap();
 	let pair2 =
-		crate::generate_wormhole_from_seed((&mut seed2).into(), "m/44'/189189189'/0'/0'/0'")
-			.unwrap();
+		crate::generate_wormhole_from_seed(test_seed(), "m/44'/189189189'/0'/0'/0'").unwrap();
 	assert_eq!(pair.address, pair2.address);
 }
 

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -34,6 +34,7 @@ use qp_poseidon_core::{
 extern crate alloc;
 use alloc::vec::Vec;
 use qp_rusty_crystals_dilithium::SensitiveBytes32;
+use zeroize::Zeroize;
 
 /// Salt used when deriving wormhole addresses.
 pub const ADDRESS_SALT: &str = "wormhole";
@@ -92,11 +93,18 @@ impl Eq for WormholePair {}
 
 impl WormholePair {
 	/// Generates a new `WormholePair` from user-supplied entropy.
-	pub fn generate_new(seed: SensitiveBytes32) -> WormholePair {
+	///
+	/// The seed is borrowed mutably and zeroized in place after use
+	/// (security review): taking it by value would move — i.e. copy — it
+	/// through a dead stack slot that is never dropped, so `ZeroizeOnDrop`
+	/// could not wipe it. The caller's value is all zeros afterwards; the
+	/// entropy stack-residue regression test pins this.
+	pub fn generate_new(seed: &mut SensitiveBytes32) -> WormholePair {
 		let mut hashed_seed = hash_bytes(seed.as_bytes());
 		let secret = SensitiveBytes32::new(&mut hashed_seed);
+		seed.as_mut_bytes().zeroize();
 
-		// seed and secret are automatically zeroized when it drops
+		// secret is automatically zeroized when it drops
 		WormholePair::generate_pair_from_secret(secret)
 	}
 
@@ -273,7 +281,7 @@ mod tests {
 	fn test_generate_new_produces_valid_pair() {
 		let mut seed = [55u8; 32];
 		// Act
-		let pair = WormholePair::generate_new((&mut seed).into());
+		let pair = WormholePair::generate_new(&mut (&mut seed).into());
 
 		// The secret should not be all zeros
 		assert_ne!(pair.secret.as_bytes(), &[0u8; 32]);

--- a/hdwallet/tests/bip39_stack_zeroization.rs
+++ b/hdwallet/tests/bip39_stack_zeroization.rs
@@ -23,8 +23,9 @@
 use std::alloc::{alloc, dealloc, Layout};
 
 use bip39::Language;
-use qp_rusty_crystals_hdwallet::{generate_mnemonic, mnemonic_to_seed, SensitiveBytes32};
-use zeroize::Zeroize;
+use qp_rusty_crystals_hdwallet::{
+	generate_mnemonic, mnemonic_to_seed, SensitiveBytes32, SensitiveBytes64,
+};
 
 const PAINT: u8 = 0xAA;
 // 4 MiB: comfortably above what PBKDF2 seed stretching needs.
@@ -84,8 +85,7 @@ fn mnemonic_word_indices_never_survive_on_the_stack() {
 	// parses one and skips its destructor must be seen.
 	assert!(
 		probe_stack_for(&pattern, || {
-			let mnemonic =
-				bip39::Mnemonic::parse_in_normalized(Language::English, PHRASE).unwrap();
+			let mnemonic = bip39::Mnemonic::parse_in_normalized(Language::English, PHRASE).unwrap();
 			core::mem::forget(mnemonic);
 		}),
 		"probe self-check: a deliberately leaked Mnemonic was not detected"
@@ -95,8 +95,9 @@ fn mnemonic_word_indices_never_survive_on_the_stack() {
 	// after PBKDF2; its word-index buffer must not survive.
 	let phrase = PHRASE.to_string();
 	let seed_stretch_leaked = probe_stack_for(&pattern, move || {
-		let mut seed = mnemonic_to_seed(phrase, None).unwrap();
-		seed.zeroize();
+		let mut seed = SensitiveBytes64::zeroed();
+		mnemonic_to_seed(phrase, None, &mut seed).unwrap();
+		core::hint::black_box(&seed);
 	});
 
 	// Scenario B: mnemonic generation. The Mnemonic built from entropy is
@@ -120,5 +121,37 @@ fn mnemonic_word_indices_never_survive_on_the_stack() {
 		!generation_leaked,
 		"generate_mnemonic() left the mnemonic word indices in dead stack memory; \
 		 the phrase is reconstructible from them and yields the whole HD wallet"
+	);
+}
+
+// Regression test (security review): the seed produced by `mnemonic_to_seed`
+// must leave no copy in memory once the caller's `SensitiveBytes64` is
+// dropped — with no manual zeroization hygiene on the caller's part. The seed
+// yields the entire HD wallet.
+//
+// This is why the API writes into a caller-provided `SensitiveBytes64`
+// instead of returning the seed by value: a by-value return is moved (i.e.
+// copied) through the `Result` payload and return slot, and moved-from stack
+// slots are dead but never dropped, so `ZeroizeOnDrop` cannot wipe them. With
+// the out-parameter the secret only ever exists inside the caller's wiping
+// guard, and this probe asserts exactly that: zero residue.
+#[test]
+fn seed_produced_by_mnemonic_to_seed_wipes_itself_on_drop() {
+	// Expected seed bytes, computed outside the probed region.
+	let mut expected_holder = SensitiveBytes64::zeroed();
+	mnemonic_to_seed(PHRASE.to_string(), None, &mut expected_holder).unwrap();
+	let expected = *expected_holder.as_bytes();
+
+	let phrase = PHRASE.to_string();
+	let leaked = probe_stack_for(&expected[..], move || {
+		let mut seed = SensitiveBytes64::zeroed();
+		mnemonic_to_seed(phrase, None, &mut seed).unwrap();
+		core::hint::black_box(&seed);
+		// `seed` drops here and wipes its interior in place.
+	});
+	assert!(
+		!leaked,
+		"the seed produced by mnemonic_to_seed() survived in dead stack memory \
+		 after the caller's SensitiveBytes64 was dropped"
 	);
 }

--- a/hdwallet/tests/bip39_stack_zeroization.rs
+++ b/hdwallet/tests/bip39_stack_zeroization.rs
@@ -1,0 +1,124 @@
+//! Regression tests (security review): dropped `bip39::Mnemonic` values must
+//! not leave the mnemonic's word indices in dead stack memory.
+//!
+//! `Mnemonic` stores the secret phrase as `words: [u16; 24]` (indices into the
+//! public BIP39 word list, so the phrase is trivially reconstructible from
+//! them) and only implements `Zeroize`/`ZeroizeOnDrop` when the bip39 crate's
+//! `zeroize` feature is enabled. The workspace previously declared bip39 with
+//! `default-features = false` and no `zeroize` feature, so the `Mnemonic`
+//! locals dropped inside `mnemonic_to_seed` (seed stretching) and
+//! `generate_mnemonic` left the full word-index buffer in dead stack frames.
+//!
+//! Detection uses the same painted-stack technique as the other
+//! `*_stack_zeroization` tests: run the operation on a sentinel-painted buffer
+//! via `psm::on_stack`, then scan the buffer — which we own, so the read is
+//! sound — for the native-endian byte image of the expected word-index array.
+//!
+//! The assertion is about codegen (which temporaries get wiped), so it is only
+//! compiled for optimized builds (`cargo test --release`): unoptimized codegen
+//! materializes additional compiler-generated move temporaries that no
+//! source-level fix can wipe.
+#![cfg(not(debug_assertions))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+use bip39::Language;
+use qp_rusty_crystals_hdwallet::{generate_mnemonic, mnemonic_to_seed, SensitiveBytes32};
+use zeroize::Zeroize;
+
+const PAINT: u8 = 0xAA;
+// 4 MiB: comfortably above what PBKDF2 seed stretching needs.
+const STACK_BYTES: usize = 4 * 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == &pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// The in-memory image of `Mnemonic`'s `words: [u16; 24]` buffer for `phrase`:
+/// each word's index into the English word list, in native endianness.
+fn word_index_pattern(phrase: &str) -> Vec<u8> {
+	let words: Vec<&str> = phrase.split_whitespace().collect();
+	assert_eq!(words.len(), 24, "test phrases must use all 24 word slots");
+	words
+		.iter()
+		.flat_map(|w| {
+			Language::English
+				.find_word(w)
+				.unwrap_or_else(|| panic!("{w:?} is not a BIP39 word"))
+				.to_ne_bytes()
+		})
+		.collect()
+}
+
+const PHRASE: &str = "panda eyebrow bullet gorilla call smoke muffin taste mesh \
+	discover soft ostrich alcohol speed nation flash devote level hobby quick \
+	inner drive ghost inside";
+
+#[test]
+fn mnemonic_word_indices_never_survive_on_the_stack() {
+	let pattern = word_index_pattern(PHRASE);
+
+	// Sanity: the technique detects an unwiped Mnemonic. A closure that
+	// parses one and skips its destructor must be seen.
+	assert!(
+		probe_stack_for(&pattern, || {
+			let mnemonic =
+				bip39::Mnemonic::parse_in_normalized(Language::English, PHRASE).unwrap();
+			core::mem::forget(mnemonic);
+		}),
+		"probe self-check: a deliberately leaked Mnemonic was not detected"
+	);
+
+	// Scenario A: seed stretching. The Mnemonic parsed inside is dropped
+	// after PBKDF2; its word-index buffer must not survive.
+	let phrase = PHRASE.to_string();
+	let seed_stretch_leaked = probe_stack_for(&pattern, move || {
+		let mut seed = mnemonic_to_seed(phrase, None).unwrap();
+		seed.zeroize();
+	});
+
+	// Scenario B: mnemonic generation. The Mnemonic built from entropy is
+	// dropped after the phrase string is produced; same requirement. The
+	// expected pattern is computed from a non-probed run with the same
+	// entropy (generation is deterministic in the entropy).
+	let entropy = [0x27u8; 32];
+	let generated = generate_mnemonic(SensitiveBytes32::from(&mut { entropy })).unwrap();
+	let generated_pattern = word_index_pattern(&generated);
+	let generation_leaked = probe_stack_for(&generated_pattern, || {
+		let phrase = generate_mnemonic(SensitiveBytes32::from(&mut { entropy })).unwrap();
+		core::hint::black_box(&phrase);
+	});
+
+	assert!(
+		!seed_stretch_leaked,
+		"mnemonic_to_seed() left the mnemonic word indices in dead stack memory; \
+		 the phrase is reconstructible from them and yields the whole HD wallet"
+	);
+	assert!(
+		!generation_leaked,
+		"generate_mnemonic() left the mnemonic word indices in dead stack memory; \
+		 the phrase is reconstructible from them and yields the whole HD wallet"
+	);
+}

--- a/hdwallet/tests/entropy_stack_zeroization.rs
+++ b/hdwallet/tests/entropy_stack_zeroization.rs
@@ -1,0 +1,123 @@
+//! Regression test (security review): the 32 bytes of derived keypair
+//! entropy must not survive in dead stack memory after key generation.
+//!
+//! The entropy is the crown jewel of the pipeline: it deterministically
+//! yields the entire keypair. It previously crossed three function
+//! boundaries by value — `derive_entropy_from_seed`'s return,
+//! `Keypair::generate`'s parameter, and `keypair_var`'s parameter (which
+//! additionally unwrapped it into a raw array via `into_bytes()`). Rust
+//! moves are copies that leave the moved-from stack slot dead but never
+//! dropped, so `ZeroizeOnDrop` could not wipe those slots. The fixed
+//! pipeline fills a caller-owned `SensitiveBytes32` in place and lends it
+//! to key generation by reference, which wipes it in place after use.
+//!
+//! Detection uses the same painted-stack technique as the other
+//! `*_stack_zeroization` tests; see `hderive_stack_zeroization.rs`.
+//!
+//! The assertion is about codegen (which temporaries get wiped), so it is
+//! only compiled for optimized builds (`cargo test --release`).
+#![cfg(all(not(debug_assertions), feature = "ml-dsa-87"))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+use qp_rusty_crystals_hdwallet::{
+	derive_key_from_seed, generate_wormhole_from_seed, hderive::ExtendedPrivKey, SensitiveBytes64,
+};
+
+const PAINT: u8 = 0xAA;
+// 4 MiB: comfortably above what ML-DSA-87 key generation needs.
+const STACK_BYTES: usize = 4 * 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == &pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// Distinctive 64-byte seed (ASCII, so a match cannot come from byte-swapped
+/// words inside a hash message schedule — only from a verbatim copy).
+const SEED: [u8; 64] = *b"entropy-probe-seed-first-half-0Aentropy-probe-seed-second-half0B";
+const PATH: &str = "m/44'/189189'/0'/0'/0'";
+const WORMHOLE_PATH: &str = "m/44'/189189189'/0'/0'/0'";
+
+fn seed_holder() -> SensitiveBytes64 {
+	let mut seed = SensitiveBytes64::zeroed();
+	seed.as_mut_bytes().copy_from_slice(&SEED);
+	seed
+}
+
+/// Reference entropy at (SEED, path), computed outside any probed region.
+fn reference_entropy(path: &str) -> [u8; 32] {
+	let mut xpriv = ExtendedPrivKey::zeroed();
+	ExtendedPrivKey::derive(&SEED, path, &mut xpriv).unwrap();
+	*xpriv.secret().as_bytes()
+}
+
+#[test]
+fn derived_entropy_never_survives_key_generation() {
+	let entropy = reference_entropy(PATH);
+
+	// Sanity: the technique detects an unwiped copy.
+	assert!(
+		probe_stack_for(&entropy, || {
+			let leaked: [u8; 32] = entropy;
+			core::hint::black_box(&leaked);
+		}),
+		"probe self-check: a deliberately leaked entropy copy was not detected"
+	);
+
+	// The full pipeline: seed -> HD entropy -> ML-DSA-87 keypair. Once the
+	// keypair has been produced and dropped, no copy of the entropy may
+	// remain anywhere on the stack.
+	let holder = seed_holder();
+	let leaked = probe_stack_for(&entropy, move || {
+		let keypair = derive_key_from_seed(holder, PATH).unwrap();
+		core::hint::black_box(&keypair);
+	});
+	assert!(
+		!leaked,
+		"the derived keypair entropy survived in dead stack memory after key \
+		 generation; it deterministically yields the entire keypair"
+	);
+}
+
+// Same property for the wormhole consumer of the derived entropy. This path
+// is the sensitive detector for by-value entropy hops: ML-DSA key generation
+// uses ~100 KB of stack whose frames happen to overwrite earlier move
+// temporaries, but the wormhole pair only computes a Poseidon hash, so an
+// unwiped entropy copy in a dead slot survives and the probe sees it.
+#[test]
+fn derived_entropy_never_survives_wormhole_generation() {
+	let entropy = reference_entropy(WORMHOLE_PATH);
+
+	let holder = seed_holder();
+	let leaked = probe_stack_for(&entropy, move || {
+		let pair = generate_wormhole_from_seed(holder, WORMHOLE_PATH).unwrap();
+		core::hint::black_box(&pair);
+	});
+	assert!(
+		!leaked,
+		"the derived wormhole entropy survived in dead stack memory; it yields \
+		 the wormhole secret (and the keypair at the same path)"
+	);
+}

--- a/hdwallet/tests/hderive_stack_zeroization.rs
+++ b/hdwallet/tests/hderive_stack_zeroization.rs
@@ -93,8 +93,9 @@ fn hderive_leaves_no_secret_material_on_the_stack() {
 	let master_secret: [u8; 32] = reference[..32].try_into().unwrap();
 	let master_chain: [u8; 32] = reference[32..].try_into().unwrap();
 
-	let master = ExtendedPrivKey::derive(&SEED, "m").unwrap();
-	assert_eq!(master.secret(), master_secret, "reference HMAC disagrees with derive()");
+	let mut master = ExtendedPrivKey::zeroed();
+	ExtendedPrivKey::derive(&SEED, "m", &mut master).unwrap();
+	assert_eq!(master.secret().as_bytes(), &master_secret, "reference HMAC disagrees with derive()");
 
 	// Sanity: the technique detects an unwiped copy. A closure that
 	// deliberately leaves the seed in a dead stack frame must be seen.
@@ -115,7 +116,8 @@ fn hderive_leaves_no_secret_material_on_the_stack() {
 	// must not survive anywhere on the stack once the derived key (which is
 	// self-zeroizing) has been dropped.
 	let derive_leaks = probe_stack_for(&seed_patterns, || {
-		let key = ExtendedPrivKey::derive(&SEED, "m").unwrap();
+		let mut key = ExtendedPrivKey::zeroed();
+		ExtendedPrivKey::derive(&SEED, "m", &mut key).unwrap();
 		core::hint::black_box(&key);
 	});
 
@@ -130,8 +132,10 @@ fn hderive_leaves_no_secret_material_on_the_stack() {
 	];
 	let child_number: ChildNumber = "0'".parse().unwrap();
 	let child_leaks = probe_stack_for(&child_patterns, || {
-		let child = master.child(child_number).unwrap();
-		core::hint::black_box(&child);
+		let mut key = ExtendedPrivKey::zeroed();
+		ExtendedPrivKey::derive(&SEED, "m", &mut key).unwrap();
+		key.child_in_place(child_number);
+		core::hint::black_box(&key);
 	});
 
 	assert!(
@@ -140,6 +144,45 @@ fn hderive_leaves_no_secret_material_on_the_stack() {
 	);
 	assert!(
 		child_leaks.is_empty(),
-		"child() left secret material in dead stack memory: {child_leaks:?}"
+		"child_in_place() left secret material in dead stack memory: {child_leaks:?}"
+	);
+}
+
+// Regression test (security review): deriving a key, reading its secret
+// through `ExtendedPrivKey::secret()`, and dropping everything must leave no
+// copy of the derived key material in dead stack memory — with no manual
+// wiping on the caller's part.
+//
+// Two past violations are pinned here. The raw-array accessor
+// (`fn secret(&self) -> [u8; 32]`) handed the caller an unguarded duplicate
+// with no destruction-time zeroization. And `derive()` returned the key
+// struct by value: Rust moves are copies that leave the moved-from stack
+// slot dead but never dropped, so the secret key and chain code survived in
+// a dead `Result` slot that `ZeroizeOnDrop` could not wipe. The accessor now
+// returns a borrow (no copy exists to leak) and `derive()` fills a
+// caller-provided key in place, so the material only ever lives inside the
+// caller's self-zeroizing value.
+#[test]
+fn derive_and_secret_access_leave_no_unwiped_copies() {
+	// Reference master secret and chain code, computed independently outside
+	// the probed region.
+	let mut reference: Hmac<Sha512> = Hmac::new_from_slice(b"Dilithium seed").unwrap();
+	reference.update(&SEED);
+	let reference = reference.finalize().into_bytes();
+	let patterns = [
+		("master secret_key", reference[..32].try_into().unwrap()),
+		("master chain_code", reference[32..].try_into().unwrap()),
+	];
+
+	let leaks = probe_stack_for(&patterns, || {
+		let mut key = ExtendedPrivKey::zeroed();
+		ExtendedPrivKey::derive(&SEED, "m", &mut key).unwrap();
+		let secret = key.secret();
+		core::hint::black_box(&secret);
+		// `key` drops here and wipes its fields in place.
+	});
+	assert!(
+		leaks.is_empty(),
+		"derived key material survived in dead stack memory: {leaks:?}"
 	);
 }

--- a/hdwallet/tests/hderive_stack_zeroization.rs
+++ b/hdwallet/tests/hderive_stack_zeroization.rs
@@ -1,0 +1,147 @@
+//! Regression tests (security review): the HMAC-SHA512 derivation steps in
+//! `ExtendedPrivKey::derive` and `ExtendedPrivKey::child` must not leave
+//! secret material in dead stack memory.
+//!
+//! The previous implementation drove the derivation through the `hmac` crate's
+//! `Hmac<Sha512>`, whose state is dropped without zeroization:
+//!
+//! - `Hmac::new_from_slice` builds a 128-byte key block, XORs it in place with
+//!   the ipad/opad constants and drops it unwiped, leaving `key ^ 0x5c..` (the
+//!   parent chain code in `child()`) in a dead stack frame.
+//! - The wrapper's block buffer holds the raw message tail — the BIP39 seed in
+//!   `derive()`, `0x00 || parent_secret_key || child_index` in `child()` —
+//!   verbatim, and `finalize()` consumes the ~470-byte wrapper by value, so
+//!   moves smear unwiped copies of that buffer across the stack.
+//! - The two inner SHA-512 states that absorbed the secrets are dropped
+//!   unwiped as well.
+//!
+//! Detection uses the same painted-stack technique as
+//! `dilithium/tests/import_stack_zeroization.rs`: run the derivation on a
+//! dedicated sentinel-painted buffer via `psm::on_stack`, then scan the buffer
+//! — which we own, so the read is sound — for distinctive secret patterns.
+//! The reference values (master secret key and chain code) are computed
+//! independently with the `hmac` dev-dependency outside the probed region.
+//!
+//! The assertion is about codegen (which temporaries get wiped), so it is only
+//! compiled for optimized builds (`cargo test --release`): unoptimized codegen
+//! materializes additional compiler-generated move temporaries that no
+//! source-level fix can wipe.
+#![cfg(not(debug_assertions))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+use hmac::{Hmac, Mac};
+use qp_rusty_crystals_hdwallet::hderive::{ChildNumber, ExtendedPrivKey};
+use sha2::Sha512;
+
+const PAINT: u8 = 0xAA;
+// 4 MiB: comfortably above what a single HMAC-SHA512 derivation step needs.
+const STACK_BYTES: usize = 4 * 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// HMAC ipad/opad constants (RFC 2104). `Hmac::new_from_slice` leaves
+/// `key ^ OPAD` in its dropped key-block local, so a scan for these XOR
+/// patterns detects chain-code residue even though the raw chain code itself
+/// never appears verbatim.
+const IPAD: u8 = 0x36;
+const OPAD: u8 = 0x5c;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for each
+/// named pattern and return the names of those found.
+fn probe_stack_for<F: FnOnce()>(patterns: &[(&str, [u8; 32])], f: F) -> Vec<String> {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let mut found = Vec::new();
+		for (name, pattern) in patterns {
+			let offsets: Vec<usize> = region
+				.windows(pattern.len())
+				.enumerate()
+				.filter(|(_, w)| w == pattern)
+				.map(|(i, _)| i)
+				.collect();
+			if !offsets.is_empty() {
+				eprintln!("probe: pattern {name:?} found at offsets {offsets:?}");
+				found.push(name.to_string());
+			}
+		}
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// Distinctive 64-byte seed; each 32-byte half is a scan pattern. ASCII, so a
+/// match cannot come from the byte-swapped u64 words inside the SHA-512
+/// message schedule — only from a verbatim byte-level copy of the seed.
+const SEED: [u8; 64] = *b"hderive-probe-seed-first-half-0Ahderive-probe-seed-second-half0B";
+
+fn xor_pattern(bytes: &[u8; 32], pad: u8) -> [u8; 32] {
+	bytes.map(|b| b ^ pad)
+}
+
+#[test]
+fn hderive_leaves_no_secret_material_on_the_stack() {
+	// Reference master secret_key || chain_code, computed independently of the
+	// code under test (and outside the probed region).
+	let mut reference: Hmac<Sha512> = Hmac::new_from_slice(b"Dilithium seed").unwrap();
+	reference.update(&SEED);
+	let reference = reference.finalize().into_bytes();
+	let master_secret: [u8; 32] = reference[..32].try_into().unwrap();
+	let master_chain: [u8; 32] = reference[32..].try_into().unwrap();
+
+	let master = ExtendedPrivKey::derive(&SEED, "m").unwrap();
+	assert_eq!(master.secret(), master_secret, "reference HMAC disagrees with derive()");
+
+	// Sanity: the technique detects an unwiped copy. A closure that
+	// deliberately leaves the seed in a dead stack frame must be seen.
+	let seed_patterns = [
+		("seed[0..32]", SEED[..32].try_into().unwrap()),
+		("seed[32..64]", SEED[32..].try_into().unwrap()),
+	];
+	assert!(
+		!probe_stack_for(&seed_patterns, || {
+			let leaked: [u8; 64] = SEED;
+			core::hint::black_box(&leaked);
+		})
+		.is_empty(),
+		"probe self-check: a deliberately leaked stack copy was not detected"
+	);
+
+	// Scenario A: master derivation. The seed is fed into the HMAC step and
+	// must not survive anywhere on the stack once the derived key (which is
+	// self-zeroizing) has been dropped.
+	let derive_leaks = probe_stack_for(&seed_patterns, || {
+		let key = ExtendedPrivKey::derive(&SEED, "m").unwrap();
+		core::hint::black_box(&key);
+	});
+
+	// Scenario B: child derivation. The parent secret key is the HMAC message
+	// and the parent chain code is the HMAC key; neither the raw values nor
+	// their ipad/opad-XORed key blocks may survive on the stack.
+	let child_patterns = [
+		("parent secret_key", master_secret),
+		("parent chain_code", master_chain),
+		("parent chain_code ^ ipad", xor_pattern(&master_chain, IPAD)),
+		("parent chain_code ^ opad", xor_pattern(&master_chain, OPAD)),
+	];
+	let child_number: ChildNumber = "0'".parse().unwrap();
+	let child_leaks = probe_stack_for(&child_patterns, || {
+		let child = master.child(child_number).unwrap();
+		core::hint::black_box(&child);
+	});
+
+	assert!(
+		derive_leaks.is_empty(),
+		"derive() left secret material in dead stack memory: {derive_leaks:?}"
+	);
+	assert!(
+		child_leaks.is_empty(),
+		"child() left secret material in dead stack memory: {child_leaks:?}"
+	);
+}

--- a/hdwallet/tests/hderive_stack_zeroization.rs
+++ b/hdwallet/tests/hderive_stack_zeroization.rs
@@ -5,15 +5,13 @@
 //! The previous implementation drove the derivation through the `hmac` crate's
 //! `Hmac<Sha512>`, whose state is dropped without zeroization:
 //!
-//! - `Hmac::new_from_slice` builds a 128-byte key block, XORs it in place with
-//!   the ipad/opad constants and drops it unwiped, leaving `key ^ 0x5c..` (the
-//!   parent chain code in `child()`) in a dead stack frame.
-//! - The wrapper's block buffer holds the raw message tail — the BIP39 seed in
-//!   `derive()`, `0x00 || parent_secret_key || child_index` in `child()` —
-//!   verbatim, and `finalize()` consumes the ~470-byte wrapper by value, so
-//!   moves smear unwiped copies of that buffer across the stack.
-//! - The two inner SHA-512 states that absorbed the secrets are dropped
-//!   unwiped as well.
+//! - `Hmac::new_from_slice` builds a 128-byte key block, XORs it in place with the ipad/opad
+//!   constants and drops it unwiped, leaving `key ^ 0x5c..` (the parent chain code in `child()`) in
+//!   a dead stack frame.
+//! - The wrapper's block buffer holds the raw message tail — the BIP39 seed in `derive()`, `0x00 ||
+//!   parent_secret_key || child_index` in `child()` — verbatim, and `finalize()` consumes the
+//!   ~470-byte wrapper by value, so moves smear unwiped copies of that buffer across the stack.
+//! - The two inner SHA-512 states that absorbed the secrets are dropped unwiped as well.
 //!
 //! Detection uses the same painted-stack technique as
 //! `dilithium/tests/import_stack_zeroization.rs`: run the derivation on a

--- a/hdwallet/tests/hderive_stack_zeroization.rs
+++ b/hdwallet/tests/hderive_stack_zeroization.rs
@@ -95,7 +95,11 @@ fn hderive_leaves_no_secret_material_on_the_stack() {
 
 	let mut master = ExtendedPrivKey::zeroed();
 	ExtendedPrivKey::derive(&SEED, "m", &mut master).unwrap();
-	assert_eq!(master.secret().as_bytes(), &master_secret, "reference HMAC disagrees with derive()");
+	assert_eq!(
+		master.secret().as_bytes(),
+		&master_secret,
+		"reference HMAC disagrees with derive()"
+	);
 
 	// Sanity: the technique detects an unwiped copy. A closure that
 	// deliberately leaves the seed in a dead stack frame must be seen.
@@ -181,8 +185,5 @@ fn derive_and_secret_access_leave_no_unwiped_copies() {
 		core::hint::black_box(&secret);
 		// `key` drops here and wipes its fields in place.
 	});
-	assert!(
-		leaks.is_empty(),
-		"derived key material survived in dead stack memory: {leaks:?}"
-	);
+	assert!(leaks.is_empty(), "derived key material survived in dead stack memory: {leaks:?}");
 }

--- a/tests/src/sign_integration_tests.rs
+++ b/tests/src/sign_integration_tests.rs
@@ -1,7 +1,16 @@
 // tests/sign_integration_tests.rs
 
-use qp_rusty_crystals_hdwallet::{derive_key_from_seed, generate_mnemonic, mnemonic_to_seed};
+use qp_rusty_crystals_hdwallet::{
+	derive_key_from_seed, generate_mnemonic, mnemonic_to_seed, SensitiveBytes64,
+};
 use rand::{Rng, RngExt};
+
+/// Test helper: stretch a known-valid mnemonic into a fresh seed.
+fn seed_from(mnemonic: String) -> SensitiveBytes64 {
+	let mut seed = SensitiveBytes64::zeroed();
+	mnemonic_to_seed(mnemonic, None, &mut seed).expect("Failed to create seed from mnemonic");
+	seed
+}
 
 fn get_random_bytes() -> [u8; 32] {
 	let mut rng = rand::rng();
@@ -16,9 +25,9 @@ fn test_sign() {
 
 	// Step 1: Generate a random mnemonic and derive Dilithium keypair
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let mut seed = mnemonic_to_seed(mnemonic, None).expect("Failed to create seed from mnemonic");
-	let dilithium_keypair = derive_key_from_seed((&mut seed).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key");
+	let seed = seed_from(mnemonic);
+	let dilithium_keypair =
+		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
 	// Step 2: Define the message to sign
 	let message = b"Hello, Dilithium!";
@@ -38,9 +47,9 @@ fn test_sign_multiple_messages() {
 	rand::rng().fill_bytes(&mut entropy);
 
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let mut seed = mnemonic_to_seed(mnemonic, None).expect("Failed to create seed from mnemonic");
-	let dilithium_keypair = derive_key_from_seed((&mut seed).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key");
+	let seed = seed_from(mnemonic);
+	let dilithium_keypair =
+		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
 	let messages = [
 		b"First message".as_slice(),
@@ -64,9 +73,9 @@ fn test_hedged_vs_deterministic_signing() {
 	rand::rng().fill_bytes(&mut entropy);
 
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let mut seed = mnemonic_to_seed(mnemonic, None).expect("Failed to create seed from mnemonic");
-	let dilithium_keypair = derive_key_from_seed((&mut seed).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key");
+	let seed = seed_from(mnemonic);
+	let dilithium_keypair =
+		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
 	let message = b"Test message for hedged vs deterministic";
 
@@ -105,15 +114,13 @@ fn test_cross_keypair_verification_fails() {
 	let mnemonic2 =
 		generate_mnemonic((&mut entropy2).into()).expect("Failed to generate mnemonic 2");
 
-	let mut seed1 =
-		mnemonic_to_seed(mnemonic1, None).expect("Failed to create seed from mnemonic 1");
-	let mut seed2 =
-		mnemonic_to_seed(mnemonic2, None).expect("Failed to create seed from mnemonic 2");
+	let seed1 = seed_from(mnemonic1);
+	let seed2 = seed_from(mnemonic2);
 
-	let keypair1 = derive_key_from_seed((&mut seed1).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key 1");
-	let keypair2 = derive_key_from_seed((&mut seed2).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key 2");
+	let keypair1 =
+		derive_key_from_seed(seed1, "m/44'/0'/0'/0'/0'").expect("Failed to derive key 1");
+	let keypair2 =
+		derive_key_from_seed(seed2, "m/44'/0'/0'/0'/0'").expect("Failed to derive key 2");
 
 	let message = b"Cross-verification test message";
 
@@ -135,9 +142,9 @@ fn test_corrupted_signature_fails() {
 	rand::rng().fill_bytes(&mut entropy);
 
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let mut seed = mnemonic_to_seed(mnemonic, None).expect("Failed to create seed from mnemonic");
-	let dilithium_keypair = derive_key_from_seed((&mut seed).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key");
+	let seed = seed_from(mnemonic);
+	let dilithium_keypair =
+		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
 	let message = b"Message for corruption test";
 	let mut signature = dilithium_keypair.sign(message, None, None).unwrap();
@@ -181,15 +188,13 @@ fn test_same_seed_produces_same_keypair() {
 	// Same seed should produce same mnemonic
 	assert_eq!(mnemonic1, mnemonic2);
 
-	let mut seed1 =
-		mnemonic_to_seed(mnemonic1, None).expect("Failed to create seed from mnemonic 1");
-	let mut seed2 =
-		mnemonic_to_seed(mnemonic2, None).expect("Failed to create seed from mnemonic 2");
+	let seed1 = seed_from(mnemonic1);
+	let seed2 = seed_from(mnemonic2);
 
-	let keypair1 = derive_key_from_seed((&mut seed1).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key 1");
-	let keypair2 = derive_key_from_seed((&mut seed2).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key 2");
+	let keypair1 =
+		derive_key_from_seed(seed1, "m/44'/0'/0'/0'/0'").expect("Failed to derive key 1");
+	let keypair2 =
+		derive_key_from_seed(seed2, "m/44'/0'/0'/0'/0'").expect("Failed to derive key 2");
 
 	// Same mnemonic should produce same keypair
 	let message = b"Test message";
@@ -210,9 +215,9 @@ fn test_stress_multiple_signatures() {
 	rand::rng().fill_bytes(&mut entropy);
 
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let mut seed = mnemonic_to_seed(mnemonic, None).expect("Failed to create seed from mnemonic");
-	let dilithium_keypair = derive_key_from_seed((&mut seed).into(), "m/44'/0'/0'/0'/0'")
-		.expect("Failed to derive key");
+	let seed = seed_from(mnemonic);
+	let dilithium_keypair =
+		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
 	// Sign and verify many messages
 	for i in 0..50 {

--- a/tests/src/verify_integration_tests.rs
+++ b/tests/src/verify_integration_tests.rs
@@ -24,7 +24,7 @@ macro_rules! nist_kat_for {
 				verify_test_vector(
 					test,
 					PUBLICKEYBYTES,
-					|entropy| Keypair::generate(entropy),
+					|mut entropy| Keypair::generate(&mut entropy),
 					|bytes| Keypair::from_bytes(bytes).expect("KAT keypair bytes must deserialize"),
 				);
 			}
@@ -191,12 +191,12 @@ impl_has_nist_kat_api!(ml_dsa_87);
 fn test_verify_invalid_signature() {
 	use qp_rusty_crystals_dilithium::ml_dsa_87::Keypair;
 
-	let entropy1 = get_random_bytes();
-	let entropy2 = get_random_bytes();
-	let entropy3 = get_random_bytes();
-	let keys_1 = Keypair::generate(entropy1);
-	let keys_2 = Keypair::generate(entropy2);
-	let keys_3 = Keypair::generate(entropy3);
+	let mut entropy1 = get_random_bytes();
+	let mut entropy2 = get_random_bytes();
+	let mut entropy3 = get_random_bytes();
+	let keys_1 = Keypair::generate(&mut entropy1);
+	let keys_2 = Keypair::generate(&mut entropy2);
+	let keys_3 = Keypair::generate(&mut entropy3);
 
 	let message = b"Hello, Resonance!";
 	let signature = keys_2.sign(message, None, None).unwrap();

--- a/threshold/benches/threshold_benchmarks.rs
+++ b/threshold/benches/threshold_benchmarks.rs
@@ -302,7 +302,7 @@ fn bench_comparison(c: &mut Criterion) {
 	let context: &[u8] = b"";
 
 	// Standard Dilithium
-	let keypair = Keypair::generate((&mut seed).into());
+	let keypair = Keypair::generate(&mut (&mut seed).into());
 
 	group.bench_function("standard_dilithium_sign", |b| {
 		b.iter(|| keypair.sign(message, None, None).unwrap());

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -179,8 +179,15 @@ pub fn generate_with_dealer(
 	let mut pk_packed = [0u8; PUBLIC_KEY_SIZE];
 	packing::pack_pk(&mut pk_packed, &rho, &t1);
 
-	// Create public key (TR is computed internally)
-	let public_key = PublicKey::new(pk_packed);
+	// Create public key (TR is computed internally). Validation is practically
+	// unreachable for an honestly seeded dealer (t1 = 0 requires astronomically
+	// unlikely entropy), but internal construction enforces the same parser
+	// rules as every import boundary.
+	let public_key = PublicKey::new(pk_packed).map_err(|_| {
+		ThresholdError::InvalidData(
+			"dealer generated a degenerate public key (all-zero t1)".into(),
+		)
+	})?;
 
 	// 8. Compute TR = SHAKE256(pk) for private key shares
 	let tr = *public_key.tr();

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -184,9 +184,7 @@ pub fn generate_with_dealer(
 	// unlikely entropy), but internal construction enforces the same parser
 	// rules as every import boundary.
 	let public_key = PublicKey::new(pk_packed).map_err(|_| {
-		ThresholdError::InvalidData(
-			"dealer generated a degenerate public key (all-zero t1)".into(),
-		)
+		ThresholdError::InvalidData("dealer generated a degenerate public key (all-zero t1)".into())
 	})?;
 
 	// 8. Compute TR = SHAKE256(pk) for private key shares

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -2510,7 +2510,7 @@ mod tests {
 			seed[4] = 0xDE;
 			seed[5] = 0xAD;
 
-			let keypair = Keypair::generate(SensitiveBytes32::from(&mut seed));
+			let keypair = Keypair::generate(&mut SensitiveBytes32::from(&mut seed));
 
 			public_keys.push(keypair.public().clone());
 			// Explicitly copy secret key to create signer

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -538,6 +538,19 @@ impl<S: TranscriptSigner> Dkg<S> {
 		&self.ssid
 	}
 
+	/// Check if the protocol has completed successfully.
+	pub fn is_complete(&self) -> bool {
+		self.state.is_complete()
+	}
+
+	/// Check if the protocol has failed terminally.
+	///
+	/// Every fatal `poke` error drives the state machine here; a failed
+	/// session holds no secret material and only reports its saved error.
+	pub fn is_failed(&self) -> bool {
+		self.state.is_failed()
+	}
+
 	/// Pop the next queued Round 1 private without leaving K_S behind.
 	///
 	/// `Vec::pop` alone moves the element out but leaves its bytes intact in
@@ -576,34 +589,69 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// * `Ok(DkgAction)` - The action to perform
 	/// * `Err(DkgError)` - If the protocol encounters an error
 	pub fn poke(&mut self) -> Result<DkgAction, DkgError> {
-		if let Some((to, private)) = self.pop_pending_private() {
-			return serialize_round1_private(to, private);
-		}
-
-		match self.state.phase {
-			DkgPhase::Initialized => self.start_round1(),
-			DkgPhase::Round1 => self.process_round1(),
-			DkgPhase::Round2 => self.process_round2(),
-			DkgPhase::Round3 => self.process_round3(),
-			DkgPhase::Round4 => self.process_round4(),
-			DkgPhase::Complete => {
-				let output = self
+		let result = if let Some((to, private)) = self.pop_pending_private() {
+			serialize_round1_private(to, private)
+		} else {
+			match self.state.phase {
+				DkgPhase::Initialized => self.start_round1(),
+				DkgPhase::Round1 => self.process_round1(),
+				DkgPhase::Round2 => self.process_round2(),
+				DkgPhase::Round3 => self.process_round3(),
+				DkgPhase::Round4 => self.process_round4(),
+				DkgPhase::Complete => self
 					.state
 					.output
 					.as_ref()
-					.ok_or_else(|| DkgError::InvalidState("Complete but no output".into()))?;
-				Ok(DkgAction::Return(output.clone()))
-			},
-			DkgPhase::Failed => {
-				let msg = self
-					.state
-					.error_message
-					.as_ref()
-					.cloned()
-					.unwrap_or_else(|| "unknown error".into());
-				Err(DkgError::InvalidState(msg))
+					.map(|output| DkgAction::Return(output.clone()))
+					.ok_or_else(|| DkgError::InvalidState("Complete but no output".into())),
+				DkgPhase::Failed => {
+					// Already terminal: keep reporting the saved error without
+					// re-running abort (which would re-wrap the message).
+					let msg = self
+						.state
+						.error_message
+						.as_ref()
+						.cloned()
+						.unwrap_or_else(|| "unknown error".into());
+					return Err(DkgError::InvalidState(msg));
+				},
+			}
+		};
+
+		// Common abort path: every fatal error from an active phase is
+		// terminal. The documented lifecycle has a Failed branch from every
+		// active phase, and integrations observe it via `is_failed()`;
+		// without this, a validation failure (e.g. CommitmentMismatch) left
+		// the phase at the current round, so a subsequent poke re-entered
+		// the failing round and secret round material stayed resident until
+		// the caller dropped the instance.
+		match result {
+			Ok(action) => Ok(action),
+			Err(error) => {
+				self.abort(&error);
+				Err(error)
 			},
 		}
+	}
+
+	/// Terminal abort: wipe all secret session material (mirroring `Drop`),
+	/// then record the `Failed` phase and the error message — in that order,
+	/// because `DkgState::zeroize` resets `phase` and `error_message` too.
+	/// Idempotent, so nested `poke` recursion may abort more than once.
+	fn abort(&mut self, error: &DkgError) {
+		self.state.zeroize();
+		self.seed.zeroize();
+		for (_, private) in self.pending_privates.iter_mut() {
+			private.zeroize();
+		}
+		self.pending_privates.clear();
+		for private in self.message_buffer.round1_privates.values_mut() {
+			private.zeroize();
+		}
+		self.message_buffer = DkgMessageBuffer::new();
+
+		self.state.phase = DkgPhase::Failed;
+		self.state.error_message = Some(format!("{}", error));
 	}
 
 	/// Process an incoming message from another party.
@@ -2814,6 +2862,45 @@ mod tests {
 			.any(|e| matches!(e, Some(DkgError::CommitmentMismatch { party_id: 2 })));
 
 		assert!(has_commitment_error, "At least one party should reject party 2's bad commitment");
+
+		// Security review: a fatal round error must be terminal, exactly like a
+		// `complete()` failure — the state machine transitions to Failed (so
+		// `is_failed()` is observable), secret round material is wiped, and a
+		// subsequent poke reports the saved error instead of re-entering the
+		// failed round. Before the fix, the CommitmentMismatch above left the
+		// phase at Round2 with randomness and shared secrets still resident.
+		for (party_id, error) in errors.iter().enumerate() {
+			if !matches!(error, Some(DkgError::CommitmentMismatch { party_id: 2 })) {
+				continue;
+			}
+			let dkg = &mut dkgs[party_id];
+			assert!(
+				dkg.is_failed(),
+				"party {} hit a fatal round error but is_failed() is false",
+				party_id
+			);
+			assert!(
+				dkg.state.my_randomness.is_none() &&
+					dkg.state.my_shared_secrets.is_none() &&
+					dkg.state.received_shared_secrets.is_none() &&
+					dkg.state.shared_secrets.is_none() &&
+					dkg.state.my_contributions.is_none(),
+				"party {} failed terminally but secret round material is still resident",
+				party_id
+			);
+			assert!(
+				dkg.state.error_message.is_some(),
+				"party {} failed without a saved error message",
+				party_id
+			);
+			// Terminal: poking again reports the saved failure rather than
+			// re-running the failed round's processing.
+			assert!(
+				matches!(dkg.poke(), Err(DkgError::InvalidState(_))),
+				"a failed session must keep reporting its terminal error on poke"
+			);
+			assert!(dkg.is_failed(), "a failed session must stay failed after poke");
+		}
 	}
 
 	/// Test that non-leaders detect tampered PK commitments in Round 4 before signing.

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -1548,12 +1548,20 @@ impl<S: TranscriptSigner> Dkg<S> {
 		)?;
 
 		// Combine partial PKs to get final public key. Reject any partial PK with
-		// non-canonical coefficients rather than overflowing the i32 accumulation.
-		let public_key =
-			pack_combined_pk(&rho, all_partial_pks.values().map(|pk| &pk.t)).map_err(|_| {
-				DkgError::InvalidMessage(
-					"a partial public key contains out-of-range coefficients".into(),
-				)
+		// non-canonical coefficients rather than overflowing the i32 accumulation,
+		// and reject a degenerate (all-zero t1) combined key that standard ML-DSA
+		// verification would refuse.
+		let public_key = pack_combined_pk(&rho, all_partial_pks.values().map(|pk| &pk.t))
+			.map_err(|e| {
+				use crate::protocol::partial_pk::PackCombinedPkError;
+				DkgError::InvalidMessage(match e {
+					PackCombinedPkError::CoefficientOutOfRange => {
+						"a partial public key contains out-of-range coefficients".into()
+					},
+					PackCombinedPkError::DegenerateCombinedKey => {
+						"the combined public key is degenerate (all-zero t1)".into()
+					},
+				})
 			})?;
 
 		// Build private key share

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -1599,16 +1599,14 @@ impl<S: TranscriptSigner> Dkg<S> {
 		// non-canonical coefficients rather than overflowing the i32 accumulation,
 		// and reject a degenerate (all-zero t1) combined key that standard ML-DSA
 		// verification would refuse.
-		let public_key = pack_combined_pk(&rho, all_partial_pks.values().map(|pk| &pk.t))
-			.map_err(|e| {
+		let public_key =
+			pack_combined_pk(&rho, all_partial_pks.values().map(|pk| &pk.t)).map_err(|e| {
 				use crate::protocol::partial_pk::PackCombinedPkError;
 				DkgError::InvalidMessage(match e {
-					PackCombinedPkError::CoefficientOutOfRange => {
-						"a partial public key contains out-of-range coefficients".into()
-					},
-					PackCombinedPkError::DegenerateCombinedKey => {
-						"the combined public key is degenerate (all-zero t1)".into()
-					},
+					PackCombinedPkError::CoefficientOutOfRange =>
+						"a partial public key contains out-of-range coefficients".into(),
+					PackCombinedPkError::DegenerateCombinedKey =>
+						"the combined public key is degenerate (all-zero t1)".into(),
 				})
 			})?;
 

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -4,7 +4,10 @@
 //! threshold signing. The private key share is intentionally opaque to
 //! prevent accidental exposure of secret material.
 
-use alloc::{collections::BTreeMap, format};
+use alloc::{
+	collections::{BTreeMap, BTreeSet},
+	format,
+};
 use core::fmt;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -203,9 +206,9 @@ impl BorshDeserialize for PrivateKeyShare {
 				"PrivateKeyShare dkg_participants length does not match total_parties",
 			));
 		}
-		if dkg_participants.index_of(party_id).is_none() {
-			return Err(invalid("PrivateKeyShare party_id is not in dkg_participants"));
-		}
+		let my_dkg_index = dkg_participants
+			.index_of(party_id)
+			.ok_or_else(|| invalid("PrivateKeyShare party_id is not in dkg_participants"))?;
 
 		// Read shares map with bound check
 		let len = u32::deserialize_reader(reader)? as usize;
@@ -226,6 +229,28 @@ impl BorshDeserialize for PrivateKeyShare {
 			}
 			let value = SecretShareData::deserialize_reader(reader)?;
 			shares.insert(key, value);
+		}
+
+		// The share map keys must be exactly the holder-specific canonical
+		// set: every subset of size (total_parties - threshold + 1) whose
+		// mask contains the holder's DKG index. Every producer (dealer, DKG,
+		// resharing) emits exactly that set, and Round 3 share recovery
+		// (`translated_subset_masks` + `recover_share`) assumes the entries
+		// it needs exist — with a missing mask, a signer initializes, runs
+		// rounds 1-2, and only fails at Round 3; extraneous or non-holder
+		// masks are secret material recovery can never use.
+		let subset_size = (total_parties - threshold + 1) as usize;
+		let expected: BTreeSet<u16> = crate::protocol::secret_sharing::generate_subsets_of_size(
+			total_parties as usize,
+			subset_size,
+		)
+		.into_iter()
+		.filter(|mask| mask & (1u16 << my_dkg_index) != 0)
+		.collect();
+		if shares.len() != expected.len() || !shares.keys().all(|mask| expected.contains(mask)) {
+			return Err(invalid(
+				"PrivateKeyShare shares is not the complete subset-share set for the holder",
+			));
 		}
 
 		Ok(Self { party_id, total_parties, threshold, dkg_participants, key, rho, tr, shares })
@@ -475,11 +500,15 @@ mod tests {
 		assert!(result.is_err(), "share coefficient outside (-Q, Q) must be rejected at import");
 
 		// Boundary: exactly Q and -Q are invalid, Q-1 and -(Q-1) are valid.
+		// The map carries the holder's complete subset set so the valid cases
+		// pass the share-map completeness check.
 		for (value, valid) in [(Q, false), (-Q, false), (Q - 1, true), (-(Q - 1), true)] {
 			let mut shares = BTreeMap::new();
 			let mut data = SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] };
 			data.s2[K - 1][255] = value;
 			shares.insert(0b011u16, data);
+			shares
+				.insert(0b101u16, SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] });
 			let share = PrivateKeyShare::new(
 				0,
 				3,
@@ -536,8 +565,9 @@ mod tests {
 			borsh::from_slice(&bytes)
 		};
 
-		// Baseline: consistent metadata imports fine.
-		assert!(roundtrip(0, 3, 2, &[0, 1, 2], &[0b011]).is_ok());
+		// Baseline: consistent metadata with the holder's complete share map
+		// (all size-2 subsets containing dkg index 0) imports fine.
+		assert!(roundtrip(0, 3, 2, &[0, 1, 2], &[0b011, 0b101]).is_ok());
 
 		// party_id not in dkg_participants: Round 3 recovery would fail late
 		// with InvalidConfiguration after rounds 1-2 already ran.
@@ -578,6 +608,69 @@ mod tests {
 		assert!(
 			roundtrip(0, 3, 2, &[0, 1, 2], &[0]).is_err(),
 			"empty share mask must be rejected at import"
+		);
+	}
+
+	/// Security review: the share map must be exactly the holder-specific
+	/// canonical subset set — every subset of size `n - t + 1` whose mask
+	/// contains the holder's DKG index. Every producer (dealer, DKG,
+	/// resharing) emits exactly that set, and `recover_share` assumes the
+	/// entries it needs exist; a tampered blob with a missing mask would
+	/// otherwise initialize a signer that runs rounds 1-2 and only fails at
+	/// Round 3 share recovery, and foreign masks would sit unused in secret
+	/// storage.
+	#[test]
+	fn test_private_key_share_borsh_rejects_wrong_share_map_key_set() {
+		let roundtrip = |party_id: u32, masks: &[u16]| -> Result<PrivateKeyShare, borsh::io::Error> {
+			let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
+			let mut shares = BTreeMap::new();
+			for &mask in masks {
+				shares.insert(mask, SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] });
+			}
+			let share = PrivateKeyShare::new(
+				party_id,
+				3,
+				2,
+				[0x11u8; 32],
+				[0x22u8; 32],
+				[0x33u8; TR_SIZE],
+				shares,
+				dkg_participants,
+			);
+			let bytes = borsh::to_vec(&share).unwrap();
+			borsh::from_slice(&bytes)
+		};
+
+		// 2-of-3, party at dkg index 0: the canonical set is the size-2
+		// subsets containing bit 0, i.e. {0b011, 0b101}.
+		assert!(roundtrip(0, &[0b011, 0b101]).is_ok(), "the complete holder set must import");
+		// Same for dkg index 2: {0b101, 0b110}.
+		assert!(roundtrip(2, &[0b101, 0b110]).is_ok(), "the complete holder set must import");
+
+		// A required mask is missing.
+		assert!(
+			roundtrip(0, &[0b011]).is_err(),
+			"a share map missing a required subset mask must be rejected at import"
+		);
+		// Empty map.
+		assert!(
+			roundtrip(0, &[]).is_err(),
+			"an empty share map must be rejected at import"
+		);
+		// Complete set plus an extra mask that excludes the holder.
+		assert!(
+			roundtrip(0, &[0b011, 0b101, 0b110]).is_err(),
+			"a share map with a non-holder subset mask must be rejected at import"
+		);
+		// Complete set plus an extra mask of the wrong subset size.
+		assert!(
+			roundtrip(0, &[0b011, 0b101, 0b111]).is_err(),
+			"a share map with a wrong-size subset mask must be rejected at import"
+		);
+		// Right count, but one entry swapped for a non-holder mask.
+		assert!(
+			roundtrip(0, &[0b011, 0b110]).is_err(),
+			"a share map substituting a non-holder mask must be rejected at import"
 		);
 	}
 

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -145,8 +145,22 @@ impl PublicKey {
 /// - Never transmit this over an insecure channel
 /// - Never log or print this value
 /// - Store securely (encrypted at rest)
-/// - The `Zeroize` trait ensures memory is cleared on drop
-#[derive(Clone, PartialEq, Eq, BorshSerialize)]
+/// - The `Zeroize` trait ensures memory is cleared on drop — **per
+///   instance**: zeroization never reaches other copies (see *Cloning*)
+///
+/// # Cloning
+///
+/// Cloning is supported because protocol instances consume a share by
+/// value: each signing attempt's `ThresholdSigner` and a resharing
+/// session's `ResharingConfig` take ownership, so a holder that needs the
+/// share again must duplicate it first. **Every clone is a fully
+/// independent plaintext copy of all secret fields with its own
+/// zeroize-on-drop lifecycle**; dropping or zeroizing one copy does not
+/// erase the others. Each clone therefore carries the full custody
+/// obligations above. Clone deliberately — once per protocol instance
+/// that consumes it — and never into long-lived caches, logs, or
+/// diagnostics.
+#[derive(PartialEq, Eq, BorshSerialize)]
 pub struct PrivateKeyShare {
 	/// Party identifier (can be arbitrary u32, e.g., NEAR participant ID).
 	party_id: ParticipantId,
@@ -352,6 +366,25 @@ impl PrivateKeyShare {
 	}
 }
 
+/// Duplication policy (see the type-level *Cloning* docs): the clone is an
+/// independent plaintext copy of every secret field, wiped only by its own
+/// drop. Implemented manually rather than derived so the policy is explicit
+/// and the secret-bearing field list is visible at the duplication site.
+impl Clone for PrivateKeyShare {
+	fn clone(&self) -> Self {
+		Self {
+			party_id: self.party_id,
+			total_parties: self.total_parties,
+			threshold: self.threshold,
+			dkg_participants: self.dkg_participants.clone(),
+			key: self.key,
+			rho: self.rho,
+			tr: self.tr,
+			shares: self.shares.clone(),
+		}
+	}
+}
+
 impl Zeroize for PrivateKeyShare {
 	fn zeroize(&mut self) {
 		self.party_id.zeroize();
@@ -448,6 +481,45 @@ mod tests {
 		let debug_str = format!("{:?}", pk_share);
 		assert!(debug_str.contains("REDACTED"));
 		assert!(!debug_str.contains("42")); // Should not contain the key bytes
+	}
+
+	/// Pins the documented cloning policy: a clone is a fully independent
+	/// plaintext copy with its own zeroization lifecycle. Wiping one copy
+	/// must leave the other intact (so a holder can hand one copy to a
+	/// protocol instance and keep another), and the wiped copy must hold no
+	/// secret material.
+	#[test]
+	fn test_private_key_share_clone_is_independent_plaintext_copy() {
+		let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
+		let mut shares = BTreeMap::new();
+		for mask in [0b011u16, 0b101u16] {
+			let mut data = SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] };
+			data.s1[0][0] = 7;
+			shares.insert(mask, data);
+		}
+		let mut original = PrivateKeyShare::new(
+			0,
+			3,
+			2,
+			[0x42u8; 32],
+			[0x43u8; 32],
+			[0x44u8; TR_SIZE],
+			shares,
+			dkg_participants,
+		);
+
+		let copy = original.clone();
+		assert!(copy == original, "a clone must be a faithful copy");
+
+		original.zeroize();
+
+		// The original is wiped...
+		assert_eq!(original.key, [0u8; 32]);
+		assert!(original.shares.is_empty());
+		// ...and the clone is untouched: an independent lifecycle.
+		assert_eq!(copy.key, [0x42u8; 32], "zeroizing one copy must not erase another");
+		assert_eq!(copy.shares.len(), 2);
+		assert_eq!(copy.shares[&0b011].s1[0][0], 7);
 	}
 
 	#[test]

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -79,20 +79,22 @@ impl BorshSerialize for PublicKey {
 impl BorshDeserialize for PublicKey {
 	fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
 		let bytes = <[u8; PUBLIC_KEY_SIZE]>::deserialize_reader(reader)?;
-		validate_pk_bytes(&bytes)
-			.map_err(|e| borsh::io::Error::new(borsh::io::ErrorKind::InvalidData, e))?;
-		let tr = compute_tr(&bytes);
-		Ok(Self { bytes, tr })
+		Self::new(bytes).map_err(|e| borsh::io::Error::new(borsh::io::ErrorKind::InvalidData, e))
 	}
 }
 
 impl PublicKey {
 	/// Create a new public key from packed bytes.
 	///
+	/// The bytes are validated through the canonical ML-DSA parser (rejecting
+	/// e.g. the degenerate all-zero t1 key), so internal producers — dealer
+	/// generation and DKG/resharing aggregation — cannot construct a
+	/// `PublicKey` that standard ML-DSA verification would later reject.
 	/// TR is computed automatically as `SHAKE256(bytes)`.
-	pub(crate) fn new(bytes: [u8; PUBLIC_KEY_SIZE]) -> Self {
+	pub(crate) fn new(bytes: [u8; PUBLIC_KEY_SIZE]) -> Result<Self, &'static str> {
+		validate_pk_bytes(&bytes)?;
 		let tr = compute_tr(&bytes);
-		Self { bytes, tr }
+		Ok(Self { bytes, tr })
 	}
 
 	/// Get the packed public key bytes.
@@ -120,10 +122,7 @@ impl PublicKey {
 
 		let mut pk_bytes = [0u8; PUBLIC_KEY_SIZE];
 		pk_bytes.copy_from_slice(bytes);
-		validate_pk_bytes(&pk_bytes)?;
-
-		let tr = compute_tr(&pk_bytes);
-		Ok(Self { bytes: pk_bytes, tr })
+		Self::new(pk_bytes)
 	}
 }
 

--- a/threshold/src/keys.rs
+++ b/threshold/src/keys.rs
@@ -145,8 +145,8 @@ impl PublicKey {
 /// - Never transmit this over an insecure channel
 /// - Never log or print this value
 /// - Store securely (encrypted at rest)
-/// - The `Zeroize` trait ensures memory is cleared on drop — **per
-///   instance**: zeroization never reaches other copies (see *Cloning*)
+/// - The `Zeroize` trait ensures memory is cleared on drop — **per instance**: zeroization never
+///   reaches other copies (see *Cloning*)
 ///
 /// # Cloning
 ///
@@ -579,8 +579,7 @@ mod tests {
 			let mut data = SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] };
 			data.s2[K - 1][255] = value;
 			shares.insert(0b011u16, data);
-			shares
-				.insert(0b101u16, SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] });
+			shares.insert(0b101u16, SecretShareData { s1: [[0i32; 256]; L], s2: [[0i32; 256]; K] });
 			let share = PrivateKeyShare::new(
 				0,
 				3,
@@ -693,7 +692,9 @@ mod tests {
 	/// storage.
 	#[test]
 	fn test_private_key_share_borsh_rejects_wrong_share_map_key_set() {
-		let roundtrip = |party_id: u32, masks: &[u16]| -> Result<PrivateKeyShare, borsh::io::Error> {
+		let roundtrip = |party_id: u32,
+		                 masks: &[u16]|
+		 -> Result<PrivateKeyShare, borsh::io::Error> {
 			let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
 			let mut shares = BTreeMap::new();
 			for &mask in masks {
@@ -725,10 +726,7 @@ mod tests {
 			"a share map missing a required subset mask must be rejected at import"
 		);
 		// Empty map.
-		assert!(
-			roundtrip(0, &[]).is_err(),
-			"an empty share map must be rejected at import"
-		);
+		assert!(roundtrip(0, &[]).is_err(), "an empty share map must be rejected at import");
 		// Complete set plus an extra mask that excludes the holder.
 		assert!(
 			roundtrip(0, &[0b011, 0b101, 0b110]).is_err(),

--- a/threshold/src/protocol/partial_pk.rs
+++ b/threshold/src/protocol/partial_pk.rs
@@ -68,6 +68,14 @@ pub enum PackCombinedPkError {
 	/// is always reduced into `[0, Q)`. A value outside that range indicates a
 	/// malformed or attacker-supplied contribution.
 	CoefficientOutOfRange,
+	/// The combined key failed canonical ML-DSA public-key validation.
+	///
+	/// This happens when the aggregated t vector's high bits (t1) are all
+	/// zero — e.g. colluding contributors whose partial PKs cancel mod Q.
+	/// Such a key is rejected by `PublicKey::from_bytes` and by standard
+	/// ML-DSA verification, so packing it would hand out a trusted-looking
+	/// `PublicKey` that can never verify a signature.
+	DegenerateCombinedKey,
 }
 
 /// Sum a collection of partial-PK polynomial vectors and pack into the canonical
@@ -117,7 +125,7 @@ where
 	let mut pk_packed = [0u8; PUBLIC_KEY_SIZE];
 	packing::pack_pk(&mut pk_packed, rho, &t1);
 
-	Ok(PublicKey::new(pk_packed))
+	PublicKey::new(pk_packed).map_err(|_| PackCombinedPkError::DegenerateCombinedKey)
 }
 
 #[cfg(test)]
@@ -214,6 +222,37 @@ mod tests {
 		assert_eq!(
 			pack_combined_pk(&rho, [&at_q]),
 			Err(PackCombinedPkError::CoefficientOutOfRange),
+		);
+	}
+
+	/// Regression test (security review): `pack_combined_pk` must not
+	/// construct a `PublicKey` that the canonical ML-DSA parser rejects.
+	/// Colluding contributors can make the aggregated t vector sum to values
+	/// whose high bits are all zero (a single all-zero partial PK is the
+	/// simplest case), yielding the degenerate all-zero t1 encoding that
+	/// `PublicKey::from_bytes` and the verifier both reject. Handing such
+	/// bytes out as a trusted-looking `PublicKey` leaves the group with an
+	/// unusable key that only fails later, at verification time.
+	#[test]
+	fn pack_combined_pk_rejects_degenerate_all_zero_t1() {
+		let rho = [7u8; 32];
+
+		// All-zero contribution: every coefficient is canonical, but t1 = 0.
+		let zero = [[0i32; N as usize]; K];
+		assert_eq!(
+			pack_combined_pk(&rho, [&zero]),
+			Err(PackCombinedPkError::DegenerateCombinedKey),
+			"a combined key with all-zero t1 must be rejected, not packed"
+		);
+
+		// Small nonzero coefficients are also degenerate: power2round drops
+		// the low 13 bits, so any t with all coefficients below 2^12 still
+		// packs to an all-zero t1.
+		let small = [[1i32; N as usize]; K];
+		assert_eq!(
+			pack_combined_pk(&rho, [&small]),
+			Err(PackCombinedPkError::DegenerateCombinedKey),
+			"a combined key whose t1 high bits are all zero must be rejected"
 		);
 	}
 }

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -2513,12 +2513,20 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		let rho = self.derive_rho();
 		// Reject partial PKs with non-canonical coefficients. An attacker-supplied
 		// coefficient near i32::MAX would otherwise overflow the i32 accumulation
-		// inside `pack_combined_pk` (panic in debug, silent wrap in release).
+		// inside `pack_combined_pk` (panic in debug, silent wrap in release). A
+		// degenerate (all-zero t1) recovered key is likewise rejected there.
 		let recovered = crate::protocol::partial_pk::pack_combined_pk(&rho, canonical.values())
-			.map_err(|_| {
-				ResharingProtocolError::ShareVerificationFailed(
-					"a Round 5 partial public key contains out-of-range coefficients".to_string(),
-				)
+			.map_err(|e| {
+				use crate::protocol::partial_pk::PackCombinedPkError;
+				ResharingProtocolError::ShareVerificationFailed(match e {
+					PackCombinedPkError::CoefficientOutOfRange => {
+						"a Round 5 partial public key contains out-of-range coefficients"
+							.to_string()
+					},
+					PackCombinedPkError::DegenerateCombinedKey => {
+						"the recovered public key is degenerate (all-zero t1)".to_string()
+					},
+				})
 			})?;
 		if recovered.as_bytes() != self.config.public_key().as_bytes() {
 			return Err(ResharingProtocolError::ShareVerificationFailed(

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -2519,13 +2519,11 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			.map_err(|e| {
 				use crate::protocol::partial_pk::PackCombinedPkError;
 				ResharingProtocolError::ShareVerificationFailed(match e {
-					PackCombinedPkError::CoefficientOutOfRange => {
+					PackCombinedPkError::CoefficientOutOfRange =>
 						"a Round 5 partial public key contains out-of-range coefficients"
-							.to_string()
-					},
-					PackCombinedPkError::DegenerateCombinedKey => {
-						"the recovered public key is degenerate (all-zero t1)".to_string()
-					},
+							.to_string(),
+					PackCombinedPkError::DegenerateCombinedKey =>
+						"the recovered public key is degenerate (all-zero t1)".to_string(),
 				})
 			})?;
 		if recovered.as_bytes() != self.config.public_key().as_bytes() {
@@ -2693,21 +2691,17 @@ fn partial_secret_norm_bound(threshold: u32, parties: u32, nu: f64) -> f64 {
 /// worth of material), but with two deliberate differences matching what the
 /// guard actually measures:
 ///
-/// - **No `√τ` challenge amplification.** The recovered-partial guard
-///   multiplies its measured norm by `√τ` to match `B`'s challenge-shifted
-///   convention; [`verify_stored_new_share_norms`] compares the *raw*
-///   [`single_share_weighted_norm`]. Inheriting `√τ` here loosened the
-///   single-share envelope by ~7.75× on ML-DSA-87, letting a malicious
-///   dealer inflate individual stored shares while public-key and
-///   recovered-partial checks still passed.
-/// - **κ is kept.** Honest resharing inflates individual stored shares too:
-///   the mean-subtracted coset noise adds per-share variance that only
-///   partially cancels in recovered sums. Measured over 20 chained reshares
-///   (steady state), honest stored-share norms reach ~1.24× the keygen
-///   single-share norm on (4,6) — nearly the full 1.3 base headroom — so the
-///   envelope needs the same per-config enlargement as the recovered-partial
-///   bound. Worst honest norm/bound ratio observed with κ: 0.83 (κ ≤ 1.5, so
-///   the envelope stays ~√τ tighter than before).
+/// - **No `√τ` challenge amplification.** The recovered-partial guard multiplies its measured norm
+///   by `√τ` to match `B`'s challenge-shifted convention; [`verify_stored_new_share_norms`]
+///   compares the *raw* [`single_share_weighted_norm`]. Inheriting `√τ` here loosened the
+///   single-share envelope by ~7.75× on ML-DSA-87, letting a malicious dealer inflate individual
+///   stored shares while public-key and recovered-partial checks still passed.
+/// - **κ is kept.** Honest resharing inflates individual stored shares too: the mean-subtracted
+///   coset noise adds per-share variance that only partially cancels in recovered sums. Measured
+///   over 20 chained reshares (steady state), honest stored-share norms reach ~1.24× the keygen
+///   single-share norm on (4,6) — nearly the full 1.3 base headroom — so the envelope needs the
+///   same per-config enlargement as the recovered-partial bound. Worst honest norm/bound ratio
+///   observed with κ: 0.83 (κ ≤ 1.5, so the envelope stays ~√τ tighter than before).
 fn stored_subset_share_norm_bound(threshold: u32, parties: u32, nu: f64) -> f64 {
 	secret_norm_envelope(threshold, parties, nu, 1.0)
 }
@@ -3887,9 +3881,9 @@ mod tests {
 		}
 		protocol.new_shares.insert(0b011, inflated);
 
-		let err = protocol
-			.verify_stored_new_share_norms()
-			.expect_err("a stored share inflated 3x past the single-share envelope must be rejected");
+		let err = protocol.verify_stored_new_share_norms().expect_err(
+			"a stored share inflated 3x past the single-share envelope must be rejected",
+		);
 		assert!(
 			err.to_string().contains("exceeds single-share norm bound"),
 			"unexpected error: {}",

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -2683,30 +2683,50 @@ fn partial_secret_norm_bound(threshold: u32, parties: u32, nu: f64) -> f64 {
 		let c = binomial(parties, threshold - 1) as f64;
 		(c / threshold as f64).ceil()
 	};
-	partial_secret_norm_bound_with_num_secrets(threshold, parties, nu, num_secrets)
+	(TAU as f64).sqrt() * secret_norm_envelope(threshold, parties, nu, num_secrets)
 }
 
 /// Norm bound for a single stored RSS subset share (`B_G` analog).
 ///
-/// Uses the same Mithril §3.4 calibration as [`partial_secret_norm_bound`], but
-/// with `num_secrets = 1` because each stored subset share aggregates one base
-/// secret's worth of material rather than the `⌈C(N,T−1)/T⌉` shares summed at
-/// signing recovery time.
+/// Uses the same base dimensioning as [`partial_secret_norm_bound`] with
+/// `num_secrets = 1` (each stored subset share aggregates one base secret's
+/// worth of material), but with two deliberate differences matching what the
+/// guard actually measures:
+///
+/// - **No `√τ` challenge amplification.** The recovered-partial guard
+///   multiplies its measured norm by `√τ` to match `B`'s challenge-shifted
+///   convention; [`verify_stored_new_share_norms`] compares the *raw*
+///   [`single_share_weighted_norm`]. Inheriting `√τ` here loosened the
+///   single-share envelope by ~7.75× on ML-DSA-87, letting a malicious
+///   dealer inflate individual stored shares while public-key and
+///   recovered-partial checks still passed.
+/// - **κ is kept.** Honest resharing inflates individual stored shares too:
+///   the mean-subtracted coset noise adds per-share variance that only
+///   partially cancels in recovered sums. Measured over 20 chained reshares
+///   (steady state), honest stored-share norms reach ~1.24× the keygen
+///   single-share norm on (4,6) — nearly the full 1.3 base headroom — so the
+///   envelope needs the same per-config enlargement as the recovered-partial
+///   bound. Worst honest norm/bound ratio observed with κ: 0.83 (κ ≤ 1.5, so
+///   the envelope stays ~√τ tighter than before).
 fn stored_subset_share_norm_bound(threshold: u32, parties: u32, nu: f64) -> f64 {
-	partial_secret_norm_bound_with_num_secrets(threshold, parties, nu, 1.0)
+	secret_norm_envelope(threshold, parties, nu, 1.0)
 }
 
-fn partial_secret_norm_bound_with_num_secrets(
-	threshold: u32,
-	parties: u32,
-	nu: f64,
-	num_secrets: f64,
-) -> f64 {
+/// Raw (unchallenged) ν-weighted norm envelope of `num_secrets` base secrets'
+/// worth of η-bounded material, κ-enlarged for honest resharing inflation:
+///
+/// ```text
+/// 1.3 · √(n·(k + ℓ/ν²) · Var(U(−η,η)) · num_secrets) · κ
+/// ```
+///
+/// Shared core of both Round 5 norm bounds; the recovered-partial bound `B`
+/// additionally multiplies by the `√τ` challenge amplification, the
+/// stored-share bound does not (it guards a raw stored-share norm).
+fn secret_norm_envelope(threshold: u32, parties: u32, nu: f64, num_secrets: f64) -> f64 {
 	let n = N as f64;
 	let dim = n * (K as f64 + L as f64 / (nu * nu));
 	let var_eta = ETA as f64 * (ETA as f64 + 1.0) / 3.0;
-	let base = 1.3 * (TAU as f64).sqrt() * (dim * var_eta * num_secrets).sqrt();
-	base * resharing_norm_enlargement(threshold, parties)
+	1.3 * (dim * var_eta * num_secrets).sqrt() * resharing_norm_enlargement(threshold, parties)
 }
 
 fn single_share_weighted_norm(share: &NewShareData, nu: f64) -> f64 {
@@ -3812,6 +3832,66 @@ mod tests {
 			.expect_err("oversized recovered partial must be rejected");
 		assert!(
 			err.to_string().contains("exceeds partial-secret norm bound"),
+			"unexpected error: {}",
+			err
+		);
+	}
+
+	/// Security review: the stored-share guard measures a *raw* (unchallenged)
+	/// single-share norm, so its envelope must not inherit the √τ
+	/// challenge-amplification factor from the recovered-partial calibration —
+	/// that factor loosened the intended single-share envelope ~√τ× (≈7.75 on
+	/// ML-DSA-87), letting a malicious dealer inflate individual stored shares
+	/// while keeping public-key and recovered-partial checks satisfied.
+	#[test]
+	fn test_stored_share_norm_guard_rejects_single_share_inflation() {
+		let config = crate::ThresholdConfig::new(2, 3).expect("valid config");
+		let (public_key, shares) =
+			crate::keygen::generate_with_dealer(&[7u8; 32], config).expect("keygen");
+		let resharing_config = ResharingConfig::new(
+			Some(shares[1].clone()),
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 2],
+			1,
+			public_key,
+		)
+		.expect("valid resharing config");
+		let mut protocol = ResharingProtocol::new(
+			resharing_config,
+			test_signer_config(1, &[0, 1, 2]),
+			[1u8; 32],
+			&[2u8; 32],
+			0,
+		);
+
+		// Craft a share at 3x the honest single-share envelope
+		// 1.3 * sqrt(dim * var_eta): far above what one base secret's worth of
+		// material can honestly reach (honest resharing overshoot is covered
+		// by κ ≤ 1.5), yet well below the old √τ-inflated bound, which
+		// accepted it.
+		let (_, _, nu) = crate::protocol::signing::get_hyperball_params(2, 3)
+			.expect("hyperball params for (2, 3)");
+		let dim = N as f64 * (K as f64 + L as f64 / (nu * nu));
+		let var_eta = ETA as f64 * (ETA as f64 + 1.0) / 3.0;
+		let honest_envelope = 1.3 * (dim * var_eta).sqrt();
+
+		// Constant s2 coefficients: weighted norm = coeff * sqrt(K * N).
+		let coeff = (3.0 * honest_envelope / ((K as f64) * (N as f64)).sqrt()).ceil() as i32;
+		let mut inflated = NewShareData::new();
+		for poly in inflated.s2.iter_mut() {
+			for c in poly.iter_mut() {
+				*c = coeff;
+			}
+		}
+		protocol.new_shares.insert(0b011, inflated);
+
+		let err = protocol
+			.verify_stored_new_share_norms()
+			.expect_err("a stored share inflated 3x past the single-share envelope must be rejected");
+		assert!(
+			err.to_string().contains("exceeds single-share norm bound"),
 			"unexpected error: {}",
 			err
 		);

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -69,10 +69,10 @@
 //!
 //! The protocol uses a leader-based approach for Round 4 (signature combination):
 //!
-//! - The **leader** (party with lowest ID among participants; enforced by the constructor)
-//!   combines signature shares. On success it broadcasts `Round4Complete(signature)`; on failure
-//!   it returns `SignProtocolError::ProtocolFailed`, ending the protocol instance. The caller is
-//!   responsible for starting a fresh attempt with new randomness.
+//! - The **leader** (party with lowest ID among participants; enforced by the constructor) combines
+//!   signature shares. On success it broadcasts `Round4Complete(signature)`; on failure it returns
+//!   `SignProtocolError::ProtocolFailed`, ending the protocol instance. The caller is responsible
+//!   for starting a fresh attempt with new randomness.
 //! - **Followers** verify the leader's signature before accepting it. This removes the leader trust
 //!   assumption for signature validity (a malicious leader cannot send a forged signature).
 //!
@@ -80,8 +80,8 @@
 //! - A malicious leader cannot forge signatures (requires threshold parties to collude).
 //! - A malicious leader cannot send invalid signatures (followers verify before accepting).
 //! - A malicious leader CAN cause denial-of-signature by aborting; in that case the caller (e.g.
-//!   NEAR MPC) will retry with a fresh protocol instance. Selecting a different signing set for
-//!   the retry changes the leader (the lowest ID of the new set), routing around the aborter.
+//!   NEAR MPC) will retry with a fresh protocol instance. Selecting a different signing set for the
+//!   retry changes the leader (the lowest ID of the new set), routing around the aborter.
 //!
 //! ## Message Buffering
 //!

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -69,10 +69,10 @@
 //!
 //! The protocol uses a leader-based approach for Round 4 (signature combination):
 //!
-//! - The **leader** (party with lowest ID among participants) combines signature shares. On success
-//!   it broadcasts `Round4Complete(signature)`; on failure it returns
-//!   `SignProtocolError::ProtocolFailed`, ending the protocol instance. The caller is responsible
-//!   for starting a fresh attempt with new randomness.
+//! - The **leader** (party with lowest ID among participants; enforced by the constructor)
+//!   combines signature shares. On success it broadcasts `Round4Complete(signature)`; on failure
+//!   it returns `SignProtocolError::ProtocolFailed`, ending the protocol instance. The caller is
+//!   responsible for starting a fresh attempt with new randomness.
 //! - **Followers** verify the leader's signature before accepting it. This removes the leader trust
 //!   assumption for signature validity (a malicious leader cannot send a forged signature).
 //!
@@ -80,8 +80,8 @@
 //! - A malicious leader cannot forge signatures (requires threshold parties to collude).
 //! - A malicious leader cannot send invalid signatures (followers verify before accepting).
 //! - A malicious leader CAN cause denial-of-signature by aborting; in that case the caller (e.g.
-//!   NEAR MPC) will retry with a fresh protocol instance, potentially with a different leader
-//!   selected by the application layer.
+//!   NEAR MPC) will retry with a fresh protocol instance. Selecting a different signing set for
+//!   the retry changes the leader (the lowest ID of the new set), routing around the aborter.
 //!
 //! ## Message Buffering
 //!
@@ -590,7 +590,10 @@ impl DilithiumSignProtocol {
 	/// * `message` - The message to sign
 	/// * `context` - The context string (can be empty, max 255 bytes)
 	/// * `participants` - All participant IDs in this signing session (can be arbitrary u32 values)
-	/// * `leader_id` - The leader's identifier (responsible for combine/retry decisions)
+	/// * `leader_id` - The leader's identifier (responsible for combine/retry decisions). Must be
+	///   the lowest ID in `participants` — the protocol's documented leader-election rule, which
+	///   every party derives independently; the explicit parameter makes the caller state the
+	///   leader it expects rather than discover a disagreement as a Round 4 stall
 	/// * `round1_seed` - A 32-byte cryptographically random seed for Round 1
 	/// * `attempt_nonce` - A 32-byte nonce unique to this signing attempt (must be agreed upon by
 	///   all participants, e.g., derived from the transport layer's session/channel ID)
@@ -606,7 +609,7 @@ impl DilithiumSignProtocol {
 	/// Returns `Err(SignProtocolError::InvalidConfig)` if:
 	/// - `participants` contains duplicates
 	/// - the signer share's `party_id()` is not in `participants`
-	/// - `leader_id` is not in `participants`
+	/// - `leader_id` is not the lowest ID in `participants`
 	/// - Any participant is not in the original DKG participant set
 	///
 	/// # Security Warning
@@ -640,10 +643,21 @@ impl DilithiumSignProtocol {
 			)));
 		}
 
-		if !participant_list.contains(leader_id) {
-			return Err(SignProtocolError::InvalidConfig(
-				"leader_id is not in participants".to_string(),
-			));
+		// The protocol contract fixes the leader as the lowest-ID member of
+		// the signing set (module Trust Model; the local signing helper and
+		// the resharing session leader derive it the same way). Any other
+		// choice is a misconfiguration: peers deriving the leader per the
+		// documented rule would disagree about who may combine and broadcast
+		// Round4Complete, stalling the attempt. This also subsumes the
+		// membership check.
+		let expected_leader = participant_list
+			.get(0)
+			.expect("participant_list is non-empty: it contains my_participant_id");
+		if leader_id != expected_leader {
+			return Err(SignProtocolError::InvalidConfig(format!(
+				"leader_id ({}) must be the lowest ID in participants ({})",
+				leader_id, expected_leader
+			)));
 		}
 
 		// Validate all signing participants are valid DKG participants
@@ -1619,6 +1633,52 @@ mod tests {
 		);
 
 		assert!(matches!(result, Err(SignProtocolError::InvalidConfig(_))));
+	}
+
+	/// Security review: the protocol contract (module Trust Model, README)
+	/// fixes the leader as the lowest-ID member of the signing set, and every
+	/// in-tree leader derivation (the local signing helper, the resharing
+	/// session leader) follows that rule. The constructor accepted any in-set
+	/// `leader_id`, so an integration could create a session whose leader
+	/// disagrees with peers deriving it per the documented rule — leaving
+	/// the set with no party (or two parties) claiming Round 4 combination
+	/// and stalling the attempt.
+	#[test]
+	fn test_protocol_rejects_non_lowest_id_leader() {
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[42u8; 32], config).unwrap();
+
+		// Party 1 is in the signing set {0, 1}, but the documented leader is 0.
+		let signer = ThresholdSigner::new(shares[0].clone(), pk.clone(), config).unwrap();
+		let result = DilithiumSignProtocol::new(
+			signer,
+			b"test".to_vec(),
+			b"ctx".to_vec(),
+			vec![0, 1],
+			1, // in the set, but not the lowest ID
+			[0xAA; 32],
+			[0xBB; 32],
+		);
+		assert!(
+			matches!(result, Err(SignProtocolError::InvalidConfig(_))),
+			"an in-set leader_id that is not the lowest participant ID must be rejected"
+		);
+
+		// The lowest-ID leader is accepted, including when the signing set
+		// does not start at party 0.
+		let signer = ThresholdSigner::new(shares[1].clone(), pk, config).unwrap();
+		let protocol = DilithiumSignProtocol::new(
+			signer,
+			b"test".to_vec(),
+			b"ctx".to_vec(),
+			vec![1, 2],
+			1,
+			[0xAA; 32],
+			[0xBB; 32],
+		)
+		.unwrap();
+		assert_eq!(protocol.leader_id(), 1);
+		assert!(protocol.is_leader());
 	}
 
 	#[test]


### PR DESCRIPTION
# Security review fixes: zeroization, validation, and protocol-contract enforcement

This PR addresses 13 security review findings across `hdwallet`, `dilithium`, and `threshold`. Every fix follows the same discipline: reproduce the finding with a failing (red) test where testable, fix it, and keep the test as a regression pin. All items were verified as real before fixing; one reviewer recommendation was deliberately amended based on empirical measurement (see the last item).

## Secret zeroization and memory hygiene (`hdwallet`, `dilithium`)

- **HMAC-SHA512 state leaked HD-derivation secrets** (`ecc9fc2`). The `hmac`/`sha2` crates don't wipe their internal buffers on drop, leaving the BIP-39 seed, parent secret keys, and chain codes in freed memory. Replaced with an in-crate HMAC-SHA512 that zeroizes all intermediate state, verified against reference test vectors and painted-stack probes.
- **Dropped `Mnemonic`s retained the phrase** (`4f9f113`). Enabled the `bip39` crate's `zeroize` feature so mnemonics are wiped on drop.
- **BIP-39 seeds returned by value** (`6c4d5cc`). `mnemonic_to_seed` returned a raw `[u8; 64]`, so every caller had to remember to wipe it — and Rust's move semantics left unwiped stack copies even when they did. The seed is now written into a caller-owned `SensitiveBytes64` out-parameter, filled in place.
- **`ExtendedPrivKey` accessors and derivation materialized unguarded key copies** (`35ebccd`). `secret()` now returns `&SensitiveBytes32` instead of a raw copy; `derive()` fills a caller-owned out-parameter and child steps happen in place, eliminating the intermediate by-value returns that left key material on the stack.
- **Keypair/wormhole generation entropy crossed function boundaries by value** (`aa6c6c3`). `Keypair::generate` and `WormholePair::generate_new` now take `&mut SensitiveBytes32` and wipe it after use; `keypair_var` borrows instead of consuming.
- **`t0_pack`/`eta_pack` staging buffers held secret-derived values** (`66e3666`). The packing helpers now zeroize their local staging arrays; release-mode painted-stack tests pin the behavior against future codegen changes.

All the stack-residue fixes are verified by painted-stack probe tests asserting zero secret residue after the operation.

## Deserialization and construction validation (`threshold`)

- **`PublicKey::new` skipped validation** (`9a6b1b0`). The internal constructor accepted bytes that `from_bytes`/Borsh would reject (e.g. the degenerate all-zero t1 encoding). It is now fallible and validates on every construction path; DKG, resharing, and the trusted dealer propagate the error, and `pack_combined_pk` rejects degenerate combined keys.
- **`PrivateKeyShare` import accepted structurally invalid share maps** (`c327747`). Deserialization now verifies the share map keys exactly equal the holder's canonical subset-mask set, rejecting missing, extraneous, and non-holder masks at the import boundary instead of failing rounds later at signing recovery.

## Protocol lifecycle and contracts (`threshold`)

- **Fatal DKG errors left the session in a retryable-looking round** (`eb7a4fa`). Every fatal error from an active phase now routes through a common abort path that zeroizes all secret state (round state, seed, pending and buffered private messages) and lands in the terminal `Failed` phase. `is_failed()`/`is_complete()` are now public.
- **Signing constructor accepted any leader** (`cdd2413`). `DilithiumSignProtocol::new` now enforces the documented leader-election rule (lowest ID in the signing set), turning silent leader disagreement — which would surface as a Round 4 stall — into an immediate configuration error.
- **`PrivateKeyShare::Clone` had no documented duplication policy** (`2ee58d7`). The type-level docs now spell out that clones are independent plaintext copies with their own zeroization lifecycle and full custody obligations; `Clone` is implemented manually so the policy and the secret-field list are explicit, and a test pins the independent-lifecycle semantics.

## Documentation contract (`hdwallet`)

- **README contradicted the hardened-only parser** (`6be3852`). The README claimed `change`/`address_index` may be unhardened while the parser deliberately rejects any unhardened segment. Hardened-only is correct for lattice keys (no public-key homomorphism, mirroring SLIP-10's ed25519 rule); the README now documents that contract and the parser test pins both sides of it.

## Resharing norm guard (`threshold`) — one deliberate deviation from the review

- **Stored-share norm guard was ~7.75× looser than intended** (`cfa77cf`). The Round 5 stored-share guard compares a *raw* (unchallenged) share norm, but its bound reused the recovered-partial helper, which bakes in the `√τ` challenge-amplification factor — accepting individual stored shares far outside the single-share envelope while public-key and recovered-partial checks still passed. The bound is now the raw envelope `1.3·√(dim·var_η)·κ`, with `√τ` applied explicitly at the recovered-partial call site so the convention difference is visible.

  The review recommended dropping κ as well; measurement says otherwise. Over 20 chained reshares, honest per-share inflation reaches ~1.24× on (4,6) — nearly the full 1.3 base headroom — so without κ honest reshares would sit one bad draw from rejection. With κ the worst honest norm/bound ratio is 0.83, while the envelope is still `√τ ≈ 7.75×` tighter than before.

## Breaking API changes

Callers of the following need updating:

| API | Before | After |
|---|---|---|
| `hdwallet::mnemonic_to_seed` | returns `[u8; 64]` | fills `&mut SensitiveBytes64` |
| `ExtendedPrivKey::secret()` | returns `[u8; 32]` | returns `&SensitiveBytes32` |
| `ExtendedPrivKey::derive` | returns by value | fills `&mut ExtendedPrivKey` |
| `Keypair::generate` / `WormholePair::generate_new` | consume entropy by value | take `&mut SensitiveBytes32`, wipe after use |
| `threshold::PublicKey::new` | infallible | fallible (validates bytes) |
| `DilithiumSignProtocol::new` | any member as `leader_id` | `leader_id` must be the lowest ID in `participants` |

## Testing

- Red-then-green regression test for every code fix; painted-stack probes (release mode) for the zeroization items.
- Full workspace test suites green; clippy clean.
- The tightened resharing norm bound was validated empirically against 2,040 honest stored shares from steady-state chained reshares across all supported committee shapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes secret-handling and threshold protocol boundaries (DKG abort, leader rule, share-map and public-key validation) with several breaking public APIs; regressions are broad but mistakes could affect key derivation or distributed ceremonies.
> 
> **Overview**
> **Security-review hardening** across `hdwallet`, `dilithium`, and `threshold`, with red/green and painted-stack (release) regression tests.
> 
> **Secret lifecycle (`hdwallet` / `dilithium`)** replaces `hmac`-crate derivation with in-crate **HMAC-SHA512 / PBKDF2** that wipes hash state; enables **`bip39` `zeroize`**; writes BIP-39 seeds and HD keys via **caller-owned `SensitiveBytes64` / `ExtendedPrivKey` out-parameters** instead of by-value returns; changes **`Keypair::generate`**, **`keypair_var`**, and **`WormholePair::generate_new`** to take **`&mut SensitiveBytes32`** and zeroize in place; adds **`SensitiveBytes32/64::zeroed()` / `as_mut_bytes()`**; zeroizes **`t0_pack` / `eta_pack`** staging buffers.
> 
> **Threshold** makes **`PublicKey::new` / Borsh import** validate like `from_bytes` and rejects **degenerate combined keys** in DKG/dealer/resharing; **`PrivateKeyShare` Borsh** must match the holder’s **canonical subset-mask set**; fatal **DKG `poke` errors** call **`abort()`** (wipe secrets, **`Failed` phase**, **`is_failed` / `is_complete`**); **`DilithiumSignProtocol::new`** requires **`leader_id`** to be the **lowest** participant; documents and tests **`PrivateKeyShare::Clone`** as independent plaintext copies; tightens **resharing stored-share norm bound** (drops erroneous **√τ** on raw norms, keeps **κ**).
> 
> **Docs / contract:** `hdwallet` README now states **hardened-only** paths (aligned with the parser).
> 
> **Breaking callers:** `mnemonic_to_seed`, `ExtendedPrivKey::derive` / `secret()`, entropy-taking keygen/wormhole APIs, fallible `PublicKey::new`, and signing leader validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa77cfc8669c05a964a8eb77bb332820d06c631. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->