### PR TITLE
ci: Automate hdwallet version bump to hdwallet-v4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.0.0", default-features = false }
-qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "3.0.1", default-features = false }
+qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "4.0.0", default-features = false }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=2.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-hdwallet"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of HD wallet functionality with post-quantum cryptography"


### PR DESCRIPTION
Automated hdwallet version bump for release hdwallet-v4.0.0.

Triggered by workflow run: https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/30629070219

Type: major

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no cryptographic or runtime logic modified.
> 
> **Overview**
> Automated **major** release prep for `qp-rusty-crystals-hdwallet`: the crate and workspace dependency versions move from **3.0.1** to **4.0.0**, with `Cargo.lock` updated to match.
> 
> There are **no source or API changes** in this diff—only version metadata for the `hdwallet-v4.0.0` release workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa32df0abb1a6e8f98ccd4a9ab250612d4dd4dc8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->