### PR TITLE
ci: Automate threshold version bump to threshold-v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "qp-rusty-crystals-threshold"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "borsh",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.0.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "3.0.1", default-features = false }
-qp-rusty-crystals-threshold = { path = "./threshold", version = "=2.0.0", default-features = false }
+qp-rusty-crystals-threshold = { path = "./threshold", version = "3.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }
 rusty-crystals-integration-tests = { path = "./tests" }

--- a/threshold/Cargo.toml
+++ b/threshold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-threshold"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Quantus Network"]
 license = "GPL-3.0"


### PR DESCRIPTION
Automated threshold version bump for release threshold-v3.0.0.

Triggered by workflow run: https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/30629084846

Type: major

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-metadata-only change with no cryptographic or behavioral code modifications.
> 
> **Overview**
> **Automated major release** for `qp-rusty-crystals-threshold`: version **2.0.0 → 3.0.0** only.
> 
> Updates the crate version in `threshold/Cargo.toml`, the workspace dependency in root `Cargo.toml`, and the locked package entry in `Cargo.lock`. No source or API changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66336ff566168f214076062e999a492b5178eb41. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->