### PR TITLE
ci: Automate dilithium version bump to dilithium-v4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "55e32db7b3a5d70086f82f198ecfc021f17cb7ec70a416512dba3488f4a116c1"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hex-literal = { version = "=0.4.1", default-features = false }
 libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
-qp-rusty-crystals-dilithium = { path = "./dilithium", version = "3.0.1", default-features = false }
+qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.0.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "3.0.1", default-features = false }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=2.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-dilithium"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of CRYSTALS-Dilithium digital signature scheme"


### PR DESCRIPTION
Automated dilithium version bump for release dilithium-v4.0.0.

https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/30625594240

Triggered by workflow run: major

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no cryptographic or behavioral code in the diff; downstream consumers must adopt the new semver explicitly.
> 
> **Overview**
> Automated **major** release bump for `qp-rusty-crystals-dilithium` from **3.0.1** to **4.0.0**, aligned with release tag `dilithium-v4.0.0`.
> 
> The crate version in `dilithium/Cargo.toml`, the workspace dependency pin in the root `Cargo.toml`, and the corresponding `Cargo.lock` entry are updated together. **No Dilithium/ML-DSA implementation or API changes appear in this diff**—only versioning metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e87338cee14b217e0a0475e39d93579db5a1c65. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->