### PR TITLE
More zeroization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,8 +814,6 @@ dependencies = [
 [[package]]
 name = "qp-poseidon-core"
 version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e32db7b3a5d70086f82f198ecfc021f17cb7ec70a416512dba3488f4a116c1"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,7 @@ dependencies = [
  "hex-literal",
  "libm",
  "log",
+ "psm",
  "qp-rusty-crystals-dilithium",
  "rand",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "dudect-bencher",
  "hex",
  "psm",
+ "qp-rusty-crystals-test-utils",
  "rand",
  "serde_json",
  "zeroize",
@@ -840,6 +841,7 @@ dependencies = [
  "psm",
  "qp-poseidon-core",
  "qp-rusty-crystals-dilithium",
+ "qp-rusty-crystals-test-utils",
  "rand",
  "rand_core",
  "serde",
@@ -848,6 +850,13 @@ dependencies = [
  "thiserror",
  "unicode-normalization",
  "zeroize",
+]
+
+[[package]]
+name = "qp-rusty-crystals-test-utils"
+version = "0.1.0"
+dependencies = [
+ "psm",
 ]
 
 [[package]]
@@ -862,6 +871,7 @@ dependencies = [
  "log",
  "psm",
  "qp-rusty-crystals-dilithium",
+ "qp-rusty-crystals-test-utils",
  "rand",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,9 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "3.0.2"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5872607e25ea4ee5fb37e64bf1462168e1a36a4e719cdc8a105533c708253918"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["dilithium", "hdwallet", "tests", "test-utils", "threshold"]
+members = ["dilithium", "hdwallet", "test-utils", "tests", "threshold"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -17,8 +17,8 @@ log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.0.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "4.0.0", default-features = false }
-qp-rusty-crystals-threshold = { path = "./threshold", version = "=3.0.0", default-features = false }
 qp-rusty-crystals-test-utils = { path = "./test-utils" }
+qp-rusty-crystals-threshold = { path = "./threshold", version = "=3.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }
 rusty-crystals-integration-tests = { path = "./tests" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["dilithium", "hdwallet", "tests", "threshold"]
+members = ["dilithium", "hdwallet", "tests", "test-utils", "threshold"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -18,6 +18,7 @@ qp-poseidon-core = { version = "=3.0.2", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.0.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "4.0.0", default-features = false }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=3.0.0", default-features = false }
+qp-rusty-crystals-test-utils = { path = "./test-utils" }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }
 rand_core = { version = "=0.10.0", default-features = false }
 rusty-crystals-integration-tests = { path = "./tests" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ hex = { version = "=0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = { version = "=0.4.1", default-features = false }
 libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
-qp-poseidon-core = { version = "=3.0.2", default-features = false }
+qp-poseidon-core = { version = "=3.1.0", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.0.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "4.0.0", default-features = false }
 qp-rusty-crystals-test-utils = { path = "./test-utils" }
@@ -27,11 +27,3 @@ serde_json = { version = "=1.0.150", default-features = false, features = ["allo
 thiserror = { version = "=2.0.18", default-features = false }
 unicode-normalization = { version = "=0.1.25", default-features = false }
 zeroize = { version = "=1.8.2", default-features = false, features = ["derive"] }
-
-# TEMPORARY (security review): test against the local qp-poseidon branch that
-# wipes the sponge state after hashing (`illuzen/zeroization`), so hash inputs
-# and outputs — wormhole secrets are both — stop lingering in dead stack
-# frames. Remove once that branch is released as =3.0.3 and the pin above is
-# bumped.
-[patch.crates-io]
-qp-poseidon-core = { path = "../qp-poseidon" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,11 @@ serde_json = { version = "=1.0.150", default-features = false, features = ["allo
 thiserror = { version = "=2.0.18", default-features = false }
 unicode-normalization = { version = "=0.1.25", default-features = false }
 zeroize = { version = "=1.8.2", default-features = false, features = ["derive"] }
+
+# TEMPORARY (security review): test against the local qp-poseidon branch that
+# wipes the sponge state after hashing (`illuzen/zeroization`), so hash inputs
+# and outputs — wormhole secrets are both — stop lingering in dead stack
+# frames. Remove once that branch is released as =3.0.3 and the pin above is
+# bumped.
+[patch.crates-io]
+qp-poseidon-core = { path = "../qp-poseidon" }

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -39,6 +39,7 @@ criterion = { version = "=0.5.1", features = ["html_reports"] }
 rand = { version = "=0.10.1", features = ["thread_rng"] }
 dudect-bencher = { version = "=0.7" }
 psm = "=0.1.31"
+qp-rusty-crystals-test-utils = { workspace = true }
 # NIST ACVP known-answer-test harness (tests only; does not affect the no_std lib).
 serde_json = "1"
 hex = "0.4"

--- a/dilithium/examples/ct_bench.rs
+++ b/dilithium/examples/ct_bench.rs
@@ -33,6 +33,9 @@
 //! - `sign_norm_check`          — the infinity-norm rejection check on z = y + c*s1
 //! - `sign_make_hint`           — hint computation from secret-derived w0/w1
 //! - `ntt_pointwise`            — core polynomial arithmetic on secret operands
+//! - `secret_ct_eq`             — the constant-time 32-byte comparison behind
+//!   `SensitiveBytes32::ct_eq` and `WormholePair`'s `PartialEq` (matching vs mismatching operands;
+//!   a prefix-dependent compare would separate the classes)
 //!
 //! Intentionally not tested:
 //!
@@ -395,6 +398,37 @@ fn ntt_pointwise(runner: &mut CtRunner, rng: &mut BenchRng) {
 	}
 }
 
+/// The constant-time secret comparison (`ct_eq_32`).
+///
+/// Class Left compares two *equal* arrays (worst case for a short-circuiting
+/// compare: full scan), Class Right compares against fresh random bytes
+/// (which differ in the first byte with probability 255/256, the best case
+/// for an early exit). A prefix-dependent implementation would show a large
+/// timing gap between the classes; the fold must not.
+fn secret_ct_eq(runner: &mut CtRunner, rng: &mut BenchRng) {
+	const SAMPLES: usize = 200_000;
+	const BATCH: usize = 32;
+
+	let mut fixed = [0u8; 32];
+	rng.fill_bytes(&mut fixed);
+	let mut scratch = [0u8; 32];
+	let mut operand = [0u8; 32];
+
+	for _ in 0..SAMPLES {
+		let (is_left, class) = random_class(rng);
+		// Identical prep for both classes: RNG fill, then memcpy.
+		rng.fill_bytes(&mut scratch);
+		operand.copy_from_slice(if is_left { &fixed } else { &scratch });
+		runner.run_one(class, || {
+			for _ in 0..BATCH {
+				let eq =
+					qp_rusty_crystals_dilithium::ct_eq_32(black_box(&fixed), black_box(&operand));
+				black_box(eq);
+			}
+		});
+	}
+}
+
 ctbench_main!(
 	keygen_s1s2_sampling_eta2,
 	keygen_s1s2_sampling_eta4,
@@ -404,5 +438,6 @@ ctbench_main!(
 	sign_mask_expansion,
 	sign_norm_check,
 	sign_make_hint,
-	ntt_pointwise
+	ntt_pointwise,
+	secret_ct_eq
 );

--- a/dilithium/src/frontend.rs
+++ b/dilithium/src/frontend.rs
@@ -222,6 +222,17 @@ macro_rules! define_ml_dsa {
 			/// known-K **deterministic** signatures leak the secret key. Store key
 			/// blobs with integrity protection, or pass fresh `hedge` randomness to
 			/// [`sign`](Self::sign) when storage integrity cannot be guaranteed.
+			///
+			/// # Cost / DoS note
+			///
+			/// Confirming secret/public correspondence is inherently a keygen-scale
+			/// computation (re-deriving the public key from the secret). A cheap
+			/// structural pre-check rejects the common garbage case — a blob with
+			/// out-of-range packed coefficients — before that work runs, but a blob
+			/// crafted with canonical coefficients and an inconsistent public key
+			/// still costs one full derivation to reject. Callers exposing this
+			/// import to untrusted or unauthenticated input should rate-limit or
+			/// authenticate before calling it.
 			pub fn from_bytes(bytes: &[u8]) -> Result<Keypair, KeyParsingError> {
 				if bytes.len() != KEYPAIRBYTES {
 					return Err(KeyParsingError::BadKeypair);
@@ -317,6 +328,16 @@ macro_rules! define_ml_dsa {
 			/// **deterministic** signatures leak the secret key. Store key blobs
 			/// with integrity protection, or pass fresh `hedge` randomness to
 			/// [`sign`](Self::sign) when storage integrity cannot be guaranteed.
+			///
+			/// # Cost / DoS note
+			///
+			/// Validating a secret key re-derives its public key, a keygen-scale
+			/// computation. A cheap structural pre-check rejects the common garbage
+			/// case — a blob with out-of-range packed coefficients — before that
+			/// work runs, but a blob crafted with canonical coefficients and an
+			/// inconsistent stored `t0`/`tr` still costs one full derivation to
+			/// reject. Callers exposing this import to untrusted or unauthenticated
+			/// input should rate-limit or authenticate before calling it.
 			pub fn from_bytes(bytes: &[u8]) -> Result<SecretKey, KeyParsingError> {
 				if bytes.len() != SECRETKEYBYTES {
 					return Err(BadSecretKey);

--- a/dilithium/src/frontend.rs
+++ b/dilithium/src/frontend.rs
@@ -118,20 +118,25 @@ macro_rules! define_ml_dsa {
 			/// consumed in the practical sense: it is all zeros afterwards.
 			pub fn generate(entropy: &mut SensitiveBytes32) -> Keypair {
 				let mut pk = [0u8; PUBLICKEYBYTES];
-				let mut sk = [0u8; SECRETKEYBYTES];
+				// The packed secret key lives in a self-wiping buffer, and the
+				// Keypair is built in tail position rather than through a named
+				// local that is returned afterwards (security review): binding
+				// the struct first and returning it later moves it out of this
+				// frame, and the dead source copy of the full packed key is
+				// beyond the reach of any zeroize call (the release-mode
+				// `sign_stack_zeroization` probe found two such copies). The
+				// same tail-construction shape keeps `from_bytes` clean under
+				// the `import_stack_zeroization` probes.
+				let mut sk = Zeroizing::new([0u8; SECRETKEYBYTES]);
 				$crate::sign::keypair_var::<K, L, ETA, PUBLICKEYBYTES, SECRETKEYBYTES>(
 					&mut pk, &mut sk, entropy,
 				);
 				entropy.as_mut_bytes().zeroize();
-				let keypair = Keypair {
-					// Constructed directly rather than via `SecretKey::from_bytes`:
-					// a freshly generated key is consistent by construction, and the
-					// import-path validation would redo the keygen-scale derivation.
-					secret: SecretKey { bytes: sk },
-					public: PublicKey::from_bytes(&pk).expect("Should never fail"),
-				};
-				sk.zeroize();
-				keypair
+				let public = PublicKey::from_bytes(&pk).expect("Should never fail");
+				// Constructed directly rather than via `SecretKey::from_bytes`:
+				// a freshly generated key is consistent by construction, and the
+				// import-path validation would redo the keygen-scale derivation.
+				Keypair { secret: SecretKey { bytes: *sk }, public }
 			}
 
 			/// The secret half.

--- a/dilithium/src/lib.rs
+++ b/dilithium/src/lib.rs
@@ -63,9 +63,20 @@ pub struct SensitiveBytes32([u8; 32]);
 impl SensitiveBytes32 {
 	// Note this zeroizes the input bytes so that the struct takes practical ownership of the input.
 	pub fn new(bytes: &mut [u8; 32]) -> Self {
-		let result = Self(*bytes);
+		// Fill a zeroed wrapper in place, then `replace` it out (security
+		// review): `Self(*bytes)` can leave a `Copy` temporary the returned
+		// wrapper does not own, and a plain `let result = ...; result` return
+		// moves the secret out while leaving the named local's stack slot
+		// intact — beyond `ZeroizeOnDrop`. Writing into the wrapper and then
+		// swapping it with a zeroed value means (1) the only live secret is
+		// the return value and (2) the local is zeros when this frame drops
+		// (caught by the release-mode `sensitive_bytes_stack_zeroization`
+		// probe). Prefer [`Self::zeroed`] + [`Self::as_mut_bytes`] when the
+		// secret can be written directly into an already-placed wrapper.
+		let mut result = Self::zeroed();
+		result.0.copy_from_slice(bytes);
 		bytes.zeroize();
-		result
+		core::mem::replace(&mut result, Self::zeroed())
 	}
 
 	/// All-zero value, intended to be filled in place via [`Self::as_mut_bytes`].
@@ -106,9 +117,8 @@ impl SensitiveBytes32 {
 
 impl From<&mut [u8; 32]> for SensitiveBytes32 {
 	fn from(bytes: &mut [u8; 32]) -> Self {
-		let result = Self(*bytes);
-		bytes.zeroize();
-		result
+		// Same in-place fill + replace as [`SensitiveBytes32::new`].
+		Self::new(bytes)
 	}
 }
 
@@ -124,9 +134,13 @@ pub struct SensitiveBytes64([u8; 64]);
 impl SensitiveBytes64 {
 	// Note this zeroizes the input bytes so that the struct takes practical ownership of the input.
 	pub fn new(bytes: &mut [u8; 64]) -> Self {
-		let result = Self(*bytes);
+		// Same in-place fill + replace as [`SensitiveBytes32::new`] (security
+		// review): avoids both the `Self(*bytes)` Copy temporary and the
+		// moved-from local left behind by a plain by-value return.
+		let mut result = Self::zeroed();
+		result.0.copy_from_slice(bytes);
 		bytes.zeroize();
-		result
+		core::mem::replace(&mut result, Self::zeroed())
 	}
 
 	/// All-zero value, intended to be filled in place via [`Self::as_mut_bytes`].
@@ -156,9 +170,8 @@ impl SensitiveBytes64 {
 
 impl From<&mut [u8; 64]> for SensitiveBytes64 {
 	fn from(bytes: &mut [u8; 64]) -> Self {
-		let result = Self(*bytes);
-		bytes.zeroize();
-		result
+		// Same in-place fill + replace as [`SensitiveBytes64::new`].
+		Self::new(bytes)
 	}
 }
 

--- a/dilithium/src/lib.rs
+++ b/dilithium/src/lib.rs
@@ -24,6 +24,25 @@ extern crate std;
 
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
+/// Compares two 32-byte arrays in constant time.
+///
+/// `==` on byte arrays is *allowed* to short-circuit at the first differing
+/// byte, making the comparison time depend on the length of the matching
+/// prefix — a timing oracle that lets an attacker recover a secret
+/// incrementally (security review). Whether the compiler actually emits an
+/// early exit varies by target and optimization level, so secret material
+/// must never rely on it. This routine unconditionally folds the XOR of every
+/// byte pair into an accumulator; `black_box` denies the optimizer knowledge
+/// of the accumulated value so it cannot reintroduce a value-dependent exit.
+#[must_use]
+pub fn ct_eq_32(a: &[u8; 32], b: &[u8; 32]) -> bool {
+	let mut diff = 0u8;
+	for (x, y) in a.iter().zip(b.iter()) {
+		diff |= x ^ y;
+	}
+	core::hint::black_box(diff) == 0
+}
+
 /// Wrapper for sensitive 32-byte data that enforces move semantics and automatic zeroization
 ///
 /// Both `new()` and `from()` take mutable references and zeroize the input data,
@@ -71,6 +90,17 @@ impl SensitiveBytes32 {
 
 	pub fn into_bytes(self) -> [u8; 32] {
 		self.0
+	}
+
+	/// Constant-time equality with another secret.
+	///
+	/// `PartialEq` is intentionally not implemented for this type: a plain
+	/// `==` on the wrapped bytes may short-circuit and leak the length of the
+	/// matching prefix through timing. Callers that genuinely need to compare
+	/// secrets must do so explicitly through this method (see [`ct_eq_32`]).
+	#[must_use]
+	pub fn ct_eq(&self, other: &Self) -> bool {
+		ct_eq_32(&self.0, &other.0)
 	}
 }
 
@@ -158,6 +188,36 @@ mod acvp;
 
 #[cfg(test)]
 mod tests {
+	use crate::{ct_eq_32, SensitiveBytes32};
+
+	#[test]
+	fn ct_eq_32_semantics() {
+		let a = [0xA5u8; 32];
+		assert!(ct_eq_32(&a, &a));
+
+		// Differences at the first, last, and a middle byte must all be
+		// detected — the fold must cover the entire array.
+		for idx in [0usize, 15, 31] {
+			let mut b = a;
+			b[idx] ^= 1;
+			assert!(!ct_eq_32(&a, &b), "difference at byte {idx} not detected");
+		}
+
+		assert!(!ct_eq_32(&[0u8; 32], &[0xFFu8; 32]));
+	}
+
+	#[test]
+	fn sensitive_bytes_ct_eq() {
+		let mut raw1 = [7u8; 32];
+		let mut raw2 = [7u8; 32];
+		let mut raw3 = [8u8; 32];
+		let a = SensitiveBytes32::new(&mut raw1);
+		let b = SensitiveBytes32::new(&mut raw2);
+		let c = SensitiveBytes32::new(&mut raw3);
+		assert!(a.ct_eq(&b));
+		assert!(!a.ct_eq(&c));
+	}
+
 	#[test]
 	fn params() {
 		assert_eq!(crate::params::Q, 8380417);

--- a/dilithium/src/lib.rs
+++ b/dilithium/src/lib.rs
@@ -99,9 +99,13 @@ impl SensitiveBytes32 {
 		&self.0
 	}
 
-	pub fn into_bytes(self) -> [u8; 32] {
-		self.0
-	}
+	// There is deliberately no `into_bytes(self) -> [u8; 32]` (security
+	// review): extracting the inner array hands the secret back as a plain
+	// `Copy` value with no erasure obligation, silently re-creating every
+	// hazard this wrapper exists to prevent. Borrow via [`Self::as_bytes`],
+	// or transfer ownership of the wrapper itself (e.g. with
+	// `core::mem::replace(&mut src, Self::zeroed())` to keep the vacated
+	// slot clean).
 
 	/// Constant-time equality with another secret.
 	///
@@ -163,9 +167,7 @@ impl SensitiveBytes64 {
 		&self.0
 	}
 
-	pub fn into_bytes(self) -> [u8; 64] {
-		self.0
-	}
+	// No `into_bytes`; see the note on [`SensitiveBytes32`].
 }
 
 impl From<&mut [u8; 64]> for SensitiveBytes64 {

--- a/dilithium/src/poly.rs
+++ b/dilithium/src/poly.rs
@@ -2157,8 +2157,8 @@ mod pack_stack_zeroization_tests {
 	const STACK_BYTES: usize = 256 * 1024;
 	const ALIGN: usize = 4096;
 
-	/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-	/// `pattern` and return whether it was found.
+	// Local copy: unit tests cannot take a `dev-dependency`, so this cannot
+	// call `qp_rusty_crystals_test_utils` (used by the integration probes).
 	fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
 		let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
 		unsafe {

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -263,6 +263,26 @@ struct UnpackedSecretKey<const K: usize, const L: usize> {
 	secret_poly_s2_ntt: Polyvec<K>,
 }
 
+impl<const K: usize, const L: usize> UnpackedSecretKey<K, L> {
+	/// All-zero placeholder to be filled in place by
+	/// [`unpack_secret_key_for_signing`]. Constructed by the caller so the
+	/// secret-bearing value never has to be returned by value: a by-value
+	/// return moves the struct out of the callee's frame, and the dead source
+	/// copy — containing the signing key `K` and the NTT-form secret
+	/// polynomials — is beyond the reach of `ZeroizeOnDrop` (caught by the
+	/// release-mode `sign_stack_zeroization` probe).
+	fn zeroed() -> Self {
+		Self {
+			public_seed_rho: [0u8; params::SEEDBYTES],
+			public_key_hash_tr: [0u8; params::TR_BYTES],
+			private_key_seed: [0u8; params::SEEDBYTES],
+			secret_poly_t0_ntt: Polyvec::default(),
+			secret_poly_s1_ntt: Polyvec::default(),
+			secret_poly_s2_ntt: Polyvec::default(),
+		}
+	}
+}
+
 /// Signing context containing precomputed values.
 ///
 /// Holds the public seed `rho` rather than the expanded matrix A: A is regenerated on the fly
@@ -281,57 +301,46 @@ impl Drop for SigningContext {
 	}
 }
 
+/// Unpack a secret key into `unpacked` (an [`UnpackedSecretKey::zeroed`]
+/// placeholder owned by the caller), converting the secret polynomials to
+/// NTT form in place.
+///
+/// Out-parameter style on purpose (security review): the struct is filled
+/// through `&mut` — `unpack_sk` writes each field directly and the NTT runs
+/// in place — so no secret ever lives in a local of this frame and nothing
+/// secret-bearing is moved or returned by value. The previous by-value
+/// return left a dead stack copy of the whole struct (signing key `K`
+/// included) in this frame whenever the compiler did not elide the move.
 fn unpack_secret_key_for_signing<
 	const K: usize,
 	const L: usize,
 	const ETA: usize,
 	const SK: usize,
 >(
+	unpacked: &mut UnpackedSecretKey<K, L>,
 	secret_key_bytes: &[u8; SK],
-) -> UnpackedSecretKey<K, L> {
+) {
 	const {
 		assert!(SK == params::secretkeybytes(K, L, ETA));
 	}
-	let mut public_seed_rho = [0u8; params::SEEDBYTES];
-	let mut public_key_hash_tr = [0u8; params::TR_BYTES];
-	let mut private_key_seed = [0u8; params::SEEDBYTES];
-	let mut secret_poly_t0 = Polyvec::<K>::default();
-	let mut secret_poly_s1 = Polyvec::<L>::default();
-	let mut secret_poly_s2 = Polyvec::<K>::default();
-
 	// Every signing entry point receives key bytes that already passed the
 	// import validation (`SecretKey`'s storage is private and only filled by
 	// `generate`/`from_bytes`), so a non-canonical encoding here is a crate
 	// bug, not reachable attacker input.
 	let canonical = packing::unpack_sk::<K, L, ETA, SK>(
-		&mut public_seed_rho,
-		&mut public_key_hash_tr,
-		&mut private_key_seed,
-		&mut secret_poly_t0,
-		&mut secret_poly_s1,
-		&mut secret_poly_s2,
+		&mut unpacked.public_seed_rho,
+		&mut unpacked.public_key_hash_tr,
+		&mut unpacked.private_key_seed,
+		&mut unpacked.secret_poly_t0_ntt,
+		&mut unpacked.secret_poly_s1_ntt,
+		&mut unpacked.secret_poly_s2_ntt,
 		secret_key_bytes,
 	);
 	debug_assert!(canonical, "signing with a secret key that failed import validation");
 
-	polyvec::ntt(&mut secret_poly_s1);
-	polyvec::ntt(&mut secret_poly_s2);
-	polyvec::ntt(&mut secret_poly_t0);
-
-	let unpacked = UnpackedSecretKey {
-		public_seed_rho,
-		public_key_hash_tr,
-		private_key_seed,
-		secret_poly_t0_ntt: secret_poly_t0,
-		secret_poly_s1_ntt: secret_poly_s1,
-		secret_poly_s2_ntt: secret_poly_s2,
-	};
-	// `private_key_seed` is `Copy`, so the field init above left a copy of the
-	// secret seed in this stack local. `UnpackedSecretKey` is `ZeroizeOnDrop`,
-	// but this source is not (rho/tr are public; the polyvecs are moved, not
-	// copied), so wipe it.
-	private_key_seed.zeroize();
-	unpacked
+	polyvec::ntt(&mut unpacked.secret_poly_s1_ntt);
+	polyvec::ntt(&mut unpacked.secret_poly_s2_ntt);
+	polyvec::ntt(&mut unpacked.secret_poly_t0_ntt);
 }
 
 /// Compute the message representative μ = H(tr || pre || M).
@@ -563,7 +572,8 @@ pub(crate) fn signature_var<
 		assert_sign_params::<K, L, ETA, GAMMA1, GAMMA2, OMEGA, CD, PZ, W1, KW1, PK, SK, SIG>();
 	}
 
-	let unpacked_sk = unpack_secret_key_for_signing::<K, L, ETA, SK>(secret_key_bytes);
+	let mut unpacked_sk = UnpackedSecretKey::<K, L>::zeroed();
+	unpack_secret_key_for_signing::<K, L, ETA, SK>(&mut unpacked_sk, secret_key_bytes);
 	let signing_ctx = prepare_signing_context(&unpacked_sk, domain_prefix, message, hedge);
 
 	// Fiat-Shamir with aborts. The *number* of rejection-sampling attempts is
@@ -1092,8 +1102,11 @@ mod tests {
 			{ params::SIGNBYTES },
 		>(&mut challenge_seed, &mut z, &mut h, sig));
 
-		let unpacked =
-			unpack_secret_key_for_signing::<K, L, { params::ETA }, { params::SECRETKEYBYTES }>(sk); // s1 already in NTT domain
+		let mut unpacked = UnpackedSecretKey::<K, L>::zeroed();
+		unpack_secret_key_for_signing::<K, L, { params::ETA }, { params::SECRETKEYBYTES }>(
+			&mut unpacked,
+			sk,
+		); // s1 already in NTT domain
 		let mut challenge_poly = Poly::default();
 		poly::challenge::<{ params::TAU }, { params::C_DASH_BYTES }>(
 			&mut challenge_poly,

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -200,6 +200,28 @@ pub(crate) fn public_key_from_secret_var<
 		&mut rho, &mut tr, &mut key, &mut t0, &mut s1, &mut s2, sk,
 	);
 
+	// Lightweight structural pre-check gating the keygen-scale work below
+	// (security review, DoS amplification): `unpack_sk` already reports whether
+	// every packed s1/s2 coefficient is canonical (in [-ETA, ETA]). A random /
+	// garbage blob of the correct length almost always has at least one
+	// out-of-range slot, so bailing here avoids the expensive path that
+	// follows — SHAKE128 expansion of the whole K×L matrix A, forward and
+	// inverse NTT, power2round, and the SHAKE256 public-key re-hash. Honest
+	// keys are always in range and take the full path unchanged, so this adds
+	// no cost to the legitimate case and leaks nothing secret (the range of an
+	// imported blob is known to whoever supplied it). Note this only cheapens
+	// the common garbage case: a blob crafted with canonical coefficients but
+	// an inconsistent t0/tr still pays one full derivation, which is inherent
+	// to correspondence checking — callers importing untrusted key material
+	// must still rate-limit or authenticate (see the import-path docs).
+	if !s_in_range {
+		key.zeroize();
+		s1.zeroize();
+		s2.zeroize();
+		t0.zeroize();
+		return None;
+	}
+
 	let (t1, mut t0_derived) = derive_public_components(&rho, &s1, &s2);
 
 	let t1_nonzero = !t1.vec.iter().all(|p| p.coeffs().iter().all(|&c| c == 0));
@@ -223,7 +245,8 @@ pub(crate) fn public_key_from_secret_var<
 	t0.zeroize();
 	t0_derived.zeroize();
 
-	if s_in_range && t0_consistent && tr_consistent && t1_nonzero {
+	// `s_in_range` was already enforced above (we returned early otherwise).
+	if t0_consistent && tr_consistent && t1_nonzero {
 		Some(pk)
 	} else {
 		None

--- a/dilithium/tests/import_stack_zeroization.rs
+++ b/dilithium/tests/import_stack_zeroization.rs
@@ -37,37 +37,10 @@
 //! zero-copy assertion is only meaningful once those are elided.
 #![cfg(not(debug_assertions))]
 
-use std::alloc::{alloc, dealloc, Layout};
+use qp_rusty_crystals_test_utils::probe_stack_for;
 
-const PAINT: u8 = 0xAA;
 // 4 MiB: comfortably above the keygen-scale derivation the import paths run.
 const STACK_BYTES: usize = 4 * 1024 * 1024;
-const ALIGN: usize = 4096;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| w == pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
 
 /// A distinctive 32-byte window from the packed s1 region of the secret key.
 /// SK layout (identical prefix for every parameter set): rho (32) || key (32)
@@ -98,7 +71,7 @@ macro_rules! import_stack_zeroization_tests {
 				// deliberately leaves the secret key in a dead stack frame must
 				// be seen.
 				assert!(
-					probe_stack_for(&pattern, || {
+					probe_stack_for(super::STACK_BYTES, &pattern, || {
 						let leaked: [u8; SECRETKEYBYTES] = *sk_bytes;
 						core::hint::black_box(&leaked);
 					}),
@@ -110,7 +83,7 @@ macro_rules! import_stack_zeroization_tests {
 				// never moves the secret and cannot smear its own copies
 				// around); anything left afterwards is a copy the import path
 				// failed to wipe.
-				let keypair_import_leaked = probe_stack_for(&pattern, || {
+				let keypair_import_leaked = probe_stack_for(super::STACK_BYTES, &pattern, || {
 					let mut imported = Keypair::from_bytes(kp_bytes.as_slice());
 					if let Ok(kp) = imported.as_mut() {
 						kp.zeroize();
@@ -118,7 +91,7 @@ macro_rules! import_stack_zeroization_tests {
 				});
 
 				// Scenario B: SecretKey::from_bytes, same contract.
-				let secret_key_import_leaked = probe_stack_for(&pattern, || {
+				let secret_key_import_leaked = probe_stack_for(super::STACK_BYTES, &pattern, || {
 					let mut imported = SecretKey::from_bytes(sk_bytes.as_slice());
 					if let Ok(sk) = imported.as_mut() {
 						sk.zeroize();
@@ -131,13 +104,13 @@ macro_rules! import_stack_zeroization_tests {
 				// hygiene would — must leave nothing. Any surviving match is
 				// either an internal temporary the library dropped unwiped or
 				// a caller-side copy the API failed to self-wipe.
-				let serialize_leaked = probe_stack_for(&pattern, || {
+				let serialize_leaked = probe_stack_for(super::STACK_BYTES, &pattern, || {
 					let serialized = keypair.to_bytes();
 					core::hint::black_box(&serialized);
 				});
 
 				// Scenario D: SecretKey::to_bytes, same contract as C.
-				let sk_serialize_leaked = probe_stack_for(&pattern, || {
+				let sk_serialize_leaked = probe_stack_for(super::STACK_BYTES, &pattern, || {
 					let serialized = keypair.secret().to_bytes();
 					core::hint::black_box(&serialized);
 				});

--- a/dilithium/tests/import_stack_zeroization.rs
+++ b/dilithium/tests/import_stack_zeroization.rs
@@ -91,12 +91,13 @@ macro_rules! import_stack_zeroization_tests {
 				});
 
 				// Scenario B: SecretKey::from_bytes, same contract.
-				let secret_key_import_leaked = probe_stack_for(super::STACK_BYTES, &pattern, || {
-					let mut imported = SecretKey::from_bytes(sk_bytes.as_slice());
-					if let Ok(sk) = imported.as_mut() {
-						sk.zeroize();
-					}
-				});
+				let secret_key_import_leaked =
+					probe_stack_for(super::STACK_BYTES, &pattern, || {
+						let mut imported = SecretKey::from_bytes(sk_bytes.as_slice());
+						if let Ok(sk) = imported.as_mut() {
+							sk.zeroize();
+						}
+					});
 
 				// Scenario C: Keypair::to_bytes. The returned serialization
 				// necessarily contains the secret key, but it is `Zeroizing`,

--- a/dilithium/tests/sensitive_bytes_stack_zeroization.rs
+++ b/dilithium/tests/sensitive_bytes_stack_zeroization.rs
@@ -1,0 +1,108 @@
+//! Regression test (security review): the `SensitiveBytes{32,64}`
+//! constructors must not leave a plaintext copy of the input secret in dead
+//! stack memory.
+//!
+//! `new`/`from` were written as `Self(*bytes)` followed by `bytes.zeroize()`.
+//! Because `[u8; N]` is `Copy`, the `*bytes` expression can materialize a
+//! by-value temporary that is not owned by the returned wrapper, so the
+//! wrapper's `ZeroizeOnDrop` never reaches it and the source wipe does not
+//! cover it — its survival depends purely on whether codegen elides the copy.
+//!
+//! Detection uses the same painted-stack technique as the crate's other
+//! stack probes: run the constructor on a sentinel-painted buffer via
+//! `psm::on_stack`, then scan the buffer — which we own, so the read is sound
+//! — for the input pattern. The source array lives outside the probe (the
+//! closure captures it by `&mut`, so the harness never copies the pattern
+//! onto the probed stack itself), and the returned wrapper is wiped in place
+//! through `as_mut_bytes`. Any surviving match is a copy the constructor
+//! failed to clean up.
+//!
+//! Only compiled for optimized builds (`cargo test --release`): unoptimized
+//! codegen materializes additional move temporaries that no source-level fix
+//! can wipe.
+#![cfg(not(debug_assertions))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+use qp_rusty_crystals_dilithium::{SensitiveBytes32, SensitiveBytes64};
+use zeroize::Zeroize;
+
+const PAINT: u8 = 0xAA;
+const STACK_BYTES: usize = 1024 * 1024;
+const ALIGN: usize = 4096;
+
+const PATTERN32: [u8; 32] = *b"sensitive-bytes-32-stack-pattern";
+const PATTERN64: [u8; 64] = *b"sensitive-bytes-64-stack-residue-probe-pattern-unique-abcdefghij";
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| *w == pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+#[test]
+fn sensitive_bytes_constructors_leave_no_secret_copies_on_the_stack() {
+	// Sanity: the technique detects an unwiped copy.
+	assert!(
+		probe_stack_for(&PATTERN32, || {
+			let leaked = PATTERN32;
+			core::hint::black_box(&leaked);
+		}),
+		"probe self-check: a deliberately leaked stack copy was not detected"
+	);
+
+	// The source arrays live here, outside the probe; the closures capture
+	// them by `&mut`, so the harness never places the pattern on the probed
+	// stack. Each constructor zeroizes its source, so refill before reuse.
+	let mut src32 = PATTERN32;
+	let new32_leaked = probe_stack_for(&PATTERN32, || {
+		let mut w = SensitiveBytes32::new(&mut src32);
+		w.as_mut_bytes().zeroize();
+		core::hint::black_box(&w);
+	});
+
+	let mut src32 = PATTERN32;
+	let from32_leaked = probe_stack_for(&PATTERN32, || {
+		let mut w = SensitiveBytes32::from(&mut src32);
+		w.as_mut_bytes().zeroize();
+		core::hint::black_box(&w);
+	});
+
+	let mut src64 = PATTERN64;
+	let new64_leaked = probe_stack_for(&PATTERN64, || {
+		let mut w = SensitiveBytes64::new(&mut src64);
+		w.as_mut_bytes().zeroize();
+		core::hint::black_box(&w);
+	});
+
+	let mut src64 = PATTERN64;
+	let from64_leaked = probe_stack_for(&PATTERN64, || {
+		let mut w = SensitiveBytes64::from(&mut src64);
+		w.as_mut_bytes().zeroize();
+		core::hint::black_box(&w);
+	});
+
+	assert!(!new32_leaked, "SensitiveBytes32::new left the secret in stack memory");
+	assert!(!from32_leaked, "SensitiveBytes32::from left the secret in stack memory");
+	assert!(!new64_leaked, "SensitiveBytes64::new left the secret in stack memory");
+	assert!(!from64_leaked, "SensitiveBytes64::from left the secret in stack memory");
+}

--- a/dilithium/tests/sensitive_bytes_stack_zeroization.rs
+++ b/dilithium/tests/sensitive_bytes_stack_zeroization.rs
@@ -22,48 +22,20 @@
 //! can wipe.
 #![cfg(not(debug_assertions))]
 
-use std::alloc::{alloc, dealloc, Layout};
-
 use qp_rusty_crystals_dilithium::{SensitiveBytes32, SensitiveBytes64};
+use qp_rusty_crystals_test_utils::probe_stack_for;
 use zeroize::Zeroize;
 
-const PAINT: u8 = 0xAA;
 const STACK_BYTES: usize = 1024 * 1024;
-const ALIGN: usize = 4096;
 
 const PATTERN32: [u8; 32] = *b"sensitive-bytes-32-stack-pattern";
 const PATTERN64: [u8; 64] = *b"sensitive-bytes-64-stack-residue-probe-pattern-unique-abcdefghij";
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| *w == pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
 
 #[test]
 fn sensitive_bytes_constructors_leave_no_secret_copies_on_the_stack() {
 	// Sanity: the technique detects an unwiped copy.
 	assert!(
-		probe_stack_for(&PATTERN32, || {
+		probe_stack_for(STACK_BYTES, &PATTERN32, || {
 			let leaked = PATTERN32;
 			core::hint::black_box(&leaked);
 		}),
@@ -74,28 +46,28 @@ fn sensitive_bytes_constructors_leave_no_secret_copies_on_the_stack() {
 	// them by `&mut`, so the harness never places the pattern on the probed
 	// stack. Each constructor zeroizes its source, so refill before reuse.
 	let mut src32 = PATTERN32;
-	let new32_leaked = probe_stack_for(&PATTERN32, || {
+	let new32_leaked = probe_stack_for(STACK_BYTES, &PATTERN32, || {
 		let mut w = SensitiveBytes32::new(&mut src32);
 		w.as_mut_bytes().zeroize();
 		core::hint::black_box(&w);
 	});
 
 	let mut src32 = PATTERN32;
-	let from32_leaked = probe_stack_for(&PATTERN32, || {
+	let from32_leaked = probe_stack_for(STACK_BYTES, &PATTERN32, || {
 		let mut w = SensitiveBytes32::from(&mut src32);
 		w.as_mut_bytes().zeroize();
 		core::hint::black_box(&w);
 	});
 
 	let mut src64 = PATTERN64;
-	let new64_leaked = probe_stack_for(&PATTERN64, || {
+	let new64_leaked = probe_stack_for(STACK_BYTES, &PATTERN64, || {
 		let mut w = SensitiveBytes64::new(&mut src64);
 		w.as_mut_bytes().zeroize();
 		core::hint::black_box(&w);
 	});
 
 	let mut src64 = PATTERN64;
-	let from64_leaked = probe_stack_for(&PATTERN64, || {
+	let from64_leaked = probe_stack_for(STACK_BYTES, &PATTERN64, || {
 		let mut w = SensitiveBytes64::from(&mut src64);
 		w.as_mut_bytes().zeroize();
 		core::hint::black_box(&w);

--- a/dilithium/tests/sign_stack_zeroization.rs
+++ b/dilithium/tests/sign_stack_zeroization.rs
@@ -17,11 +17,10 @@
 //! we own, so the read is sound — for distinctive 32-byte windows of the
 //! secret key. Scanned windows:
 //!
-//! - `K` at offset 64..96 of the packed key (rho || key || tr || s1 ...):
-//!   high-entropy XOF output that the signing path must copy to derive ρ'.
-//! - the packed-s1 window at 128..160: signing unpacks the key through a
-//!   reference, so this window appearing on the stack would mean a full
-//!   packed-key copy was smeared and dropped unwiped.
+//! - `K` at offset 64..96 of the packed key (rho || key || tr || s1 ...): high-entropy XOF output
+//!   that the signing path must copy to derive ρ'.
+//! - the packed-s1 window at 128..160: signing unpacks the key through a reference, so this window
+//!   appearing on the stack would mean a full packed-key copy was smeared and dropped unwiped.
 //! - the keygen input seed, which deterministically derives the entire key.
 //!
 //! Key generation is seed-deterministic, so the reference keypair generated
@@ -107,7 +106,8 @@ macro_rules! sign_stack_zeroization_tests {
 					let mut generated = Keypair::generate(&mut sensitive);
 					generated.zeroize();
 				};
-				let keygen_leaked_k = probe_stack_for(super::STACK_BYTES, &k_pattern, keygen_closure);
+				let keygen_leaked_k =
+					probe_stack_for(super::STACK_BYTES, &k_pattern, keygen_closure);
 
 				// Scenario D/E: keygen must not leave the packed-s1 window or
 				// the raw input seed behind either. Fresh runs per pattern

--- a/dilithium/tests/sign_stack_zeroization.rs
+++ b/dilithium/tests/sign_stack_zeroization.rs
@@ -36,38 +36,11 @@
 //! which no source-level fix can wipe.
 #![cfg(not(debug_assertions))]
 
-use std::alloc::{alloc, dealloc, Layout};
+use qp_rusty_crystals_test_utils::probe_stack_for;
 
-const PAINT: u8 = 0xAA;
 // 4 MiB: comfortably above the keygen/signing frames (matrix expansion,
 // NTT chains, rejection-sampling loops).
 const STACK_BYTES: usize = 4 * 1024 * 1024;
-const ALIGN: usize = 4096;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| w == pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
 
 /// A 32-byte window of the packed secret key. SK layout (identical prefix for
 /// every parameter set): rho (32) || key (32) || tr (64) || s1 || s2 || t0.
@@ -102,7 +75,7 @@ macro_rules! sign_stack_zeroization_tests {
 				// that deliberately leaves K in a dead stack frame must be
 				// seen.
 				assert!(
-					probe_stack_for(&k_pattern, || {
+					probe_stack_for(super::STACK_BYTES, &k_pattern, || {
 						let leaked: [u8; 32] = k_pattern;
 						core::hint::black_box(&leaked);
 					}),
@@ -111,7 +84,7 @@ macro_rules! sign_stack_zeroization_tests {
 
 				// Scenario A: signing must wipe its copy of the signing key K
 				// (copied out of the packed key to derive the mask seed rho').
-				let sign_leaked_k = probe_stack_for(&k_pattern, || {
+				let sign_leaked_k = probe_stack_for(super::STACK_BYTES, &k_pattern, || {
 					let sig = keypair.sign(message, None, None).expect("signing succeeds");
 					core::hint::black_box(&sig);
 				});
@@ -119,7 +92,7 @@ macro_rules! sign_stack_zeroization_tests {
 				// Scenario B: signing reads the packed key through a
 				// reference; no full packed-key copy may be smeared onto the
 				// stack and dropped unwiped.
-				let sign_leaked_s1 = probe_stack_for(&s1_pattern, || {
+				let sign_leaked_s1 = probe_stack_for(super::STACK_BYTES, &s1_pattern, || {
 					let sig = keypair.sign(message, None, None).expect("signing succeeds");
 					core::hint::black_box(&sig);
 				});
@@ -134,20 +107,20 @@ macro_rules! sign_stack_zeroization_tests {
 					let mut generated = Keypair::generate(&mut sensitive);
 					generated.zeroize();
 				};
-				let keygen_leaked_k = probe_stack_for(&k_pattern, keygen_closure);
+				let keygen_leaked_k = probe_stack_for(super::STACK_BYTES, &k_pattern, keygen_closure);
 
 				// Scenario D/E: keygen must not leave the packed-s1 window or
 				// the raw input seed behind either. Fresh runs per pattern
 				// (each needs its own seed holder; generate consumes it).
 				let mut seed_third = SEED;
 				let mut sensitive_third = (&mut seed_third).into();
-				let keygen_leaked_s1 = probe_stack_for(&s1_pattern, || {
+				let keygen_leaked_s1 = probe_stack_for(super::STACK_BYTES, &s1_pattern, || {
 					let mut generated = Keypair::generate(&mut sensitive_third);
 					generated.zeroize();
 				});
 				let mut seed_fourth = SEED;
 				let mut sensitive_fourth = (&mut seed_fourth).into();
-				let keygen_leaked_seed = probe_stack_for(&SEED, || {
+				let keygen_leaked_seed = probe_stack_for(super::STACK_BYTES, &SEED, || {
 					let mut generated = Keypair::generate(&mut sensitive_fourth);
 					generated.zeroize();
 				});

--- a/dilithium/tests/sign_stack_zeroization.rs
+++ b/dilithium/tests/sign_stack_zeroization.rs
@@ -1,0 +1,173 @@
+//! Regression tests (security review): signing and key generation must not
+//! leave secret material in dead stack memory.
+//!
+//! The signing path copies the packed key's secret fields into stack locals:
+//! the signing key `K` (absorbed to derive the mask seed ρ'), ρ' itself, and
+//! the unpacked `s1`/`s2`/`t0` polynomials. All of them carry explicit
+//! `.zeroize()` calls (and `SigningContext` zeroizes on drop), but nothing
+//! verified that discipline survives optimized codegen. Leaking ρ' or the
+//! mask `y` is equivalent to leaking the key (the published response is
+//! `z = y + c*s1`); leaking `K` breaks the deterministic-signing hedge. Key
+//! generation likewise wipes its packed-key locals, verified here from the
+//! outside for the first time.
+//!
+//! Detection uses the same painted-stack technique as the crate's
+//! `import_stack_zeroization` test: run the operation on a dedicated
+//! sentinel-painted buffer via `psm::on_stack`, then scan the buffer — which
+//! we own, so the read is sound — for distinctive 32-byte windows of the
+//! secret key. Scanned windows:
+//!
+//! - `K` at offset 64..96 of the packed key (rho || key || tr || s1 ...):
+//!   high-entropy XOF output that the signing path must copy to derive ρ'.
+//! - the packed-s1 window at 128..160: signing unpacks the key through a
+//!   reference, so this window appearing on the stack would mean a full
+//!   packed-key copy was smeared and dropped unwiped.
+//! - the keygen input seed, which deterministically derives the entire key.
+//!
+//! Key generation is seed-deterministic, so the reference keypair generated
+//! outside the probe and the probed generation produce identical keys,
+//! letting the same patterns serve both scenarios. Scenario closures capture
+//! only references, so the probe machinery cannot plant a match itself.
+//!
+//! The assertion is about codegen and is per-monomorphization, so the suite
+//! is stamped once per enabled ML-DSA variant. Only compiled for optimized
+//! builds (`cargo test --release`): unoptimized codegen materializes
+//! compiler-generated move temporaries for the large by-value key structs
+//! which no source-level fix can wipe.
+#![cfg(not(debug_assertions))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+const PAINT: u8 = 0xAA;
+// 4 MiB: comfortably above the keygen/signing frames (matrix expansion,
+// NTT chains, rejection-sampling loops).
+const STACK_BYTES: usize = 4 * 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// A 32-byte window of the packed secret key. SK layout (identical prefix for
+/// every parameter set): rho (32) || key (32) || tr (64) || s1 || s2 || t0.
+fn sk_window(sk_bytes: &[u8], offset: usize) -> [u8; 32] {
+	let mut pattern = [0u8; 32];
+	pattern.copy_from_slice(&sk_bytes[offset..offset + 32]);
+	pattern
+}
+
+macro_rules! sign_stack_zeroization_tests {
+	($mod_name:ident, $feature:literal) => {
+		#[cfg(feature = $feature)]
+		mod $mod_name {
+			use super::{probe_stack_for, sk_window};
+			use qp_rusty_crystals_dilithium::$mod_name::Keypair;
+			use zeroize::Zeroize;
+
+			/// Distinctive seed; a repeated single byte could false-positive
+			/// against unrelated memory noise.
+			const SEED: [u8; 32] = *b"sign-stack-zeroize-seed-pattern!";
+
+			#[test]
+			fn signing_and_keygen_leave_no_secret_copies_on_the_stack() {
+				let mut seed = SEED;
+				let keypair = Keypair::generate(&mut (&mut seed).into());
+				let sk_bytes = keypair.secret().to_bytes();
+				let k_pattern = sk_window(sk_bytes.as_slice(), 32);
+				let s1_pattern = sk_window(sk_bytes.as_slice(), 128);
+				let message = b"stack zeroization probe";
+
+				// Sanity: the technique detects an unwiped copy. A closure
+				// that deliberately leaves K in a dead stack frame must be
+				// seen.
+				assert!(
+					probe_stack_for(&k_pattern, || {
+						let leaked: [u8; 32] = k_pattern;
+						core::hint::black_box(&leaked);
+					}),
+					"probe self-check: a deliberately leaked stack copy was not detected"
+				);
+
+				// Scenario A: signing must wipe its copy of the signing key K
+				// (copied out of the packed key to derive the mask seed rho').
+				let sign_leaked_k = probe_stack_for(&k_pattern, || {
+					let sig = keypair.sign(message, None, None).expect("signing succeeds");
+					core::hint::black_box(&sig);
+				});
+
+				// Scenario B: signing reads the packed key through a
+				// reference; no full packed-key copy may be smeared onto the
+				// stack and dropped unwiped.
+				let sign_leaked_s1 = probe_stack_for(&s1_pattern, || {
+					let sig = keypair.sign(message, None, None).expect("signing succeeds");
+					core::hint::black_box(&sig);
+				});
+
+				// Scenario C: key generation. Same seed => identical key, so
+				// the reference patterns apply. The seed holder is built
+				// outside the probe (the closure captures only a reference),
+				// and the produced keypair is wiped in place.
+				let mut seed_again = SEED;
+				let mut sensitive = (&mut seed_again).into();
+				let keygen_closure = || {
+					let mut generated = Keypair::generate(&mut sensitive);
+					generated.zeroize();
+				};
+				let keygen_leaked_k = probe_stack_for(&k_pattern, keygen_closure);
+
+				// Scenario D/E: keygen must not leave the packed-s1 window or
+				// the raw input seed behind either. Fresh runs per pattern
+				// (each needs its own seed holder; generate consumes it).
+				let mut seed_third = SEED;
+				let mut sensitive_third = (&mut seed_third).into();
+				let keygen_leaked_s1 = probe_stack_for(&s1_pattern, || {
+					let mut generated = Keypair::generate(&mut sensitive_third);
+					generated.zeroize();
+				});
+				let mut seed_fourth = SEED;
+				let mut sensitive_fourth = (&mut seed_fourth).into();
+				let keygen_leaked_seed = probe_stack_for(&SEED, || {
+					let mut generated = Keypair::generate(&mut sensitive_fourth);
+					generated.zeroize();
+				});
+
+				assert!(!sign_leaked_k, "signing left the signing key K in stack memory");
+				assert!(!sign_leaked_s1, "signing left a packed secret-key copy in stack memory");
+				assert!(!keygen_leaked_k, "key generation left the signing key K in stack memory");
+				assert!(
+					!keygen_leaked_s1,
+					"key generation left a packed secret-key copy in stack memory"
+				);
+				assert!(
+					!keygen_leaked_seed,
+					"key generation left the raw input seed in stack memory"
+				);
+			}
+		}
+	};
+}
+
+sign_stack_zeroization_tests!(ml_dsa_44, "ml-dsa-44");
+sign_stack_zeroization_tests!(ml_dsa_65, "ml-dsa-65");
+sign_stack_zeroization_tests!(ml_dsa_87, "ml-dsa-87");

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -46,6 +46,7 @@ rand_core.workspace = true
 # Reference HMAC implementation for the stack-zeroization regression test.
 hmac = { version = "0.12", default-features = false }
 psm = "=0.1.31"
+qp-rusty-crystals-test-utils = { workspace = true }
 
 [features]
 default = ["ml-dsa-87", "std"]

--- a/hdwallet/README.md
+++ b/hdwallet/README.md
@@ -93,7 +93,7 @@ parameter set. It requires the wormhole coin type (`189189189'`) in the path:
 use qp_rusty_crystals_hdwallet::derive_wormhole_from_mnemonic;
 
 let pair = derive_wormhole_from_mnemonic(&mnemonic, None, "m/44'/189189189'/0'/0'/0'")?;
-println!("Address: {}", hex::encode(pair.address));
+println!("Address: {}", hex::encode(pair.address()));
 ```
 
 ### Derivation Paths

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -326,12 +326,12 @@ mod hdwallet_tests {
 		let w = derive_wormhole_from_mnemonic(mnemonic, None, "m/44'/189189189'/0'").unwrap();
 
 		assert_eq!(
-			w.address(),
+			*w.address(),
 			hex!("6a2f0d3abe4390e0b05f6dea4ba10670676cda7c00d49526ddde59f16c85269f"),
 			"wormhole address derivation changed"
 		);
 		assert_eq!(
-			w.first_hash(),
+			*w.first_hash(),
 			hex!("890ff21aa4fda75dc56c6c322c164d3c21a18ca7853d368c28cf158affc8b5b1"),
 			"wormhole first_hash derivation changed"
 		);
@@ -349,8 +349,8 @@ mod hdwallet_tests {
 		let mnemonic = "rocket primary way job input cactus submit menu zoo burger rent impose";
 		let w = derive_wormhole_from_mnemonic(mnemonic, None, "m/44'/189189189'/0'").unwrap();
 		let hex = |b: &[u8]| b.iter().map(|x| format!("{x:02x}")).collect::<String>();
-		println!("address    = {}", hex(&w.address()));
-		println!("first_hash = {}", hex(&w.first_hash()));
+		println!("address    = {}", hex(w.address()));
+		println!("first_hash = {}", hex(w.first_hash()));
 		println!("secret     = {}", hex(w.secret().as_bytes()));
 	}
 
@@ -519,7 +519,7 @@ mod hdwallet_tests {
 		assert_eq!(wormhole.address().len(), 32);
 		assert_eq!(wormhole.first_hash().len(), 32);
 		assert_ne!(wormhole.secret().as_bytes(), &[0u8; 32]);
-		assert_ne!(wormhole.address(), [0u8; 32]);
+		assert_ne!(*wormhole.address(), [0u8; 32]);
 	}
 
 	#[test]

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -326,17 +326,17 @@ mod hdwallet_tests {
 		let w = derive_wormhole_from_mnemonic(mnemonic, None, "m/44'/189189189'/0'").unwrap();
 
 		assert_eq!(
-			w.address,
+			w.address(),
 			hex!("6a2f0d3abe4390e0b05f6dea4ba10670676cda7c00d49526ddde59f16c85269f"),
 			"wormhole address derivation changed"
 		);
 		assert_eq!(
-			w.first_hash,
+			w.first_hash(),
 			hex!("890ff21aa4fda75dc56c6c322c164d3c21a18ca7853d368c28cf158affc8b5b1"),
 			"wormhole first_hash derivation changed"
 		);
 		assert_eq!(
-			w.secret.as_bytes(),
+			w.secret().as_bytes(),
 			&hex!("30051cfa3abd462d3bc26da2d660e90ba8af6080b7fe95d9fd3f3b37c7d9ce4b"),
 			"wormhole secret derivation changed"
 		);
@@ -349,9 +349,9 @@ mod hdwallet_tests {
 		let mnemonic = "rocket primary way job input cactus submit menu zoo burger rent impose";
 		let w = derive_wormhole_from_mnemonic(mnemonic, None, "m/44'/189189189'/0'").unwrap();
 		let hex = |b: &[u8]| b.iter().map(|x| format!("{x:02x}")).collect::<String>();
-		println!("address    = {}", hex(&w.address));
-		println!("first_hash = {}", hex(&w.first_hash));
-		println!("secret     = {}", hex(w.secret.as_bytes()));
+		println!("address    = {}", hex(&w.address()));
+		println!("first_hash = {}", hex(&w.first_hash()));
+		println!("secret     = {}", hex(w.secret().as_bytes()));
 	}
 
 	#[test]
@@ -515,11 +515,11 @@ mod hdwallet_tests {
 		let wormhole = generate_wormhole_from_seed(seed, "m/44'/189189189'/0'").unwrap();
 
 		// Verify wormhole pair has expected structure
-		assert_eq!(wormhole.secret.as_bytes().len(), 32);
-		assert_eq!(wormhole.address.len(), 32);
-		assert_eq!(wormhole.first_hash.len(), 32);
-		assert_ne!(wormhole.secret.as_bytes(), &[0u8; 32]);
-		assert_ne!(wormhole.address, [0u8; 32]);
+		assert_eq!(wormhole.secret().as_bytes().len(), 32);
+		assert_eq!(wormhole.address().len(), 32);
+		assert_eq!(wormhole.first_hash().len(), 32);
+		assert_ne!(wormhole.secret().as_bytes(), &[0u8; 32]);
+		assert_ne!(wormhole.address(), [0u8; 32]);
 	}
 
 	#[test]

--- a/hdwallet/src/tests_variants.rs
+++ b/hdwallet/src/tests_variants.rs
@@ -103,7 +103,7 @@ fn variant_independent_surface_available() {
 	// Determinism of the variant-independent path.
 	let pair2 =
 		crate::generate_wormhole_from_seed(test_seed(), "m/44'/189189189'/0'/0'/0'").unwrap();
-	assert_eq!(pair.address, pair2.address);
+	assert_eq!(pair.address(), pair2.address());
 }
 
 /// Fixed (mnemonic, path) cases shared by the 44/65 golden-vector suites.

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -12,7 +12,8 @@
 //!
 //! - You can:
 //!     - Generate new wormhole identities using random entropy (`generate_new`).
-//!     - Verify if a given secret or pre-hashed secret matches a wormhole address.
+//!     - Verify a secret against an address by re-deriving (derivation is deterministic, so
+//!       re-run `generate_new` with the same input and compare the resulting `address`).
 //!
 //! The hashing strategy ensures determinism while hiding the original secret.
 //!
@@ -107,26 +108,23 @@ impl WormholePair {
 	/// entropy stack-residue regression test pins this.
 	pub fn generate_new(seed: &mut SensitiveBytes32) -> WormholePair {
 		let mut hashed_seed = hash_bytes(seed.as_bytes());
-		let secret = SensitiveBytes32::new(&mut hashed_seed);
+		let mut secret = SensitiveBytes32::new(&mut hashed_seed);
 		seed.as_mut_bytes().zeroize();
 
-		// secret is automatically zeroized when it drops
-		WormholePair::generate_pair_from_secret(secret)
+		// Lend the secret rather than moving it (security review): a
+		// by-value argument copies the wrapper into the callee's frame and
+		// leaves this local's slot dead but never dropped, beyond
+		// `ZeroizeOnDrop`. The callee swaps the secret into the returned
+		// pair, so `secret` holds zeros when this frame drops (pinned by the
+		// release-mode `wormhole_stack_zeroization` probe).
+		WormholePair::generate_pair_from_secret(&mut secret)
 	}
 
-	/// Verifies whether the given raw secret generates the specified wormhole address.
-	///
-	/// # Arguments
-	/// * `address` - The expected wormhole address.
-	/// * `secret` - Raw secret to verify.
-	///
-	/// # Returns
-	/// `true` if the address matches the derived one, `false` otherwise.
-	pub fn verify(address: [u8; 32], secret: SensitiveBytes32) -> bool {
-		let generated_address = Self::generate_pair_from_secret(secret).address;
-		// Note: secret is automatically zeroized when the SensitiveBytes32 wrapper drops
-		generated_address == address
-	}
+	// There is deliberately no `verify(address, secret)` helper (security
+	// review): it took the secret by value (a move that leaves a dead,
+	// never-dropped stack copy of the wrapper) and no consumer used it —
+	// verification is re-derivation plus an address comparison, which
+	// callers that hold the secret can do directly.
 
 	/// Internal function that generates a `WormholePair` from a given secret.
 	///
@@ -134,10 +132,15 @@ impl WormholePair {
 	/// to derive the wormhole address.
 	///
 	/// # Security Note
-	/// This function takes ownership of the secret for security (move semantics).
-	/// The secret parameter is zeroized before returning.
-	fn generate_pair_from_secret(secret: SensitiveBytes32) -> WormholePair {
-		let mut secret_bytes = secret.into_bytes();
+	/// The secret never leaves its [`SensitiveBytes32`] wrapper (security
+	/// review): it is borrowed for the felt encoding and then *swapped* into
+	/// the returned pair, leaving the caller's wrapper zeroed. The previous
+	/// shape — take the wrapper by value, unwrap it with `into_bytes`, and
+	/// re-wrap into a named `result` — left three dead stack copies of the
+	/// secret (the moved-from parameter, the extracted plain array's source,
+	/// and the moved-from `result`), all beyond `ZeroizeOnDrop`'s reach. The
+	/// release-mode `wormhole_stack_zeroization` probe pins the fixed shape.
+	fn generate_pair_from_secret(secret: &mut SensitiveBytes32) -> WormholePair {
 		let salt_felt = string_to_felts(ADDRESS_SALT);
 		// Encode the 32-byte secret as 4 felts via the 8-bytes/felt `bytes_to_digest_lossy`.
 		// This encoding is non-injective (limbs ≥ the Goldilocks prime are reduced),
@@ -145,7 +148,7 @@ impl WormholePair {
 		// felt-tuple, and a collision would only alias the holder's own secret —
 		// it cannot forge another user's address without their secret. The same
 		// encoding is used when proving, so derivation stays consistent.
-		let mut secret_felt = bytes_to_digest_lossy(&secret_bytes);
+		let mut secret_felt = bytes_to_digest_lossy(secret.as_bytes());
 		// Exact capacity: growing the vector after the secret felts are in it
 		// would reallocate and free a block still holding the secret.
 		let mut preimage_felts = Vec::with_capacity(salt_felt.len() + secret_felt.len());
@@ -154,22 +157,21 @@ impl WormholePair {
 		let inner_hash = hash_to_bytes(&preimage_felts);
 		let second_hash = hash_twice(&preimage_felts);
 
-		// Move the secret into the move-only, self-zeroizing wrapper.
-		// `SensitiveBytes32::new` copies the bytes into the wrapper and zeroizes
-		// `secret_bytes` in place, so no separate scrub of it is needed.
-		let result = WormholePair {
-			address: second_hash,
-			first_hash: inner_hash,
-			secret: SensitiveBytes32::new(&mut secret_bytes),
-		};
-
 		// Wipe the felt-encoded copies of the secret before their backing
 		// memory is released: `clear()`/drop alone would hand the allocator a
 		// block that still contains the secret limbs.
 		zeroize_felts(&mut secret_felt);
 		zeroize_felts(&mut preimage_felts);
 
-		result
+		// Tail construction, with the secret swapped straight from the
+		// caller's wrapper into the pair: no named local holds the pair (a
+		// later return would leave a moved-from copy), and the caller's
+		// wrapper is left zeroed rather than dead-with-plaintext.
+		WormholePair {
+			address: second_hash,
+			first_hash: inner_hash,
+			secret: core::mem::replace(secret, SensitiveBytes32::zeroed()),
+		}
 	}
 }
 
@@ -185,7 +187,7 @@ mod tests {
 		let mut secret = [42u8; 32];
 
 		// Act
-		let pair = WormholePair::generate_pair_from_secret((&mut secret).into());
+		let pair = WormholePair::generate_pair_from_secret(&mut (&mut secret).into());
 
 		// Assert secret was zeroized and pair.secret was not zeroized
 		assert_eq!(secret, [0u8; 32]);
@@ -198,36 +200,24 @@ mod tests {
 
 		// Verify determinism
 		let mut secret2 = [42u8; 32];
-		let pair2 = WormholePair::generate_pair_from_secret((&mut secret2).into());
+		let pair2 = WormholePair::generate_pair_from_secret(&mut (&mut secret2).into());
 		assert_eq!(pair.address, pair2.address);
 	}
 
+	/// Verification is re-derivation: the same secret must reproduce the
+	/// address, and a different secret must not.
 	#[test]
-	fn test_verify_valid_secret() {
-		// Arrange
+	fn test_rederivation_verifies_secret() {
 		let mut secret = [1u8; 32];
-		let pair = WormholePair::generate_pair_from_secret((&mut secret).into());
+		let pair = WormholePair::generate_pair_from_secret(&mut (&mut secret).into());
 
-		// Act
-		let mut secret_for_verify = [1u8; 32];
-		let result = WormholePair::verify(pair.address, (&mut secret_for_verify).into());
+		let mut same_secret = [1u8; 32];
+		let rederived = WormholePair::generate_pair_from_secret(&mut (&mut same_secret).into());
+		assert_eq!(pair.address, rederived.address);
 
-		// Assert
-		assert!(result);
-	}
-
-	#[test]
-	fn test_verify_invalid_secret() {
-		// Arrange
-		let mut secret = [1u8; 32];
 		let mut wrong_secret = [2u8; 32];
-		let pair = WormholePair::generate_pair_from_secret((&mut secret).into());
-
-		// Act
-		let result = WormholePair::verify(pair.address, (&mut wrong_secret).into());
-
-		// Assert
-		assert!(!result);
+		let mismatched = WormholePair::generate_pair_from_secret(&mut (&mut wrong_secret).into());
+		assert_ne!(pair.address, mismatched.address);
 	}
 
 	#[test]
@@ -238,20 +228,22 @@ mod tests {
 
 		// Act - Generate the pair
 		let mut secret_copy = secret;
-		let pair = WormholePair::generate_pair_from_secret((&mut secret_copy).into());
+		let pair = WormholePair::generate_pair_from_secret(&mut (&mut secret_copy).into());
 
 		// Assert
 		// 1. Verify that the secret is stored correctly
 		assert_eq!(pair.secret.as_bytes(), &secret);
 
-		// 2. Verify that the derived address is consistent with our verification method
+		// 2. Verify that re-deriving from the same secret reproduces the address
 		let mut secret_for_verify = secret;
-		assert!(WormholePair::verify(pair.address, (&mut secret_for_verify).into()));
+		let rederived =
+			WormholePair::generate_pair_from_secret(&mut (&mut secret_for_verify).into());
+		assert_eq!(pair.address, rederived.address);
 
 		// 3. Verify that even a small change in the secret produces a different address
 		let mut altered_secret = secret;
 		altered_secret[0] ^= 1; // Flip one bit in the first byte
-		let altered_pair = WormholePair::generate_pair_from_secret((&mut altered_secret).into());
+		let altered_pair = WormholePair::generate_pair_from_secret(&mut (&mut altered_secret).into());
 		assert_ne!(pair.address, altered_pair.address);
 
 		// 4. Verify that the process uses the salt
@@ -276,8 +268,8 @@ mod tests {
 		let mut secret2 = [6u8; 32];
 
 		// Act
-		let pair1 = WormholePair::generate_pair_from_secret((&mut secret1).into());
-		let pair2 = WormholePair::generate_pair_from_secret((&mut secret2).into());
+		let pair1 = WormholePair::generate_pair_from_secret(&mut (&mut secret1).into());
+		let pair2 = WormholePair::generate_pair_from_secret(&mut (&mut secret2).into());
 
 		// Assert
 		assert_ne!(pair1.address, pair2.address);
@@ -295,10 +287,11 @@ mod tests {
 		// Address should not be zero
 		assert_ne!(pair.address, [0u8; 32]);
 
-		// Verification should work with the generated secret
+		// Re-deriving from the stored secret must reproduce the address
 		let mut secret_for_verify = *pair.secret.as_bytes();
-		let verification = WormholePair::verify(pair.address, (&mut secret_for_verify).into());
-		assert!(verification);
+		let rederived =
+			WormholePair::generate_pair_from_secret(&mut (&mut secret_for_verify).into());
+		assert_eq!(pair.address, rederived.address);
 	}
 
 	/// Pins the semantics of the constant-time `PartialEq` (security review):
@@ -330,8 +323,8 @@ mod tests {
 		// Pairs derived from the same secret compare equal end-to-end.
 		let mut s1 = [42u8; 32];
 		let mut s2 = [42u8; 32];
-		let p1 = WormholePair::generate_pair_from_secret((&mut s1).into());
-		let p2 = WormholePair::generate_pair_from_secret((&mut s2).into());
+		let p1 = WormholePair::generate_pair_from_secret(&mut (&mut s1).into());
+		let p2 = WormholePair::generate_pair_from_secret(&mut (&mut s2).into());
 		assert!(p1 == p2);
 	}
 
@@ -346,7 +339,7 @@ mod tests {
 
 		// Generate a pair normally (with salt)
 		let mut secret_copy = secret;
-		let pair_with_salt = WormholePair::generate_pair_from_secret((&mut secret_copy).into());
+		let pair_with_salt = WormholePair::generate_pair_from_secret(&mut (&mut secret_copy).into());
 
 		// Simulate address generation without salt or with different salt
 		let different_salt = b"diffrent";

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -12,8 +12,8 @@
 //!
 //! - You can:
 //!     - Generate new wormhole identities using random entropy (`generate_new`).
-//!     - Verify a secret against an address by re-deriving (derivation is deterministic, so
-//!       re-run `generate_new` with the same input and compare the resulting `address`).
+//!     - Verify a secret against an address by re-deriving (derivation is deterministic, so re-run
+//!       `generate_new` with the same input and compare the resulting `address`).
 //!
 //! The hashing strategy ensures determinism while hiding the original secret.
 //!

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -33,7 +33,7 @@ use qp_poseidon_core::{
 };
 extern crate alloc;
 use alloc::vec::Vec;
-use qp_rusty_crystals_dilithium::SensitiveBytes32;
+use qp_rusty_crystals_dilithium::{ct_eq_32, SensitiveBytes32};
 use zeroize::Zeroize;
 
 /// Salt used when deriving wormhole addresses.
@@ -77,15 +77,21 @@ pub struct WormholePair {
 }
 
 // `secret` is a `SensitiveBytes32` (which is not `PartialEq`), so equality is
-// implemented by hand over the raw bytes to preserve the previous derived
-// semantics. The address alone determines identity; the secret is compared for
-// completeness. `SensitiveBytes32` already zeroizes itself on drop, so no
-// `ZeroizeOnDrop` derive is needed on `WormholePair`.
+// implemented by hand. Every field is compared in constant time and the
+// results are combined with non-short-circuiting `&` (security review): `==`
+// on the raw bytes may bail out at the first differing byte, and short-
+// circuiting between fields skips later comparisons entirely, so comparison
+// time would depend on the length of the matching prefix — a timing oracle
+// against the secret. `first_hash` gets the same treatment as `secret`: the
+// address is the double hash of the same preimage, so the single hash is a
+// reveal value, not public data. `SensitiveBytes32` already zeroizes itself
+// on drop, so no `ZeroizeOnDrop` derive is needed on `WormholePair`.
 impl PartialEq for WormholePair {
 	fn eq(&self, other: &Self) -> bool {
-		self.address == other.address &&
-			self.first_hash == other.first_hash &&
-			self.secret.as_bytes() == other.secret.as_bytes()
+		let address_eq = ct_eq_32(&self.address, &other.address);
+		let first_hash_eq = ct_eq_32(&self.first_hash, &other.first_hash);
+		let secret_eq = self.secret.ct_eq(&other.secret);
+		address_eq & first_hash_eq & secret_eq
 	}
 }
 
@@ -293,6 +299,40 @@ mod tests {
 		let mut secret_for_verify = *pair.secret.as_bytes();
 		let verification = WormholePair::verify(pair.address, (&mut secret_for_verify).into());
 		assert!(verification);
+	}
+
+	/// Pins the semantics of the constant-time `PartialEq` (security review):
+	/// equality must hold exactly when all three fields match, including a
+	/// difference in *any single* field — the non-short-circuiting fold must
+	/// not drop any comparison.
+	#[test]
+	fn test_pair_equality_covers_every_field() {
+		let make_pair = |address: [u8; 32], first_hash: [u8; 32], secret: [u8; 32]| {
+			let mut secret = secret;
+			WormholePair { address, first_hash, secret: SensitiveBytes32::new(&mut secret) }
+		};
+
+		// `WormholePair` has no `Debug` (it would print the secret), so plain
+		// `assert!` is used instead of `assert_eq!`/`assert_ne!`.
+		let base = make_pair([1u8; 32], [2u8; 32], [3u8; 32]);
+		assert!(base == make_pair([1u8; 32], [2u8; 32], [3u8; 32]));
+
+		assert!(base != make_pair([9u8; 32], [2u8; 32], [3u8; 32]), "address ignored by eq");
+		assert!(base != make_pair([1u8; 32], [9u8; 32], [3u8; 32]), "first_hash ignored by eq");
+		assert!(base != make_pair([1u8; 32], [2u8; 32], [9u8; 32]), "secret ignored by eq");
+
+		// A difference in only the last byte of the secret must be detected:
+		// a truncated comparison would miss it.
+		let mut tail_diff = [3u8; 32];
+		tail_diff[31] ^= 1;
+		assert!(base != make_pair([1u8; 32], [2u8; 32], tail_diff));
+
+		// Pairs derived from the same secret compare equal end-to-end.
+		let mut s1 = [42u8; 32];
+		let mut s2 = [42u8; 32];
+		let p1 = WormholePair::generate_pair_from_secret((&mut s1).into());
+		let p2 = WormholePair::generate_pair_from_secret((&mut s2).into());
+		assert!(p1 == p2);
 	}
 
 	#[test]

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -125,14 +125,15 @@ impl WormholePair {
 	}
 
 	/// The deterministic Poseidon-derived address (public data).
-	pub fn address(&self) -> [u8; 32] {
-		self.address
+	pub fn address(&self) -> &[u8; 32] {
+		&self.address
 	}
 
 	/// The single hash of the salted preimage. This is a reveal value used
-	/// when proving, not public data; disclose it deliberately.
-	pub fn first_hash(&self) -> [u8; 32] {
-		self.first_hash
+	/// when proving, not public data — borrowed so a copy is an explicit
+	/// `*` at the call site.
+	pub fn first_hash(&self) -> &[u8; 32] {
+		&self.first_hash
 	}
 
 	/// Borrow the secret; the pair keeps ownership (and wipes it on drop).

--- a/hdwallet/src/wormhole.rs
+++ b/hdwallet/src/wormhole.rs
@@ -59,22 +59,26 @@ fn zeroize_felts(felts: &mut [Goldilocks]) {
 
 /// A struct representing a wormhole identity pair: address + secret.
 ///
-/// `Clone` is intentionally not derived because `secret` is sensitive. The
-/// secret is stored as a [`SensitiveBytes32`] wrapper rather than a bare
-/// `[u8; 32]`: a plain array is `Copy`, so `pair.secret` could silently
-/// duplicate the secret (leaving copies in stack frames, logs, or crash dumps)
-/// that the pair's own drop-time zeroization can never scrub. The wrapper is
-/// move-only and zeroizes on drop, so any duplication must be explicit
-/// (`pair.secret.as_bytes()`), making it visible at the call site. Prefer
+/// Fields are private (security review) so `address` and `first_hash` are
+/// always the values derived from `secret` — a struct literal or field
+/// assignment can't assemble an inconsistent tuple. Read via the accessors.
+///
+/// `Clone` is intentionally not derived because the secret is sensitive. It
+/// is stored as a [`SensitiveBytes32`] wrapper rather than a bare `[u8; 32]`:
+/// a plain array is `Copy`, so it could silently duplicate the secret
+/// (leaving copies in stack frames, logs, or crash dumps) that the pair's
+/// own drop-time zeroization can never scrub. The wrapper is move-only and
+/// zeroizes on drop, so any duplication must be explicit
+/// (`pair.secret().as_bytes()`), making it visible at the call site. Prefer
 /// passing `&WormholePair` instead.
 pub struct WormholePair {
 	/// Deterministic Poseidon-derived address.
-	pub address: [u8; 32],
+	address: [u8; 32],
 	/// First hash of secret
-	pub first_hash: [u8; 32],
+	first_hash: [u8; 32],
 	/// The hashed secret used to generate this address. Move-only and zeroized
-	/// on drop; read the raw bytes via `secret.as_bytes()`.
-	pub secret: SensitiveBytes32,
+	/// on drop; read the raw bytes via `secret().as_bytes()`.
+	secret: SensitiveBytes32,
 }
 
 // `secret` is a `SensitiveBytes32` (which is not `PartialEq`), so equality is
@@ -118,6 +122,22 @@ impl WormholePair {
 		// pair, so `secret` holds zeros when this frame drops (pinned by the
 		// release-mode `wormhole_stack_zeroization` probe).
 		WormholePair::generate_pair_from_secret(&mut secret)
+	}
+
+	/// The deterministic Poseidon-derived address (public data).
+	pub fn address(&self) -> [u8; 32] {
+		self.address
+	}
+
+	/// The single hash of the salted preimage. This is a reveal value used
+	/// when proving, not public data; disclose it deliberately.
+	pub fn first_hash(&self) -> [u8; 32] {
+		self.first_hash
+	}
+
+	/// Borrow the secret; the pair keeps ownership (and wipes it on drop).
+	pub fn secret(&self) -> &SensitiveBytes32 {
+		&self.secret
 	}
 
 	// There is deliberately no `verify(address, secret)` helper (security
@@ -243,7 +263,8 @@ mod tests {
 		// 3. Verify that even a small change in the secret produces a different address
 		let mut altered_secret = secret;
 		altered_secret[0] ^= 1; // Flip one bit in the first byte
-		let altered_pair = WormholePair::generate_pair_from_secret(&mut (&mut altered_secret).into());
+		let altered_pair =
+			WormholePair::generate_pair_from_secret(&mut (&mut altered_secret).into());
 		assert_ne!(pair.address, altered_pair.address);
 
 		// 4. Verify that the process uses the salt
@@ -339,7 +360,8 @@ mod tests {
 
 		// Generate a pair normally (with salt)
 		let mut secret_copy = secret;
-		let pair_with_salt = WormholePair::generate_pair_from_secret(&mut (&mut secret_copy).into());
+		let pair_with_salt =
+			WormholePair::generate_pair_from_secret(&mut (&mut secret_copy).into());
 
 		// Simulate address generation without salt or with different salt
 		let different_salt = b"diffrent";

--- a/hdwallet/tests/bip39_stack_zeroization.rs
+++ b/hdwallet/tests/bip39_stack_zeroization.rs
@@ -20,42 +20,14 @@
 //! source-level fix can wipe.
 #![cfg(not(debug_assertions))]
 
-use std::alloc::{alloc, dealloc, Layout};
-
 use bip39::Language;
 use qp_rusty_crystals_hdwallet::{
 	generate_mnemonic, mnemonic_to_seed, SensitiveBytes32, SensitiveBytes64,
 };
+use qp_rusty_crystals_test_utils::probe_stack_for;
 
-const PAINT: u8 = 0xAA;
 // 4 MiB: comfortably above what PBKDF2 seed stretching needs.
 const STACK_BYTES: usize = 4 * 1024 * 1024;
-const ALIGN: usize = 4096;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| w == &pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
 
 /// The in-memory image of `Mnemonic`'s `words: [u16; 24]` buffer for `phrase`:
 /// each word's index into the English word list, in native endianness.
@@ -84,7 +56,7 @@ fn mnemonic_word_indices_never_survive_on_the_stack() {
 	// Sanity: the technique detects an unwiped Mnemonic. A closure that
 	// parses one and skips its destructor must be seen.
 	assert!(
-		probe_stack_for(&pattern, || {
+		probe_stack_for(STACK_BYTES, &pattern, || {
 			let mnemonic = bip39::Mnemonic::parse_in_normalized(Language::English, PHRASE).unwrap();
 			core::mem::forget(mnemonic);
 		}),
@@ -94,7 +66,7 @@ fn mnemonic_word_indices_never_survive_on_the_stack() {
 	// Scenario A: seed stretching. The Mnemonic parsed inside is dropped
 	// after PBKDF2; its word-index buffer must not survive.
 	let phrase = PHRASE.to_string();
-	let seed_stretch_leaked = probe_stack_for(&pattern, move || {
+	let seed_stretch_leaked = probe_stack_for(STACK_BYTES, &pattern, move || {
 		let mut seed = SensitiveBytes64::zeroed();
 		mnemonic_to_seed(phrase, None, &mut seed).unwrap();
 		core::hint::black_box(&seed);
@@ -107,7 +79,7 @@ fn mnemonic_word_indices_never_survive_on_the_stack() {
 	let entropy = [0x27u8; 32];
 	let generated = generate_mnemonic(SensitiveBytes32::from(&mut { entropy })).unwrap();
 	let generated_pattern = word_index_pattern(&generated);
-	let generation_leaked = probe_stack_for(&generated_pattern, || {
+	let generation_leaked = probe_stack_for(STACK_BYTES, &generated_pattern, || {
 		let phrase = generate_mnemonic(SensitiveBytes32::from(&mut { entropy })).unwrap();
 		core::hint::black_box(&phrase);
 	});
@@ -143,7 +115,7 @@ fn seed_produced_by_mnemonic_to_seed_wipes_itself_on_drop() {
 	let expected = *expected_holder.as_bytes();
 
 	let phrase = PHRASE.to_string();
-	let leaked = probe_stack_for(&expected[..], move || {
+	let leaked = probe_stack_for(STACK_BYTES, &expected[..], move || {
 		let mut seed = SensitiveBytes64::zeroed();
 		mnemonic_to_seed(phrase, None, &mut seed).unwrap();
 		core::hint::black_box(&seed);

--- a/hdwallet/tests/entropy_stack_zeroization.rs
+++ b/hdwallet/tests/entropy_stack_zeroization.rs
@@ -18,41 +18,13 @@
 //! only compiled for optimized builds (`cargo test --release`).
 #![cfg(all(not(debug_assertions), feature = "ml-dsa-87"))]
 
-use std::alloc::{alloc, dealloc, Layout};
-
 use qp_rusty_crystals_hdwallet::{
 	derive_key_from_seed, generate_wormhole_from_seed, hderive::ExtendedPrivKey, SensitiveBytes64,
 };
+use qp_rusty_crystals_test_utils::probe_stack_for;
 
-const PAINT: u8 = 0xAA;
 // 4 MiB: comfortably above what ML-DSA-87 key generation needs.
 const STACK_BYTES: usize = 4 * 1024 * 1024;
-const ALIGN: usize = 4096;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| w == &pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
 
 /// Distinctive 64-byte seed (ASCII, so a match cannot come from byte-swapped
 /// words inside a hash message schedule — only from a verbatim copy).
@@ -79,7 +51,7 @@ fn derived_entropy_never_survives_key_generation() {
 
 	// Sanity: the technique detects an unwiped copy.
 	assert!(
-		probe_stack_for(&entropy, || {
+		probe_stack_for(STACK_BYTES, &entropy, || {
 			let leaked: [u8; 32] = entropy;
 			core::hint::black_box(&leaked);
 		}),
@@ -90,7 +62,7 @@ fn derived_entropy_never_survives_key_generation() {
 	// keypair has been produced and dropped, no copy of the entropy may
 	// remain anywhere on the stack.
 	let holder = seed_holder();
-	let leaked = probe_stack_for(&entropy, move || {
+	let leaked = probe_stack_for(STACK_BYTES, &entropy, move || {
 		let keypair = derive_key_from_seed(holder, PATH).unwrap();
 		core::hint::black_box(&keypair);
 	});
@@ -111,7 +83,7 @@ fn derived_entropy_never_survives_wormhole_generation() {
 	let entropy = reference_entropy(WORMHOLE_PATH);
 
 	let holder = seed_holder();
-	let leaked = probe_stack_for(&entropy, move || {
+	let leaked = probe_stack_for(STACK_BYTES, &entropy, move || {
 		let pair = generate_wormhole_from_seed(holder, WORMHOLE_PATH).unwrap();
 		core::hint::black_box(&pair);
 	});

--- a/hdwallet/tests/hderive_stack_zeroization.rs
+++ b/hdwallet/tests/hderive_stack_zeroization.rs
@@ -26,16 +26,13 @@
 //! source-level fix can wipe.
 #![cfg(not(debug_assertions))]
 
-use std::alloc::{alloc, dealloc, Layout};
-
 use hmac::{Hmac, Mac};
 use qp_rusty_crystals_hdwallet::hderive::{ChildNumber, ExtendedPrivKey};
+use qp_rusty_crystals_test_utils::probe_stack_for_named;
 use sha2::Sha512;
 
-const PAINT: u8 = 0xAA;
 // 4 MiB: comfortably above what a single HMAC-SHA512 derivation step needs.
 const STACK_BYTES: usize = 4 * 1024 * 1024;
-const ALIGN: usize = 4096;
 
 /// HMAC ipad/opad constants (RFC 2104). `Hmac::new_from_slice` leaves
 /// `key ^ OPAD` in its dropped key-block local, so a scan for these XOR
@@ -43,36 +40,6 @@ const ALIGN: usize = 4096;
 /// never appears verbatim.
 const IPAD: u8 = 0x36;
 const OPAD: u8 = 0x5c;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for each
-/// named pattern and return the names of those found.
-fn probe_stack_for<F: FnOnce()>(patterns: &[(&str, [u8; 32])], f: F) -> Vec<String> {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let mut found = Vec::new();
-		for (name, pattern) in patterns {
-			let offsets: Vec<usize> = region
-				.windows(pattern.len())
-				.enumerate()
-				.filter(|(_, w)| w == pattern)
-				.map(|(i, _)| i)
-				.collect();
-			if !offsets.is_empty() {
-				eprintln!("probe: pattern {name:?} found at offsets {offsets:?}");
-				found.push(name.to_string());
-			}
-		}
-		dealloc(base, layout);
-		found
-	}
-}
 
 /// Distinctive 64-byte seed; each 32-byte half is a scan pattern. ASCII, so a
 /// match cannot come from the byte-swapped u64 words inside the SHA-512
@@ -103,12 +70,10 @@ fn hderive_leaves_no_secret_material_on_the_stack() {
 
 	// Sanity: the technique detects an unwiped copy. A closure that
 	// deliberately leaves the seed in a dead stack frame must be seen.
-	let seed_patterns = [
-		("seed[0..32]", SEED[..32].try_into().unwrap()),
-		("seed[32..64]", SEED[32..].try_into().unwrap()),
-	];
+	let seed_patterns: [(&str, &[u8]); 2] =
+		[("seed[0..32]", &SEED[..32]), ("seed[32..64]", &SEED[32..])];
 	assert!(
-		!probe_stack_for(&seed_patterns, || {
+		!probe_stack_for_named(STACK_BYTES, &seed_patterns, || {
 			let leaked: [u8; 64] = SEED;
 			core::hint::black_box(&leaked);
 		})
@@ -119,7 +84,7 @@ fn hderive_leaves_no_secret_material_on_the_stack() {
 	// Scenario A: master derivation. The seed is fed into the HMAC step and
 	// must not survive anywhere on the stack once the derived key (which is
 	// self-zeroizing) has been dropped.
-	let derive_leaks = probe_stack_for(&seed_patterns, || {
+	let derive_leaks = probe_stack_for_named(STACK_BYTES, &seed_patterns, || {
 		let mut key = ExtendedPrivKey::zeroed();
 		ExtendedPrivKey::derive(&SEED, "m", &mut key).unwrap();
 		core::hint::black_box(&key);
@@ -128,14 +93,16 @@ fn hderive_leaves_no_secret_material_on_the_stack() {
 	// Scenario B: child derivation. The parent secret key is the HMAC message
 	// and the parent chain code is the HMAC key; neither the raw values nor
 	// their ipad/opad-XORed key blocks may survive on the stack.
-	let child_patterns = [
-		("parent secret_key", master_secret),
-		("parent chain_code", master_chain),
-		("parent chain_code ^ ipad", xor_pattern(&master_chain, IPAD)),
-		("parent chain_code ^ opad", xor_pattern(&master_chain, OPAD)),
+	let chain_ipad = xor_pattern(&master_chain, IPAD);
+	let chain_opad = xor_pattern(&master_chain, OPAD);
+	let child_patterns: [(&str, &[u8]); 4] = [
+		("parent secret_key", &master_secret),
+		("parent chain_code", &master_chain),
+		("parent chain_code ^ ipad", &chain_ipad),
+		("parent chain_code ^ opad", &chain_opad),
 	];
 	let child_number: ChildNumber = "0'".parse().unwrap();
-	let child_leaks = probe_stack_for(&child_patterns, || {
+	let child_leaks = probe_stack_for_named(STACK_BYTES, &child_patterns, || {
 		let mut key = ExtendedPrivKey::zeroed();
 		ExtendedPrivKey::derive(&SEED, "m", &mut key).unwrap();
 		key.child_in_place(child_number);
@@ -173,12 +140,10 @@ fn derive_and_secret_access_leave_no_unwiped_copies() {
 	let mut reference: Hmac<Sha512> = Hmac::new_from_slice(b"Dilithium seed").unwrap();
 	reference.update(&SEED);
 	let reference = reference.finalize().into_bytes();
-	let patterns = [
-		("master secret_key", reference[..32].try_into().unwrap()),
-		("master chain_code", reference[32..].try_into().unwrap()),
-	];
+	let patterns: [(&str, &[u8]); 2] =
+		[("master secret_key", &reference[..32]), ("master chain_code", &reference[32..])];
 
-	let leaks = probe_stack_for(&patterns, || {
+	let leaks = probe_stack_for_named(STACK_BYTES, &patterns, || {
 		let mut key = ExtendedPrivKey::zeroed();
 		ExtendedPrivKey::derive(&SEED, "m", &mut key).unwrap();
 		let secret = key.secret();

--- a/hdwallet/tests/wormhole_stack_zeroization.rs
+++ b/hdwallet/tests/wormhole_stack_zeroization.rs
@@ -25,39 +25,11 @@
 //! only compiled for optimized builds (`cargo test --release`).
 #![cfg(all(not(debug_assertions), feature = "ml-dsa-87"))]
 
-use std::alloc::{alloc, dealloc, Layout};
-
 use qp_rusty_crystals_hdwallet::{SensitiveBytes32, WormholePair};
+use qp_rusty_crystals_test_utils::probe_stack_for;
 
-const PAINT: u8 = 0xAA;
 // The wormhole path only computes Poseidon hashes; 1 MiB is ample.
 const STACK_BYTES: usize = 1024 * 1024;
-const ALIGN: usize = 4096;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| w == &pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
 
 /// Distinctive ASCII seed so a match can only come from a verbatim copy.
 const SEED: [u8; 32] = *b"wormhole-probe-seed-0123456789AB";
@@ -83,7 +55,7 @@ fn wormhole_secret_never_survives_pair_drop() {
 
 	// Sanity: the technique detects an unwiped copy.
 	assert!(
-		probe_stack_for(&secret, || {
+		probe_stack_for(STACK_BYTES, &secret, || {
 			let leaked: [u8; 32] = secret;
 			core::hint::black_box(&leaked);
 		}),
@@ -92,7 +64,7 @@ fn wormhole_secret_never_survives_pair_drop() {
 
 	// Generate a pair and drop it inside the probed region. The pair's own
 	// wrapper zeroizes the live secret on drop; nothing else may retain it.
-	let leaked = probe_stack_for(&secret, || {
+	let leaked = probe_stack_for(STACK_BYTES, &secret, || {
 		let mut seed = SensitiveBytes32::zeroed();
 		seed.as_mut_bytes().copy_from_slice(&SEED);
 		let pair = WormholePair::generate_new(&mut seed);

--- a/hdwallet/tests/wormhole_stack_zeroization.rs
+++ b/hdwallet/tests/wormhole_stack_zeroization.rs
@@ -74,7 +74,7 @@ fn seed_holder() -> SensitiveBytes32 {
 fn reference_secret() -> [u8; 32] {
 	let mut seed = seed_holder();
 	let pair = WormholePair::generate_new(&mut seed);
-	*pair.secret.as_bytes()
+	*pair.secret().as_bytes()
 }
 
 #[test]

--- a/hdwallet/tests/wormhole_stack_zeroization.rs
+++ b/hdwallet/tests/wormhole_stack_zeroization.rs
@@ -1,0 +1,106 @@
+//! Regression test (security review): the 32-byte wormhole secret must not
+//! survive in dead stack memory after the `WormholePair` that owns it is
+//! dropped.
+//!
+//! The secret previously crossed several function boundaries by value:
+//! `generate_new`'s local wrapper moved into `generate_pair_from_secret`'s
+//! parameter, the parameter moved into `SensitiveBytes32::into_bytes(self)`,
+//! and the finished pair moved from a named `result` local to the return
+//! slot. Rust moves are copies that leave the moved-from stack slot dead but
+//! never dropped, so `ZeroizeOnDrop` could not wipe those slots — and
+//! `into_bytes` additionally handed back a plain `Copy` array with no
+//! erasure obligation at all. The fixed pipeline keeps the secret inside the
+//! wrapper (no extraction API), lends it to the derivation by reference, and
+//! swaps it into the tail-constructed pair, so every dead slot holds zeros.
+//!
+//! This test also depends on `qp-poseidon-core >= 3.0.3` (its own
+//! `tests/stack_zeroization.rs`): the secret *is* a Poseidon digest, and
+//! before that version the hasher's self-consuming finalize chain left dead
+//! copies of it in the sponge frames, out of this crate's reach.
+//!
+//! Detection uses the same painted-stack technique as the other
+//! `*_stack_zeroization` tests; see `hderive_stack_zeroization.rs`.
+//!
+//! The assertion is about codegen (which temporaries get wiped), so it is
+//! only compiled for optimized builds (`cargo test --release`).
+#![cfg(all(not(debug_assertions), feature = "ml-dsa-87"))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+use qp_rusty_crystals_hdwallet::{SensitiveBytes32, WormholePair};
+
+const PAINT: u8 = 0xAA;
+// The wormhole path only computes Poseidon hashes; 1 MiB is ample.
+const STACK_BYTES: usize = 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == &pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// Distinctive ASCII seed so a match can only come from a verbatim copy.
+const SEED: [u8; 32] = *b"wormhole-probe-seed-0123456789AB";
+
+fn seed_holder() -> SensitiveBytes32 {
+	let mut seed = SensitiveBytes32::zeroed();
+	seed.as_mut_bytes().copy_from_slice(&SEED);
+	seed
+}
+
+/// The wormhole secret for SEED, computed outside any probed region.
+/// Derivation is deterministic, so a second run inside the probe produces
+/// the same secret bytes.
+fn reference_secret() -> [u8; 32] {
+	let mut seed = seed_holder();
+	let pair = WormholePair::generate_new(&mut seed);
+	*pair.secret.as_bytes()
+}
+
+#[test]
+fn wormhole_secret_never_survives_pair_drop() {
+	let secret = reference_secret();
+
+	// Sanity: the technique detects an unwiped copy.
+	assert!(
+		probe_stack_for(&secret, || {
+			let leaked: [u8; 32] = secret;
+			core::hint::black_box(&leaked);
+		}),
+		"probe self-check: a deliberately leaked secret copy was not detected"
+	);
+
+	// Generate a pair and drop it inside the probed region. The pair's own
+	// wrapper zeroizes the live secret on drop; nothing else may retain it.
+	let leaked = probe_stack_for(&secret, || {
+		let mut seed = SensitiveBytes32::zeroed();
+		seed.as_mut_bytes().copy_from_slice(&SEED);
+		let pair = WormholePair::generate_new(&mut seed);
+		core::hint::black_box(&pair);
+	});
+	assert!(
+		!leaked,
+		"the wormhole secret survived in dead stack memory after the pair was \
+		 dropped; it alone derives (and verifies against) the wormhole address"
+	);
+}

--- a/hdwallet/tests/wormhole_stack_zeroization.rs
+++ b/hdwallet/tests/wormhole_stack_zeroization.rs
@@ -13,7 +13,7 @@
 //! wrapper (no extraction API), lends it to the derivation by reference, and
 //! swaps it into the tail-constructed pair, so every dead slot holds zeros.
 //!
-//! This test also depends on `qp-poseidon-core >= 3.0.3` (its own
+//! This test also depends on `qp-poseidon-core >= 3.1.0` (its own
 //! `tests/stack_zeroization.rs`): the secret *is* a Poseidon digest, and
 //! before that version the hasher's self-consuming finalize chain left dead
 //! copies of it in the sponge frames, out of this crate's reach.

--- a/hdwallet/tests/wormhole_zeroization.rs
+++ b/hdwallet/tests/wormhole_zeroization.rs
@@ -14,14 +14,23 @@
 //! concurrent allocations can race the scanner.
 
 use core::sync::atomic::{AtomicBool, Ordering};
-use std::alloc::{GlobalAlloc, Layout, System};
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	sync::OnceLock,
+};
 
 use qp_rusty_crystals_hdwallet::wormhole::WormholePair;
 
-/// Distinctive 32-byte secret. Each 8-byte little-endian limb is below the
-/// Goldilocks prime (high byte is ASCII < 0x80), so `bytes_to_digest_lossy`
-/// stores the limbs verbatim and the felt buffer contains these exact bytes.
-const SECRET_PATTERN: [u8; 32] = *b"wormhole-heap-zeroize-pattern-32";
+/// Seed for `generate_new`. The scanned pattern is not the seed itself but
+/// the *derived* secret (`hash_bytes(seed)`): that is what the derivation
+/// felt-encodes into the heap-backed Poseidon preimage, and its 8-byte
+/// little-endian limbs are canonical field elements by construction, so
+/// `bytes_to_digest_lossy` stores them verbatim in the felt buffer.
+const SEED_PATTERN: [u8; 32] = *b"wormhole-heap-zeroize-pattern-32";
+
+/// The derived secret, learned from a reference run with the scanner off.
+/// Derivation is deterministic, so the probed run reproduces these bytes.
+static DERIVED_SECRET: OnceLock<[u8; 32]> = OnceLock::new();
 
 static SCANNING: AtomicBool = AtomicBool::new(false);
 static SECRET_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
@@ -34,10 +43,14 @@ unsafe impl GlobalAlloc for SecretScanningAllocator {
 	}
 
 	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-		if SCANNING.load(Ordering::SeqCst) && layout.size() >= SECRET_PATTERN.len() {
-			let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
-			if block.windows(SECRET_PATTERN.len()).any(|w| w == SECRET_PATTERN) {
-				SECRET_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+		if SCANNING.load(Ordering::SeqCst) {
+			if let Some(pattern) = DERIVED_SECRET.get() {
+				if layout.size() >= pattern.len() {
+					let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+					if block.windows(pattern.len()).any(|w| w == pattern) {
+						SECRET_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+					}
+				}
 			}
 		}
 		unsafe { System.dealloc(ptr, layout) }
@@ -49,10 +62,16 @@ static ALLOCATOR: SecretScanningAllocator = SecretScanningAllocator;
 
 #[test]
 fn wormhole_derivation_never_frees_heap_memory_containing_the_secret() {
-	let mut secret = SECRET_PATTERN;
+	// Reference run (scanner off) to learn the derived secret bytes.
+	let mut seed = SEED_PATTERN;
+	let reference = WormholePair::generate_new(&mut (&mut seed).into());
+	DERIVED_SECRET.set(*reference.secret.as_bytes()).expect("set once");
+	drop(reference);
 
+	let mut seed = SEED_PATTERN;
 	SCANNING.store(true, Ordering::SeqCst);
-	let pair = WormholePair::verify([0u8; 32], (&mut secret).into());
+	let pair = WormholePair::generate_new(&mut (&mut seed).into());
+	drop(pair);
 	SCANNING.store(false, Ordering::SeqCst);
 
 	assert!(
@@ -61,7 +80,4 @@ fn wormhole_derivation_never_frees_heap_memory_containing_the_secret() {
 		 (felt-encoded preimage); the secret grants control of the derived \
 		 address, so it must be zeroized before its memory is released"
 	);
-
-	// Sanity: the pattern secret does not verify against a zero address.
-	assert!(!pair);
 }

--- a/hdwallet/tests/wormhole_zeroization.rs
+++ b/hdwallet/tests/wormhole_zeroization.rs
@@ -65,7 +65,7 @@ fn wormhole_derivation_never_frees_heap_memory_containing_the_secret() {
 	// Reference run (scanner off) to learn the derived secret bytes.
 	let mut seed = SEED_PATTERN;
 	let reference = WormholePair::generate_new(&mut (&mut seed).into());
-	DERIVED_SECRET.set(*reference.secret.as_bytes()).expect("set once");
+	DERIVED_SECRET.set(*reference.secret().as_bytes()).expect("set once");
 	drop(reference);
 
 	let mut seed = SEED_PATTERN;

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "qp-rusty-crystals-test-utils"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Shared test helpers for painted-stack zeroization probes"
+
+[dependencies]
+psm = "=0.1.31"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,0 +1,52 @@
+//! Shared helpers for painted-stack zeroization probes.
+//!
+//! Run an operation on a sentinel-painted stack buffer via `psm::on_stack`,
+//! then scan the buffer for secret patterns. Used by the
+//! `*_stack_zeroization` integration tests across dilithium, hdwallet, and
+//! threshold. Unit-test probes that cannot take a `dev-dependency` keep a
+//! local copy.
+
+use std::alloc::{alloc, dealloc, Layout};
+
+const PAINT: u8 = 0xAA;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack of `stack_bytes`, then scan for
+/// `pattern`. Returns whether any match was found (and eprints offsets).
+pub fn probe_stack_for<F: FnOnce()>(stack_bytes: usize, pattern: &[u8], f: F) -> bool {
+	!probe_stack_for_named(stack_bytes, &[("pattern", pattern)], f).is_empty()
+}
+
+/// Like [`probe_stack_for`], but scans for several named patterns and returns
+/// the names of those found.
+pub fn probe_stack_for_named<F: FnOnce()>(
+	stack_bytes: usize,
+	patterns: &[(&str, &[u8])],
+	f: F,
+) -> Vec<String> {
+	let layout = Layout::from_size_align(stack_bytes, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, stack_bytes);
+
+		psm::on_stack(base, stack_bytes, f);
+
+		let region = std::slice::from_raw_parts(base, stack_bytes);
+		let mut found = Vec::new();
+		for (name, pattern) in patterns {
+			let offsets: Vec<usize> = region
+				.windows(pattern.len())
+				.enumerate()
+				.filter(|(_, w)| w == pattern)
+				.map(|(i, _)| i)
+				.collect();
+			if !offsets.is_empty() {
+				eprintln!("probe: pattern {name:?} found at offsets {offsets:?}");
+				found.push((*name).to_string());
+			}
+		}
+		dealloc(base, layout);
+		found
+	}
+}

--- a/threshold/Cargo.toml
+++ b/threshold/Cargo.toml
@@ -32,8 +32,10 @@ criterion = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
 rand = { workspace = true }
-# Painted-stack probe for the dealer stack-zeroization regression test.
+# Painted-stack probe for stack-zeroization regression tests (also used
+# directly by the unit-test probe in `derivation.rs`).
 psm = "=0.1.31"
+qp-rusty-crystals-test-utils = { workspace = true }
 
 [features]
 default = ["ml-dsa-87", "std"]

--- a/threshold/Cargo.toml
+++ b/threshold/Cargo.toml
@@ -32,6 +32,8 @@ criterion = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
 rand = { workspace = true }
+# Painted-stack probe for the dealer stack-zeroization regression test.
+psm = "=0.1.31"
 
 [features]
 default = ["ml-dsa-87", "std"]

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -279,7 +279,8 @@ mod tests {
 	/// contribution for any tweak. Painted-stack technique as in the
 	/// `*_stack_zeroization` integration tests; release-only because the
 	/// assertion is about codegen.
-	// Unsafe is required for the raw painted-stack buffer; scoped to this
+	// Local probe copy: unit tests cannot take a `dev-dependency`, so this
+	// cannot call `qp_rusty_crystals_test_utils`. Unsafe is scoped to this
 	// test only (the crate otherwise denies unsafe_code).
 	#[allow(unsafe_code)]
 	#[cfg(not(debug_assertions))]

--- a/threshold/src/derivation.rs
+++ b/threshold/src/derivation.rs
@@ -49,10 +49,16 @@
 //! # Security
 //!
 //! The contribution input is bound to the share's actual secret polynomials
-//! (`s1`, `s2`), which are the only true secret material in a `PrivateKeyShare`.
-//! The legacy `key` byte string is *not* used here, because in the DKG path it is
-//! derived deterministically from public values (`rho`, `party_id`) and therefore
-//! provides no secrecy.
+//! (`s1`, `s2`), which are the ground-truth secret of the threshold scheme.
+//! The `key` byte string is *not* used here, even though current code derives
+//! it from secret material and it must itself be treated as secret (the
+//! dealer squeezes it from the secret master seed; the DKG and resharing
+//! paths bind it to the secret subset shares under `dkg-party-key-v2` /
+//! `reshare-party-key-v2` — never log, cache, or expose it). The reason is
+//! share vintage: shares serialized by pre-v2 code derived `key` from the
+//! public `rho` and `party_id` only, so a contribution bound to `key` would
+//! carry no secrecy for those shares, while binding to the polynomials is
+//! sound for every share ever produced.
 
 use alloc::vec::Vec;
 
@@ -111,7 +117,12 @@ const DKG_CONTRIBUTION_DOMAIN: &[u8] = b"near-mpc-dilithium-dkg-contribution-v3"
 /// parameter set (same discipline as the DKG / signing / resharing SSIDs).
 pub fn derive_dkg_contribution(master_share: &PrivateKeyShare, tweak: &[u8; 32]) -> [u8; 32] {
 	let party_id_bytes = master_share.party_id().to_le_bytes();
-	let shares_digest = hash_secret_shares(master_share);
+	// The digest is secret-share-derived keying material, so it lives in a
+	// self-wiping buffer filled in place (security review): a plain local —
+	// or a by-value return from the hash — would leave an unwipeable copy in
+	// dead stack memory (pinned by `shares_digest_never_survives_derivation`).
+	let mut shares_digest = Zeroizing::new([0u8; 64]);
+	hash_secret_shares(master_share, &mut shares_digest);
 
 	let mut state = fips202::KeccakState::default();
 	fips202::shake256_absorb(&mut state, DKG_CONTRIBUTION_DOMAIN);
@@ -119,7 +130,7 @@ pub fn derive_dkg_contribution(master_share: &PrivateKeyShare, tweak: &[u8; 32])
 	fips202::shake256_absorb(&mut state, &SUITE_ID.to_le_bytes());
 	fips202::shake256_absorb(&mut state, &party_id_bytes);
 	fips202::shake256_absorb(&mut state, tweak);
-	fips202::shake256_absorb(&mut state, &shares_digest);
+	fips202::shake256_absorb(&mut state, &*shares_digest);
 	fips202::shake256_finalize(&mut state);
 
 	let mut contribution = [0u8; 32];
@@ -128,11 +139,15 @@ pub fn derive_dkg_contribution(master_share: &PrivateKeyShare, tweak: &[u8; 32])
 	contribution
 }
 
-/// Hash all secret share polynomials into a 64-byte digest for use as keying material.
+/// Hash all secret share polynomials into `digest` (64 bytes of keying material).
 ///
 /// `BTreeMap` iteration is deterministic by key, so the digest is stable across calls
 /// and across machines holding the same share data.
-pub(crate) fn hash_secret_shares(master_share: &PrivateKeyShare) -> [u8; 64] {
+///
+/// Writes into a caller-provided buffer instead of returning by value so the
+/// caller can keep the (secret-derived) digest in a zeroizing container with
+/// no dead by-value copy left in this frame.
+pub(crate) fn hash_secret_shares(master_share: &PrivateKeyShare, digest: &mut [u8; 64]) {
 	let mut state = fips202::KeccakState::default();
 	fips202::shake256_absorb(&mut state, b"threshold-share-digest-v1");
 	fips202::shake256_absorb(&mut state, &master_share.party_id().to_le_bytes());
@@ -160,9 +175,7 @@ pub(crate) fn hash_secret_shares(master_share: &PrivateKeyShare) -> [u8; 64] {
 	}
 
 	fips202::shake256_finalize(&mut state);
-	let mut digest = [0u8; 64];
-	fips202::shake256_squeeze(&mut digest, &mut state);
-	digest
+	fips202::shake256_squeeze(digest, &mut state);
 }
 
 /// Identifier for a derived key, used for storage lookup.
@@ -260,6 +273,66 @@ mod tests {
 		tweak
 	}
 
+	/// Regression probe (security review): the 64-byte secret-share digest
+	/// must not survive in dead stack memory after `derive_dkg_contribution`
+	/// returns — it lets a memory-disclosure attacker reproduce the party's
+	/// contribution for any tweak. Painted-stack technique as in the
+	/// `*_stack_zeroization` integration tests; release-only because the
+	/// assertion is about codegen.
+	// Unsafe is required for the raw painted-stack buffer; scoped to this
+	// test only (the crate otherwise denies unsafe_code).
+	#[allow(unsafe_code)]
+	#[cfg(not(debug_assertions))]
+	#[test]
+	fn shares_digest_never_survives_derivation() {
+		use alloc::alloc::{alloc, dealloc, Layout};
+
+		const PAINT: u8 = 0xAA;
+		const STACK_BYTES: usize = 1024 * 1024;
+		const ALIGN: usize = 4096;
+
+		fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
+			let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+			unsafe {
+				let base = alloc(layout);
+				assert!(!base.is_null(), "probe stack allocation failed");
+				core::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+				psm::on_stack(base, STACK_BYTES, f);
+
+				let region = core::slice::from_raw_parts(base, STACK_BYTES);
+				let found = region.windows(pattern.len()).any(|w| w == pattern);
+				dealloc(base, layout);
+				found
+			}
+		}
+
+		let share = create_test_share(0, 42);
+		let tweak = [0x5Au8; 32];
+		// Reference digest, computed outside the probed region.
+		let mut digest = Zeroizing::new([0u8; 64]);
+		hash_secret_shares(&share, &mut digest);
+
+		// Sanity: the technique detects an unwiped copy.
+		assert!(
+			probe_stack_for(&*digest, || {
+				let leaked: [u8; 64] = *digest;
+				core::hint::black_box(&leaked);
+			}),
+			"probe self-check: a deliberately leaked digest copy was not detected"
+		);
+
+		let leaked = probe_stack_for(&*digest, || {
+			let contribution = derive_dkg_contribution(&share, &tweak);
+			core::hint::black_box(&contribution);
+		});
+		assert!(
+			!leaked,
+			"the secret-share digest survived in dead stack memory after \
+			 derive_dkg_contribution returned"
+		);
+	}
+
 	#[test]
 	fn test_derive_dkg_contribution_deterministic() {
 		let share = create_test_share(0, 42);
@@ -277,7 +350,8 @@ mod tests {
 		let share = create_test_share(0, 42);
 		let tweak = [0x11u8; 32];
 		let real = derive_dkg_contribution(&share, &tweak);
-		let shares_digest = hash_secret_shares(&share);
+		let mut shares_digest = Zeroizing::new([0u8; 64]);
+		hash_secret_shares(&share, &mut shares_digest);
 
 		let mut state = fips202::KeccakState::default();
 		fips202::shake256_absorb(&mut state, DKG_CONTRIBUTION_DOMAIN);
@@ -285,7 +359,7 @@ mod tests {
 		fips202::shake256_absorb(&mut state, &(SUITE_ID ^ 0xDEAD).to_le_bytes());
 		fips202::shake256_absorb(&mut state, &share.party_id().to_le_bytes());
 		fips202::shake256_absorb(&mut state, &tweak);
-		fips202::shake256_absorb(&mut state, &shares_digest);
+		fips202::shake256_absorb(&mut state, &*shares_digest);
 		fips202::shake256_finalize(&mut state);
 		let mut other_suite = [0u8; 32];
 		fips202::shake256_squeeze(&mut other_suite, &mut state);
@@ -331,9 +405,10 @@ mod tests {
 
 	#[test]
 	fn test_contribution_independent_of_legacy_key_field() {
-		// Two shares that differ ONLY in the publicly-derivable `key` byte string
-		// must still produce the same contribution, because security comes from the
-		// secret polynomial shares, not from `key`.
+		// Two shares that differ ONLY in the `key` byte string must still
+		// produce the same contribution: the binding comes from the secret
+		// polynomial shares directly, not from the derived `key` (which
+		// pre-v2 code computed from public inputs only).
 		let dkg_participants = ParticipantList::new(&[0, 1, 2]).unwrap();
 		let mut shares = BTreeMap::new();
 		shares.insert(

--- a/threshold/src/keygen/README.md
+++ b/threshold/src/keygen/README.md
@@ -90,7 +90,27 @@ Example for (2, 3):
 2. **No Trusted Dealer**: No single party ever knows the complete secret key
 3. **Commitment Scheme**: Parties commit before revealing, preventing adaptive attacks
 4. **Transcript Signing**: Provides non-repudiation and detects tampering
-5. **PK Commitment Verification**: Non-leaders verify partial PKs before signing
+5. **PK Commitment Verification**: Members of a subset verify that subset's partial PK before signing
+
+### Integrity Model (secure-with-abort)
+
+A subset's partial public key `t_S` can be checked against the prescribed
+η-bounded derivation only by a party that holds `K_S` — i.e. a member of `S`.
+On its own `t_S` is an LWE sample, and testing it for an η-bounded preimage is
+LWE/SIS-hard; the preimage cannot be revealed for checking without exposing the
+secret (`s = Σ_S s_S`). DKG therefore produces a provably η-distributed key only
+when **every subset contains at least one honest party**.
+
+A sub-threshold adversary that fully controls a subset — which includes *any
+single party* in an n-of-n config, since every subset is then a singleton
+(`k = n - t + 1 = 1`) — can commit to a non-η `t_S` that no honest party
+detects. This does **not** enable forgery or leak honest shares: the Round 3/4
+commit-reveal binds the leader to `t_S` before any honest `t` is revealed, so the
+aggregate key cannot be adaptively steered. The worst effect is a signing-time
+abort/retry or a bounded widening of the secret distribution (absorbed by the
+hyperball headroom). Deployments that require robust completion against a
+fully-corrupt subset must add a zero-knowledge proof of short preimage to each
+partial key (not implemented).
 
 ### Supported Configurations
 

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -7,7 +7,7 @@
 use alloc::{collections::BTreeMap, vec::Vec};
 
 use qp_rusty_crystals_dilithium::{fips202, packing, poly, polyvec};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::{
 	config::ThresholdConfig,
@@ -126,12 +126,17 @@ pub fn generate_with_dealer(
 	let mut rho = [0u8; 32];
 	fips202::shake256_squeeze(&mut rho, &mut h);
 
-	// 2. Squeeze party keys
-	let mut party_keys = Vec::with_capacity(parties as usize);
+	// 2. Squeeze party keys. Each seed is copied into a returned share (which
+	// wipes its copy on drop), but this dealer-side vector also holds every
+	// party's seed; `Zeroizing` wipes it on every exit path (security review)
+	// rather than freeing the plaintext seeds with the allocation.
+	let mut party_keys: Zeroizing<Vec<[u8; 32]>> =
+		Zeroizing::new(Vec::with_capacity(parties as usize));
 	for _ in 0..parties {
 		let mut key = [0u8; 32];
 		fips202::shake256_squeeze(&mut key, &mut h);
 		party_keys.push(key);
+		key.zeroize();
 	}
 
 	// 3. Generate threshold shares
@@ -214,6 +219,14 @@ pub fn generate_with_dealer(
 			}
 
 			shares_data.insert(subset_id, SecretShareData { s1: s1_data, s2: s2_data });
+
+			// The arrays are Copy, so the struct literal above duplicated them
+			// and these locals are now dead plaintext copies of the share
+			// coefficients; wipe them instead of leaving them on the stack
+			// (security review). The copies inside `shares_data` are owned by
+			// `SecretShareData`, which zeroizes on drop.
+			s1_data.zeroize();
+			s2_data.zeroize();
 		}
 
 		// For dealer-generated keys, participants have sequential IDs (0, 1, 2, ..., n-1)

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -267,9 +267,9 @@ struct SecretShare {
 
 /// Result type for threshold share generation containing:
 /// - s2_total: Polyvec<K>
-/// - s1h_total: Polyvec<L> (NTT form; the non-NTT aggregate s1 is deliberately
-///   never materialized — `t = A*s1 + s2` only needs the NTT form, and every
-///   extra full copy of the aggregate secret is another buffer to leak)
+/// - s1h_total: Polyvec<L> (NTT form; the non-NTT aggregate s1 is deliberately never materialized —
+///   `t = A*s1 + s2` only needs the NTT form, and every extra full copy of the aggregate secret is
+///   another buffer to leak)
 /// - party_shares: BTreeMap<u32, BTreeMap<u16, SecretShare>> (u16 subset masks)
 type ThresholdSharesResult =
 	(polyvec::Polyvec<K>, polyvec::Polyvec<L>, BTreeMap<u32, BTreeMap<u16, SecretShare>>);

--- a/threshold/src/keygen/dealer.rs
+++ b/threshold/src/keygen/dealer.rs
@@ -67,6 +67,14 @@ const DEALER_SUBSHARE_DOMAIN: &[u8] = b"threshold-dealer-subshare-v1";
 /// - Each share is only accessible to its designated party
 /// - The dealer does not retain copies of any shares
 ///
+/// Internally, every secret-bearing intermediate is wiped before its memory
+/// is released: the aggregate-secret locals (`s2_total`, `s1h_total`, `t`,
+/// `t0`) are `Polyvec`s and the NTT accumulator wipes itself, all of which
+/// zeroize on drop; the per-party key seeds and transient stack copies are
+/// explicitly zeroized. The usual Rust caveat applies: the compiler may leave
+/// stale copies behind when values are moved, which no `zeroize`-based
+/// discipline can prevent.
+///
 /// # Coefficient Distribution
 ///
 /// The reconstructed secret `s = (s1, s2)` is the sum of `C(n, n-t+1)` independent
@@ -140,7 +148,7 @@ pub fn generate_with_dealer(
 	}
 
 	// 3. Generate threshold shares
-	let (_s1_total, s2_total, s1h_total, party_shares) =
+	let (s2_total, s1h_total, party_shares) =
 		generate_threshold_shares(&mut h, threshold, parties)?;
 
 	// 4. Generate matrix A from rho
@@ -258,16 +266,13 @@ struct SecretShare {
 }
 
 /// Result type for threshold share generation containing:
-/// - s1_total: Polyvec<L>
 /// - s2_total: Polyvec<K>
-/// - s1h_total: Polyvec<L> (NTT form)
+/// - s1h_total: Polyvec<L> (NTT form; the non-NTT aggregate s1 is deliberately
+///   never materialized — `t = A*s1 + s2` only needs the NTT form, and every
+///   extra full copy of the aggregate secret is another buffer to leak)
 /// - party_shares: BTreeMap<u32, BTreeMap<u16, SecretShare>> (u16 subset masks)
-type ThresholdSharesResult = (
-	polyvec::Polyvec<L>,
-	polyvec::Polyvec<K>,
-	polyvec::Polyvec<L>,
-	BTreeMap<u32, BTreeMap<u16, SecretShare>>,
-);
+type ThresholdSharesResult =
+	(polyvec::Polyvec<K>, polyvec::Polyvec<L>, BTreeMap<u32, BTreeMap<u16, SecretShare>>);
 
 /// Generate threshold shares for all subset combinations.
 fn generate_threshold_shares(
@@ -281,8 +286,9 @@ fn generate_threshold_shares(
 		party_shares.insert(i, BTreeMap::new());
 	}
 
-	// Total secrets (η-bounded, safe with i32)
-	let mut s1_total = polyvec::Polyvec::<L>::default();
+	// Total s2 secret (η-bounded sums, safe with i32). The aggregate s1 is
+	// accumulated only in NTT form (below); a non-NTT total was previously
+	// also built here but was never consumed by any caller.
 	let mut s2_total = polyvec::Polyvec::<K>::default();
 
 	// NTT-domain accumulator uses u64 to avoid overflow for large configurations.
@@ -350,17 +356,9 @@ fn generate_threshold_shares(
 			}
 		}
 
-		// Add η-bounded shares to totals.
+		// Add η-bounded shares to the s2 total.
 		// η-bounded coefficients are in [-2, 2], so even with 6435 subsets (max for 15 parties),
 		// the sum is bounded by ±12870, well within i32 range.
-		for (total_poly, share_poly) in s1_total.vec.iter_mut().zip(s1_share.vec.iter()).take(L) {
-			for (total_coeff, share_coeff) in
-				total_poly.coeffs_mut().iter_mut().zip(share_poly.coeffs().iter())
-			{
-				*total_coeff += *share_coeff;
-			}
-		}
-
 		for (total_poly, share_poly) in s2_total.vec.iter_mut().zip(s2_share.vec.iter()).take(K) {
 			for (total_coeff, share_coeff) in
 				total_poly.coeffs_mut().iter_mut().zip(share_poly.coeffs().iter())
@@ -378,15 +376,6 @@ fn generate_threshold_shares(
 	// Finalize NTT accumulator (reduces mod Q)
 	let s1h_total = s1h_acc.finalize_l();
 
-	// Normalize s1_total (η-bounded sums)
-	for total_poly in s1_total.vec.iter_mut().take(L) {
-		for total_coeff in total_poly.coeffs_mut().iter_mut() {
-			let coeff_u32 =
-				if *total_coeff < 0 { (*total_coeff + Q) as u32 } else { *total_coeff as u32 };
-			*total_coeff = mod_q(coeff_u32) as i32;
-		}
-	}
-
 	// Normalize s2_total (η-bounded sums)
 	for total_poly in s2_total.vec.iter_mut().take(K) {
 		for total_coeff in total_poly.coeffs_mut().iter_mut() {
@@ -396,7 +385,7 @@ fn generate_threshold_shares(
 		}
 	}
 
-	Ok((s1_total, s2_total, s1h_total, party_shares))
+	Ok((s2_total, s1h_total, party_shares))
 }
 
 #[cfg(test)]

--- a/threshold/src/keygen/dkg/mod.rs
+++ b/threshold/src/keygen/dkg/mod.rs
@@ -62,7 +62,9 @@
 //! ## Provided guarantees
 //! - Each party contributes randomness, so no single party controls the key
 //! - Commitment scheme (Round 1/2) prevents parties from adapting r_i based on others
-//! - Algebraic verification (Round 4) detects inconsistent partial public keys
+//! - Algebraic verification (Round 4) detects an inconsistent partial public
+//!   key for any subset in which the verifier is a member (see the partial-key
+//!   η-binding limitation below for subsets with no honest member)
 //! - Transcript signing provides non-repudiation
 //!
 //! ## Known limitations
@@ -88,6 +90,51 @@
 //! - Adding reputation/staking mechanisms at the application layer
 //! - Implementing leader rotation on repeated failures
 //! - Using a complaint round with blame attribution (not currently implemented)
+//!
+//! **Partial-key η-binding requires an honest subset member (secure-with-abort):**
+//!
+//! Round 4 verifies a leader's partial public key `t_S` against the prescribed
+//! η-bounded derivation only when the verifier is itself a member of subset `S`
+//! and therefore holds `K_S`: it re-derives `s_S = H_keygen(S, K_S, R)` and
+//! checks `t_S == A·s_S`. A verifier outside `S` holds no `K_S`, and `t_S`
+//! alone is an LWE sample — deciding whether it has an η-bounded preimage is the
+//! LWE/SIS problem, so an outsider cannot check it. Detecting the bound would
+//! require revealing the preimage `s_S`, but the full secret is `s = Σ_S s_S`,
+//! so publishing every `s_S` would expose the entire key; the only parties
+//! entitled to learn `s_S` are `S`'s members, who can already verify. There is
+//! thus no "reveal-and-check" that closes the gap without a zero-knowledge proof
+//! of short preimage.
+//!
+//! Consequently, for a subset with **no honest member** a malicious leader can
+//! commit to (and later reveal) a `t_S` that is not the prescribed η-bounded
+//! derivation, and no honest party detects it. This is reachable *below* the
+//! signing threshold:
+//! - every subset in an n-of-n config is a singleton `{i}` (subset size
+//!   `k = n - t + 1 = 1`), so a single malicious party owns its own subset;
+//! - in configs with `k ≤ t - 1` (e.g. 3-of-4) a sub-threshold coalition can
+//!   fully own a subset.
+//!
+//! The impact is bounded and consistent with the secure-with-abort model:
+//! - **No forgery, no secret recovery.** The Round 3 commitment is opened only
+//!   in Round 4, so a leader is bound to its `t_S` before any honest `t` is
+//!   revealed; it cannot adaptively steer the aggregate `Σ_S t_S` toward a
+//!   chosen or self-signable key, and it never learns honest subsets' shares.
+//! - **Worst case is abort/retry or a bounded distribution skew.** A bogus
+//!   `t_S` either fails the signing-time norm checks (persistent signing
+//!   failure → abort and retry with a fresh session/participant set) or, if the
+//!   leader picks a short-but-not-η preimage that still passes those checks,
+//!   widens the aggregate secret distribution within the hyperball headroom.
+//! - **No new halting power.** In exactly the configs where a subset can be
+//!   fully corrupt below threshold, that adversary already lies in every signing
+//!   quorum covering the subset (any `t` parties intersect every
+//!   size-`(n − t + 1)` subset), so it can already force an abort by withholding.
+//!
+//! DKG therefore yields a provably η-distributed key only when every subset
+//! contains at least one honest party. Where that does not hold, integrity
+//! degrades to detect-and-abort rather than robust completion. Deployments that
+//! require a guaranteed η-distributed output despite a fully-corrupt subset must
+//! attach a zero-knowledge proof of short preimage to each partial key (not
+//! implemented).
 //!
 //! **Coefficient distribution deviates from standard ML-DSA:**
 //!

--- a/threshold/src/keygen/dkg/mod.rs
+++ b/threshold/src/keygen/dkg/mod.rs
@@ -62,9 +62,9 @@
 //! ## Provided guarantees
 //! - Each party contributes randomness, so no single party controls the key
 //! - Commitment scheme (Round 1/2) prevents parties from adapting r_i based on others
-//! - Algebraic verification (Round 4) detects an inconsistent partial public
-//!   key for any subset in which the verifier is a member (see the partial-key
-//!   η-binding limitation below for subsets with no honest member)
+//! - Algebraic verification (Round 4) detects an inconsistent partial public key for any subset in
+//!   which the verifier is a member (see the partial-key η-binding limitation below for subsets
+//!   with no honest member)
 //! - Transcript signing provides non-repudiation
 //!
 //! ## Known limitations
@@ -109,25 +109,23 @@
 //! commit to (and later reveal) a `t_S` that is not the prescribed η-bounded
 //! derivation, and no honest party detects it. This is reachable *below* the
 //! signing threshold:
-//! - every subset in an n-of-n config is a singleton `{i}` (subset size
-//!   `k = n - t + 1 = 1`), so a single malicious party owns its own subset;
-//! - in configs with `k ≤ t - 1` (e.g. 3-of-4) a sub-threshold coalition can
-//!   fully own a subset.
+//! - every subset in an n-of-n config is a singleton `{i}` (subset size `k = n - t + 1 = 1`), so a
+//!   single malicious party owns its own subset;
+//! - in configs with `k ≤ t - 1` (e.g. 3-of-4) a sub-threshold coalition can fully own a subset.
 //!
 //! The impact is bounded and consistent with the secure-with-abort model:
-//! - **No forgery, no secret recovery.** The Round 3 commitment is opened only
-//!   in Round 4, so a leader is bound to its `t_S` before any honest `t` is
-//!   revealed; it cannot adaptively steer the aggregate `Σ_S t_S` toward a
-//!   chosen or self-signable key, and it never learns honest subsets' shares.
-//! - **Worst case is abort/retry or a bounded distribution skew.** A bogus
-//!   `t_S` either fails the signing-time norm checks (persistent signing
-//!   failure → abort and retry with a fresh session/participant set) or, if the
-//!   leader picks a short-but-not-η preimage that still passes those checks,
-//!   widens the aggregate secret distribution within the hyperball headroom.
-//! - **No new halting power.** In exactly the configs where a subset can be
-//!   fully corrupt below threshold, that adversary already lies in every signing
-//!   quorum covering the subset (any `t` parties intersect every
-//!   size-`(n − t + 1)` subset), so it can already force an abort by withholding.
+//! - **No forgery, no secret recovery.** The Round 3 commitment is opened only in Round 4, so a
+//!   leader is bound to its `t_S` before any honest `t` is revealed; it cannot adaptively steer the
+//!   aggregate `Σ_S t_S` toward a chosen or self-signable key, and it never learns honest subsets'
+//!   shares.
+//! - **Worst case is abort/retry or a bounded distribution skew.** A bogus `t_S` either fails the
+//!   signing-time norm checks (persistent signing failure → abort and retry with a fresh
+//!   session/participant set) or, if the leader picks a short-but-not-η preimage that still passes
+//!   those checks, widens the aggregate secret distribution within the hyperball headroom.
+//! - **No new halting power.** In exactly the configs where a subset can be fully corrupt below
+//!   threshold, that adversary already lies in every signing quorum covering the subset (any `t`
+//!   parties intersect every size-`(n − t + 1)` subset), so it can already force an abort by
+//!   withholding.
 //!
 //! DKG therefore yields a provably η-distributed key only when every subset
 //! contains at least one honest party. Where that does not hold, integrity

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -1922,6 +1922,24 @@ fn verify_party_broadcast<S: TranscriptSigner>(
 			continue;
 		}
 
+		// Skip valid subsets this party does not lead (security review): only
+		// the leader's PK is ever aggregated — collect_and_verify_all_partial_pks
+		// drops non-leader PKs right after this returns — and a sender's
+		// Round 3 legitimately carries commitments only for its led subsets,
+		// so "verifying" a non-led entry could only fail with MissingData.
+		// Without this filter, a malicious party could abort the session
+		// after all four rounds by appending one extra valid subset mask to
+		// its otherwise-honest broadcast. Ignore the entry instead, exactly
+		// as the aggregation step would.
+		if config.get_leader(subset) != Some(party_id) {
+			log::warn!(
+				"DKG: Ignoring partial PK for non-led subset {:b} from party {} during Round 4 verification",
+				subset,
+				party_id
+			);
+			continue;
+		}
+
 		verify_partial_pk_commitment(
 			ssid,
 			shared_secrets,
@@ -4346,6 +4364,175 @@ mod tests {
 		// 2. All parties get the same public key
 		// 3. The leadership logic is correct
 		// The code now filters out non-leader PKs with a warning log.
+	}
+
+	/// A Round 4 broadcast that includes a partial PK for a *valid* subset the
+	/// sender does not lead must not abort the session. Non-leader PKs are
+	/// never aggregated (collect_and_verify_all_partial_pks drops them), and a
+	/// sender's Round 3 legitimately carries commitments only for its led
+	/// subsets — so verifying such an entry can only fail with MissingData.
+	/// Without the leader filter in verify_party_broadcast, a malicious party
+	/// could kill the session after all four rounds by appending one extra
+	/// valid subset mask to its otherwise-honest broadcast.
+	#[test]
+	fn test_extra_valid_nonled_subset_in_round4_does_not_abort() {
+		// 2-of-3: subsets 0b011 (leader 0), 0b101 (leader 0), 0b110 (leader 1).
+		let signers: Vec<TestSigner> = (0..3).map(|id| TestSigner { id }).collect();
+		let seed = [77u8; 32];
+
+		let threshold_config = ThresholdConfig::new(2, 3).unwrap();
+		let participants: Vec<ParticipantId> = (0..3).collect();
+
+		let mut pk_map: BTreeMap<ParticipantId, u32> = BTreeMap::new();
+		for i in 0..3u32 {
+			pk_map.insert(i as ParticipantId, i);
+		}
+
+		let mut dkgs: Vec<Dkg<TestSigner>> = signers
+			.into_iter()
+			.enumerate()
+			.map(|(i, signer)| {
+				let config = DkgConfig::new(
+					threshold_config,
+					i as ParticipantId,
+					participants.clone(),
+					signer,
+					pk_map.clone(),
+				)
+				.unwrap();
+				Dkg::new(config, seed, &TEST_SESSION_NONCE)
+			})
+			.collect();
+
+		// Run the protocol, holding back party 1's Round 4 broadcast to party 0
+		// so we can deliver a tampered version instead.
+		let mut pending_messages: Vec<Vec<(ParticipantId, Vec<u8>)>> = vec![Vec::new(); 3];
+		let mut intercepted_round4: Option<Round4Broadcast> = None;
+
+		'outer: for _ in 0..100 {
+			for party_id in 0..3 {
+				let messages = mem::take(&mut pending_messages[party_id]);
+				for (from, data) in messages {
+					if party_id == 0 && from == 1 {
+						if let Ok(DkgMessage::Round4Broadcast(r4)) =
+							borsh::from_slice::<DkgMessage>(&data)
+						{
+							intercepted_round4 = Some(r4);
+							continue;
+						}
+					}
+					dkgs[party_id].message(from, data).unwrap();
+				}
+			}
+
+			for (party_id, dkg) in dkgs.iter_mut().enumerate() {
+				match dkg.poke().unwrap() {
+					DkgAction::SendMany(data) => {
+						for (other, pending) in pending_messages.iter_mut().enumerate() {
+							if other != party_id {
+								pending.push((party_id as ParticipantId, data.clone()));
+							}
+						}
+					},
+					DkgAction::SendPrivate(to, data) => {
+						pending_messages[to as usize]
+							.push((party_id as ParticipantId, data.to_vec()));
+					},
+					DkgAction::Wait => {},
+					DkgAction::Return(_) => {},
+				}
+			}
+
+			if intercepted_round4.is_some() &&
+				dkgs[0].state.phase == DkgPhase::Round4 &&
+				dkgs[0].state.broadcast_sent
+			{
+				break 'outer;
+			}
+		}
+
+		let honest_r4 = intercepted_round4.expect("should have intercepted party 1's Round 4");
+
+		// Party 1 honestly leads only subset 0b110. Append its genuine PK
+		// under subset 0b011 as well — a valid subset led by party 0, so
+		// party 1's Round 3 has no commitment for it.
+		let mut tampered_pks = honest_r4.partial_public_keys.clone();
+		let donor = tampered_pks.get(&0b110).expect("party 1 leads subset 0b110").clone();
+		tampered_pks
+			.insert(0b011, PartialPublicKey { subset_mask: 0b011, t: donor.t });
+
+		// Re-sign the tampered PK set with party 1's key so the transcript
+		// signature check passes (a malicious party 1 signs whatever it sends).
+		let transcript_hash = {
+			let round1_broadcasts = dkgs[0].state.round1_broadcasts.as_ref().unwrap();
+			let round2_broadcasts = dkgs[0].state.round2_broadcasts.as_ref().unwrap();
+			let round3_broadcasts = dkgs[0].state.round3_broadcasts.as_ref().unwrap();
+			compute_transcript_hash(
+				&dkgs[0].ssid,
+				round1_broadcasts,
+				round2_broadcasts,
+				round3_broadcasts,
+			)
+		};
+		let partial_output_hash = compute_partial_output_hash(&tampered_pks);
+		let signing_message = compute_signing_message(&transcript_hash, &partial_output_hash);
+		let signature = TestSigner { id: 1 }.sign(&signing_message);
+
+		let tampered_r4 = Round4Broadcast {
+			ssid: honest_r4.ssid,
+			party_id: 1,
+			partial_public_keys: tampered_pks,
+			transcript_signature: signature,
+		};
+		let tampered_data = borsh::to_vec(&DkgMessage::Round4Broadcast(tampered_r4)).unwrap();
+		dkgs[0].message(1, tampered_data).unwrap();
+
+		// The extra non-led entry must be ignored, not abort the session.
+		dkgs[0]
+			.complete()
+			.expect("extra valid-but-non-led subset in Round 4 must not abort the DKG");
+		let output = dkgs[0].state.output.take().expect("completed DKG must have an output");
+
+		// The aggregated key must come from the real leaders' PKs only: it must
+		// match what the untampered parties compute.
+		let mut outputs: Vec<Option<DkgOutput>> = vec![None; 3];
+		for _ in 0..50 {
+			for party_id in 0..3 {
+				let messages = mem::take(&mut pending_messages[party_id]);
+				for (from, data) in messages {
+					dkgs[party_id].message(from, data).unwrap();
+				}
+			}
+			for party_id in 1..3 {
+				if outputs[party_id].is_some() {
+					continue;
+				}
+				match dkgs[party_id].poke().unwrap() {
+					DkgAction::Return(out) => outputs[party_id] = Some(*out),
+					DkgAction::SendMany(data) => {
+						for (other, pending) in pending_messages.iter_mut().enumerate() {
+							if other != party_id {
+								pending.push((party_id as ParticipantId, data.clone()));
+							}
+						}
+					},
+					DkgAction::SendPrivate(to, data) => {
+						pending_messages[to as usize]
+							.push((party_id as ParticipantId, data.to_vec()));
+					},
+					_ => {},
+				}
+			}
+			if outputs[1].is_some() && outputs[2].is_some() {
+				break;
+			}
+		}
+		let out1 = outputs[1].take().expect("party 1 should complete");
+		assert_eq!(
+			output.public_key.as_bytes(),
+			out1.public_key.as_bytes(),
+			"tampered view must still aggregate the same public key as honest parties"
+		);
 	}
 
 	#[test]

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -4458,8 +4458,7 @@ mod tests {
 		// party 1's Round 3 has no commitment for it.
 		let mut tampered_pks = honest_r4.partial_public_keys.clone();
 		let donor = tampered_pks.get(&0b110).expect("party 1 leads subset 0b110").clone();
-		tampered_pks
-			.insert(0b011, PartialPublicKey { subset_mask: 0b011, t: donor.t });
+		tampered_pks.insert(0b011, PartialPublicKey { subset_mask: 0b011, t: donor.t });
 
 		// Re-sign the tampered PK set with party 1's key so the transcript
 		// signature check passes (a malicious party 1 signs whatever it sends).

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -1937,7 +1937,19 @@ fn verify_party_broadcast<S: TranscriptSigner>(
 	Ok(())
 }
 
-/// Verify a single partial PK matches its commitment and (if possible) the shared secret.
+/// Verify a single partial PK against its Round-3 commitment and, when the
+/// verifier holds the subset's shared secret, against the prescribed η-bounded
+/// derivation.
+///
+/// The algebraic recomputation is only possible for a subset the verifier is a
+/// member of (it needs `K_S`). For a subset with no honest member the check
+/// necessarily reduces to the commitment the leader itself chose: `t_S` alone is
+/// an LWE sample, testing it for an η-bounded preimage is LWE/SIS-hard, and the
+/// preimage cannot be revealed without exposing the secret. This is an accepted
+/// secure-with-abort limitation (no forgery or secret recovery results; the
+/// worst case is a signing-time abort/retry or a bounded distribution skew).
+/// See the "Partial-key η-binding" limitation in this module's docs
+/// (`dkg/mod.rs`).
 fn verify_partial_pk_commitment(
 	ssid: &[u8; DKG_SSID_SIZE],
 	shared_secrets: &BTreeMap<SubsetMask, [u8; SHARED_SECRET_SIZE]>,

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -1115,13 +1115,8 @@ mod tests {
 		public_keys.insert(1, 1u32);
 		public_keys.insert(2, 2u32);
 
-		let result: Result<DkgConfig<TestSigner>, _> = DkgConfig::new(
-			threshold_config,
-			0,
-			vec![0, 1, 2],
-			TestSigner { id: 0 },
-			public_keys,
-		);
+		let result: Result<DkgConfig<TestSigner>, _> =
+			DkgConfig::new(threshold_config, 0, vec![0, 1, 2], TestSigner { id: 0 }, public_keys);
 
 		assert!(result.is_err(), "signer/registered key mismatch must be rejected");
 		assert_eq!(

--- a/threshold/src/keygen/dkg/types.rs
+++ b/threshold/src/keygen/dkg/types.rs
@@ -157,9 +157,10 @@ pub const DKG_SSID_SIZE: usize = 32;
 /// a config: the state machine (including quorum arithmetic such as the
 /// crate-internal `all_broadcasts_received`) trusts that `all_participants`
 /// is non-empty, sorted, duplicate-free, matches the threshold
-/// configuration's party count, contains `my_party_id`, and has a verifying
-/// key for every participant. A struct literal bypassing those checks does
-/// not compile:
+/// configuration's party count, contains `my_party_id`, has a verifying
+/// key for every participant, and registers `my_signer`'s own public key
+/// under `my_party_id` (so peers can actually verify our transcript
+/// signature). A struct literal bypassing those checks does not compile:
 ///
 /// ```compile_fail
 /// use qp_rusty_crystals_threshold::keygen::dkg::{DkgConfig, TranscriptSigner};
@@ -221,6 +222,17 @@ impl<S: TranscriptSigner> DkgConfig<S> {
 			if !participant_public_keys.contains_key(p) {
 				return Err("missing public key for participant");
 			}
+		}
+		// Peers verify this party's Round 4 transcript signature against the
+		// key *registered* in participant_public_keys, not against whatever
+		// my_signer holds. A mismatch (security review) can't forge anything,
+		// but it guarantees every peer rejects our signature and the session
+		// aborts only at transcript validation — after all four rounds. Fail
+		// at configuration time instead. (The lookup is Some: my_party_id is
+		// in all_participants and every participant has a key, both checked
+		// above.)
+		if participant_public_keys.get(&my_party_id) != Some(&my_signer.public_key()) {
+			return Err("my_signer public key doesn't match the key registered for my_party_id");
 		}
 
 		let mut sorted_participants = all_participants;
@@ -1087,6 +1099,35 @@ mod tests {
 
 		assert!(result.is_err());
 		assert_eq!(result.unwrap_err(), "duplicate participant ID in all_participants");
+	}
+
+	/// The config must reject a local signer whose public key differs from the
+	/// key registered for `my_party_id` in the shared map. Peers verify this
+	/// party's Round 4 transcript signature against the *registered* key, so a
+	/// mismatch means every peer rejects the signature and the session aborts
+	/// only after all four rounds. Misconfiguration must fail at construction
+	/// time instead.
+	#[test]
+	fn test_config_rejects_signer_key_mismatch() {
+		let threshold_config = ThresholdConfig::new(2, 3).unwrap();
+		let mut public_keys = BTreeMap::new();
+		public_keys.insert(0, 99u32); // registered key for party 0 != TestSigner{0}'s key
+		public_keys.insert(1, 1u32);
+		public_keys.insert(2, 2u32);
+
+		let result: Result<DkgConfig<TestSigner>, _> = DkgConfig::new(
+			threshold_config,
+			0,
+			vec![0, 1, 2],
+			TestSigner { id: 0 },
+			public_keys,
+		);
+
+		assert!(result.is_err(), "signer/registered key mismatch must be rejected");
+		assert_eq!(
+			result.unwrap_err(),
+			"my_signer public key doesn't match the key registered for my_party_id"
+		);
 	}
 
 	#[test]

--- a/threshold/src/protocol/primitives.rs
+++ b/threshold/src/protocol/primitives.rs
@@ -543,7 +543,9 @@ fn make_hint_single(z0: i32, r1: i32) -> i32 {
 ///
 /// The buffer length is enforced by the type (fixed-size array reference)
 /// rather than a runtime assert, so there is no release-mode panic path;
-/// callers carve exact chunks with `as_chunks_mut`.
+/// callers carve exact chunks with `as_chunks_mut`. The buffer's prior
+/// contents are ignored: it is fully overwritten, so callers may reuse a
+/// dirty scratch buffer.
 ///
 /// # Panics
 ///
@@ -557,6 +559,12 @@ pub(crate) fn poly_pack_w(p: &poly::Poly, buf: &mut [u8; POLY_Q_PACKEDBYTES]) {
 		p.coeffs().iter().all(|&c| (0..Q).contains(&c)),
 		"poly_pack_w precondition violated: coefficient outside [0, Q)"
 	);
+
+	// The bit loop below ORs each coefficient into place, which is only
+	// correct over zeroed bytes. Clearing here (security review) makes the
+	// function self-contained instead of a serializer whose correctness
+	// silently depends on every caller pre-zeroing its buffer.
+	buf.fill(0);
 
 	let mut bit_pos = 0usize;
 	for i in 0..N as usize {
@@ -816,6 +824,30 @@ mod tests {
 		for i in 0..N as usize {
 			assert_eq!(p.coeffs()[i], p2.coeffs()[i], "Mismatch at index {}", i);
 		}
+	}
+
+	/// `poly_pack_w` is a serializer, not an accumulator: its output must not
+	/// depend on the buffer's prior contents. Packing into a dirty (all-0xFF)
+	/// buffer must be byte-identical to packing into a fresh one; otherwise
+	/// any future caller that reuses a scratch buffer ORs new bits into stale
+	/// ones and silently serializes a corrupt commitment.
+	#[test]
+	fn test_poly_pack_w_overwrites_dirty_buffer() {
+		let mut p = poly::Poly::default();
+		for i in 0..N as usize {
+			p.coeffs_mut()[i] = (i * 7919) as i32 % Q;
+		}
+
+		let mut clean = [0u8; POLY_Q_PACKEDBYTES];
+		poly_pack_w(&p, &mut clean);
+
+		let mut dirty = [0xFFu8; POLY_Q_PACKEDBYTES];
+		poly_pack_w(&p, &mut dirty);
+
+		assert_eq!(
+			clean, dirty,
+			"poly_pack_w output must not depend on the buffer's prior contents"
+		);
 	}
 
 	/// `poly_pack_w`'s docs promise a debug-build panic on any coefficient

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -173,7 +173,7 @@ use zeroize::Zeroize;
 
 use crate::{
 	broadcast::{Round1Broadcast, Round2Broadcast, Round3Broadcast, Signature, SSID_SIZE},
-	params::SINGLE_COMMITMENT_SIZE,
+	params::{L, POLYZ_PACKEDBYTES, SINGLE_COMMITMENT_SIZE},
 	participants::{ParticipantId, ParticipantList},
 	protocol::signing::compute_ssid,
 	signer::ThresholdSigner,
@@ -1305,11 +1305,36 @@ impl DilithiumSignProtocol {
 				}
 			},
 			SigningMessage::Round3(r3) => {
+				// Exact-length gate at intake (security review): a response that
+				// is not the size this session's configuration produces can only
+				// ever fail `unpack_responses` inside the leader's combine(),
+				// where the abort is indistinguishable from ordinary rejection-
+				// sampling failure. Rejecting it here keeps it out of the
+				// sender's first-wins slot (and the early-round buffer) and
+				// attributes the misbehavior to the sender at receive time.
+				if !self.round3_response_well_formed(&r3) {
+					warn!(
+						"Signing: Rejecting Round 3 from party {} - response length {} does not \
+						 match this session's expected share size",
+						r3.party_id,
+						r3.response.len()
+					);
+					return Ok(());
+				}
 				// Accept Round 3 messages during Round 3 waiting or later.
-				// The Round 3 response is implicitly bound to the same attempt's Round 1
-				// and Round 2 because it's verified during combine() against
-				// the aggregated commitments (which only validate if r3 was computed
-				// from the same c = SampleInBall(H(mu || HighBits(w))) the honest party
+				//
+				// No "Round 2 seen from this party" prerequisite is needed: the
+				// states below are only reachable after have_enough_r2(), and a
+				// session runs with exactly `threshold` participants, so by then
+				// r2_broadcasts already holds a hash-bound Round 2 from every
+				// participant (buffered Round 3s are likewise only drained by
+				// process_buffered_round3 on the transition into Round 3).
+				//
+				// Beyond length, the Round 3 response is bound to the same
+				// attempt's Round 1 and Round 2 because it's verified during
+				// combine() against the aggregated commitments (which only
+				// validate if r3 was computed from the same
+				// c = SampleInBall(H(mu || HighBits(w))) the honest party
 				// derived from the now-fixed r2_broadcasts in this instance).
 				if matches!(
 					self.state,
@@ -1398,6 +1423,21 @@ impl DilithiumSignProtocol {
 		)
 	}
 
+	/// Check that a Round 3 response is exactly the size this session's
+	/// configuration produces: `k_iterations * L * POLYZ_PACKEDBYTES`, the
+	/// same bound `unpack_responses` enforces when the leader combines.
+	///
+	/// This is the Round 3 counterpart of the exact-length check inside
+	/// [`Self::round2_matches_stored_round1`]: it cannot prove the response
+	/// is honest (only combine() can, against the aggregated commitments),
+	/// but it drops in O(1) every message that is *structurally guaranteed*
+	/// to fail later, so such a message can never occupy the sender's
+	/// first-wins slot in `r3_broadcasts` or the early-round buffer.
+	fn round3_response_well_formed(&self, r3: &Round3Broadcast) -> bool {
+		let expected_len = self.signer.config().k_iterations() as usize * L * POLYZ_PACKEDBYTES;
+		r3.response.len() == expected_len
+	}
+
 	/// Process buffered Round 2 messages after transitioning to Round 2.
 	///
 	/// Buffered Round 2 messages still need the commitment-hash binding check
@@ -1420,6 +1460,11 @@ impl DilithiumSignProtocol {
 	}
 
 	/// Process buffered Round 3 messages after transitioning to Round 3.
+	///
+	/// Unlike `process_buffered_round2`, no re-validation is needed on drain:
+	/// the exact-length gate in `message()` runs before `buffer_round3`, and
+	/// (unlike the Round 2 hash-binding check) it doesn't depend on state that
+	/// arrives later, so everything in the buffer already passed it.
 	fn process_buffered_round3(&mut self) {
 		let buffered = self.message_buffer.take_round3();
 		for r3 in buffered {
@@ -2087,8 +2132,11 @@ mod tests {
 		let _ = protocol.poke().unwrap();
 		assert!(matches!(protocol.state(), SignProtocolState::Round1Waiting));
 
-		// Simulate receiving a Round 3 message while still in Round 1
-		let r3 = Round3Broadcast::new(*protocol.ssid(), 1, vec![10, 20, 30, 40]);
+		// Simulate receiving a Round 3 message while still in Round 1. The
+		// response must be well-formed (exact per-session length) or the
+		// intake gate drops it before buffering.
+		let response_len = protocol.signer.config().k_iterations() as usize * L * POLYZ_PACKEDBYTES;
+		let r3 = Round3Broadcast::new(*protocol.ssid(), 1, vec![0x1A; response_len]);
 		let msg = SigningMessage::Round3(r3);
 		let data = protocol.serialize_message(&msg).unwrap();
 
@@ -2501,6 +2549,86 @@ mod tests {
 		assert!(
 			!protocol.r2_broadcasts.contains_key(&1),
 			"hash-bound but wrong-length Round 2 reveal must be dropped at intake"
+		);
+	}
+
+	/// A Round 3 response that is not exactly the size this session's
+	/// configuration produces (`k_iterations * L * POLYZ_PACKEDBYTES`, the
+	/// same bound `unpack_responses` enforces during `combine`) must be
+	/// dropped at intake. Accepted, it occupies the sender's first-wins r3
+	/// slot with data that is guaranteed to fail — but only inside the
+	/// leader's `combine`, where the failure is indistinguishable from an
+	/// ordinary rejection-sampling abort and can no longer be attributed to
+	/// the misbehaving sender.
+	#[test]
+	fn test_round3_with_wrong_length_response_is_dropped() {
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[42u8; 32], config).unwrap();
+
+		let signer = ThresholdSigner::new(shares[0].clone(), pk, config).unwrap();
+		let mut protocol = DilithiumSignProtocol::new(
+			signer,
+			b"test".to_vec(),
+			b"ctx".to_vec(),
+			vec![0, 1],
+			0,
+			[0xAA; 32],
+			[0xBB; 32], // attempt_nonce
+		)
+		.unwrap();
+
+		let _ = protocol.poke().unwrap();
+		let ssid = *protocol.ssid();
+		protocol.state = SignProtocolState::Round3Waiting;
+
+		let bad_r3 = Round3Broadcast::new(ssid, 1, vec![0xA5u8; 64]);
+		let msg = SigningMessage::Round3(bad_r3);
+		let data = protocol.serialize_message(&msg).unwrap();
+		protocol.message(1, data).unwrap();
+
+		assert!(
+			!protocol.r3_broadcasts.contains_key(&1),
+			"wrong-length Round 3 response must be dropped at intake, not left to fail combine"
+		);
+	}
+
+	/// The same exact-length gate must protect the early-round buffer path: a
+	/// wrong-length Round 3 arriving before this party reaches Round 3 must
+	/// not be buffered and later promoted into r3_broadcasts by
+	/// process_buffered_round3.
+	#[test]
+	fn test_round3_with_wrong_length_response_is_not_buffered() {
+		let config = ThresholdConfig::new(2, 3).unwrap();
+		let (pk, shares) = generate_with_dealer(&[42u8; 32], config).unwrap();
+
+		let signer = ThresholdSigner::new(shares[0].clone(), pk, config).unwrap();
+		let mut protocol = DilithiumSignProtocol::new(
+			signer,
+			b"test".to_vec(),
+			b"ctx".to_vec(),
+			vec![0, 1],
+			0,
+			[0xAA; 32],
+			[0xBB; 32], // attempt_nonce
+		)
+		.unwrap();
+
+		// In Round1Waiting, a well-formed Round 3 would be buffered for later.
+		let _ = protocol.poke().unwrap();
+		let ssid = *protocol.ssid();
+		let bad_r3 = Round3Broadcast::new(ssid, 1, vec![0xA5u8; 64]);
+		let msg = SigningMessage::Round3(bad_r3);
+		let data = protocol.serialize_message(&msg).unwrap();
+		protocol.message(1, data).unwrap();
+
+		assert!(
+			!protocol.message_buffer.round3.contains_key(&1),
+			"wrong-length Round 3 response must be rejected before buffering"
+		);
+		protocol.process_buffered_round3();
+		assert!(
+			!protocol.r3_broadcasts.contains_key(&1),
+			"wrong-length Round 3 response must never reach r3_broadcasts"
 		);
 	}
 

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -30,6 +30,33 @@
 //! NEAR MPC satisfies these requirements by generating `round1_seed` via `rand::random()` and
 //! using unique `ChannelId`s per attempt.
 //!
+//! # Transport Requirements (Caller Responsibility)
+//!
+//! This protocol carries **no per-frame authenticator** (no signature or MAC);
+//! like [`Dkg::message`](crate::keygen::dkg::Dkg::message), sender
+//! authentication is delegated to the transport (security review). The `from`
+//! argument to [`DilithiumSignProtocol::message`] is trusted: it MUST be the
+//! transport-authenticated identity of the sending peer, never derived from
+//! attacker-controllable packet contents. On such a transport the in-protocol
+//! `party_id == from` check completes the binding: a malicious participant
+//! cannot claim another participant's identity.
+//!
+//! On an **unauthenticated** transport the exposure is denial-of-signature,
+//! not forgery or secret loss: round buffers keep the first message received
+//! per sender (a replay/memory defense), so an injected frame that arrives
+//! before the honest one occupies that participant's slot and the honest
+//! frame is ignored. The forgery is caught by commit-reveal verification —
+//! commitments are hashes, reveals are checked against the Round 1 hashes
+//! frozen at Round 2, and followers verify the leader's final signature — but
+//! only as a late abort, so repeated injection denies completion. In-protocol
+//! authenticators are deliberately not used to plug this: signing parties
+//! share no suitable pairwise keys (and long-term share material must not
+//! double as transport keys), and an attacker positioned to inject frames on
+//! an unauthenticated transport can drop frames outright, so a MAC cannot
+//! restore liveness. (The DKG, by contrast, signs its transcript via
+//! `TranscriptSigner` because it establishes long-term keys; signing sessions
+//! are ephemeral and abort/retry, driven externally by the caller.)
+//!
 //! # No in-protocol retries
 //!
 //! Earlier revisions of this protocol included a `Round4Retry` message that allowed
@@ -1111,9 +1138,20 @@ impl DilithiumSignProtocol {
 	/// based on the message type. Messages from self, non-participants,
 	/// or in terminal states are ignored with `Ok(())`.
 	///
+	/// # Sender authentication contract
+	///
+	/// `from` is trusted: it MUST be the transport-authenticated identity of
+	/// the sending peer (e.g. the identity bound to an authenticated channel),
+	/// never a value read from the frame itself. The protocol verifies that
+	/// the payload's claimed `party_id` matches `from`, which is meaningful
+	/// only if `from` is authenticated — there is no per-frame signature or
+	/// MAC. See the module-level "Transport Requirements" section for what an
+	/// unauthenticated transport costs (denial-of-signature via first-write-
+	/// wins slot poisoning; never forgery or secret exposure).
+	///
 	/// # Arguments
 	///
-	/// * `from` - The participant ID that sent the message
+	/// * `from` - The transport-authenticated participant ID that sent the message
 	/// * `data` - The serialized message bytes
 	///
 	/// # Errors

--- a/threshold/src/signing_protocol.rs
+++ b/threshold/src/signing_protocol.rs
@@ -1285,10 +1285,12 @@ impl DilithiumSignProtocol {
 						SignProtocolState::Round3Waiting
 				) {
 					if !self.round2_matches_stored_round1(&r2) {
+						// Attribute to `from` (transport-authenticated), not
+						// `r2.party_id` (unauthenticated payload).
 						warn!(
 							"Signing: Rejecting Round 2 from party {} - commitment hash does not \
-							 match stored Round 1 (likely stale/replayed)",
-							r2.party_id
+							 match stored Round 1 (likely stale/replayed; payload claims party {})",
+							from, r2.party_id
 						);
 						return Ok(());
 					}
@@ -1313,11 +1315,14 @@ impl DilithiumSignProtocol {
 				// sender's first-wins slot (and the early-round buffer) and
 				// attributes the misbehavior to the sender at receive time.
 				if !self.round3_response_well_formed(&r3) {
+					// Attribute to `from` (transport-authenticated), not
+					// `r3.party_id` (unauthenticated payload).
 					warn!(
 						"Signing: Rejecting Round 3 from party {} - response length {} does not \
-						 match this session's expected share size",
-						r3.party_id,
-						r3.response.len()
+						 match this session's expected share size (payload claims party {})",
+						from,
+						r3.response.len(),
+						r3.party_id
 					);
 					return Ok(());
 				}

--- a/threshold/tests/common/mod.rs
+++ b/threshold/tests/common/mod.rs
@@ -2,9 +2,56 @@
 
 use std::collections::BTreeMap;
 
+use qp_rusty_crystals_dilithium::fips202;
 use qp_rusty_crystals_threshold::resharing::{
 	ResharingConfig, ResharingProtocol, ResharingSignerConfig, TranscriptSigner,
 };
+
+pub use qp_rusty_crystals_test_utils::{probe_stack_for, probe_stack_for_named};
+
+/// First 32 bytes of the SHAKE256 stream `sample_hyperball` squeezes for
+/// iteration 0 of `round1_commit_with_seed(ssid, seed)`. Recomputed through
+/// the public fips202 API (iteration 0 leaves the seed unmodified).
+pub fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, seed);
+	fips202::shake256_absorb(&mut state, ssid);
+	fips202::shake256_absorb(&mut state, b"rho_prime");
+	fips202::shake256_absorb(&mut state, &[0u8]);
+	fips202::shake256_finalize(&mut state);
+	let mut iter_rho_prime = [0u8; 64];
+	fips202::shake256_squeeze(&mut iter_rho_prime, &mut state);
+
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, b"H");
+	fips202::shake256_absorb(&mut state, &iter_rho_prime);
+	fips202::shake256_absorb(&mut state, &0u16.to_le_bytes());
+	fips202::shake256_finalize(&mut state);
+	let mut pattern = [0u8; 32];
+	fips202::shake256_squeeze(&mut pattern, &mut state);
+	pattern
+}
+
+/// The 32-byte per-party key seed the dealer squeezes for party 0, recomputed
+/// through the public fips202 API in the exact absorb/squeeze order of
+/// `generate_with_dealer`: absorb the dealer seed, `[K, L]`, and the `(t, n)`
+/// policy binding, then squeeze rho (public matrix seed, discarded) followed
+/// by party 0's key seed.
+pub fn dealer_party0_seed_pattern(seed: &[u8; 32], threshold: u32, parties: u32) -> [u8; 32] {
+	use qp_rusty_crystals_threshold::params::{K, L};
+
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, seed);
+	fips202::shake256_absorb(&mut state, &[K as u8, L as u8]);
+	fips202::shake256_absorb(&mut state, &threshold.to_le_bytes());
+	fips202::shake256_absorb(&mut state, &parties.to_le_bytes());
+	fips202::shake256_finalize(&mut state);
+	let mut rho = [0u8; 32];
+	fips202::shake256_squeeze(&mut rho, &mut state);
+	let mut key0 = [0u8; 32];
+	fips202::shake256_squeeze(&mut key0, &mut state);
+	key0
+}
 
 /// Minimal transcript signer for tests: "signature" = party_id || hash.
 ///

--- a/threshold/tests/common/mod.rs
+++ b/threshold/tests/common/mod.rs
@@ -1,57 +1,14 @@
 //! Shared test helpers for integration tests.
+//!
+//! Stack/heap secret-pattern helpers live in `stack_patterns.rs` and are
+//! pulled in only by the zeroization probes (via `#[path = ...]`), so this
+//! module stays free of items unused by resharing/coverage suites.
 
 use std::collections::BTreeMap;
 
-use qp_rusty_crystals_dilithium::fips202;
 use qp_rusty_crystals_threshold::resharing::{
 	ResharingConfig, ResharingProtocol, ResharingSignerConfig, TranscriptSigner,
 };
-
-pub use qp_rusty_crystals_test_utils::{probe_stack_for, probe_stack_for_named};
-
-/// First 32 bytes of the SHAKE256 stream `sample_hyperball` squeezes for
-/// iteration 0 of `round1_commit_with_seed(ssid, seed)`. Recomputed through
-/// the public fips202 API (iteration 0 leaves the seed unmodified).
-pub fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, seed);
-	fips202::shake256_absorb(&mut state, ssid);
-	fips202::shake256_absorb(&mut state, b"rho_prime");
-	fips202::shake256_absorb(&mut state, &[0u8]);
-	fips202::shake256_finalize(&mut state);
-	let mut iter_rho_prime = [0u8; 64];
-	fips202::shake256_squeeze(&mut iter_rho_prime, &mut state);
-
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, b"H");
-	fips202::shake256_absorb(&mut state, &iter_rho_prime);
-	fips202::shake256_absorb(&mut state, &0u16.to_le_bytes());
-	fips202::shake256_finalize(&mut state);
-	let mut pattern = [0u8; 32];
-	fips202::shake256_squeeze(&mut pattern, &mut state);
-	pattern
-}
-
-/// The 32-byte per-party key seed the dealer squeezes for party 0, recomputed
-/// through the public fips202 API in the exact absorb/squeeze order of
-/// `generate_with_dealer`: absorb the dealer seed, `[K, L]`, and the `(t, n)`
-/// policy binding, then squeeze rho (public matrix seed, discarded) followed
-/// by party 0's key seed.
-pub fn dealer_party0_seed_pattern(seed: &[u8; 32], threshold: u32, parties: u32) -> [u8; 32] {
-	use qp_rusty_crystals_threshold::params::{K, L};
-
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, seed);
-	fips202::shake256_absorb(&mut state, &[K as u8, L as u8]);
-	fips202::shake256_absorb(&mut state, &threshold.to_le_bytes());
-	fips202::shake256_absorb(&mut state, &parties.to_le_bytes());
-	fips202::shake256_finalize(&mut state);
-	let mut rho = [0u8; 32];
-	fips202::shake256_squeeze(&mut rho, &mut state);
-	let mut key0 = [0u8; 32];
-	fips202::shake256_squeeze(&mut key0, &mut state);
-	key0
-}
 
 /// Minimal transcript signer for tests: "signature" = party_id || hash.
 ///

--- a/threshold/tests/common/stack_patterns.rs
+++ b/threshold/tests/common/stack_patterns.rs
@@ -1,0 +1,50 @@
+//! Secret-pattern helpers shared by the heap and stack zeroization probes.
+//!
+//! Included only by those tests (via `#[path = ...]`), not by every consumer
+//! of `common/`, so resharing/coverage suites do not see unused items.
+
+use qp_rusty_crystals_dilithium::fips202;
+
+/// First 32 bytes of the SHAKE256 stream `sample_hyperball` squeezes for
+/// iteration 0 of `round1_commit_with_seed(ssid, seed)`. Recomputed through
+/// the public fips202 API (iteration 0 leaves the seed unmodified).
+pub fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, seed);
+	fips202::shake256_absorb(&mut state, ssid);
+	fips202::shake256_absorb(&mut state, b"rho_prime");
+	fips202::shake256_absorb(&mut state, &[0u8]);
+	fips202::shake256_finalize(&mut state);
+	let mut iter_rho_prime = [0u8; 64];
+	fips202::shake256_squeeze(&mut iter_rho_prime, &mut state);
+
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, b"H");
+	fips202::shake256_absorb(&mut state, &iter_rho_prime);
+	fips202::shake256_absorb(&mut state, &0u16.to_le_bytes());
+	fips202::shake256_finalize(&mut state);
+	let mut pattern = [0u8; 32];
+	fips202::shake256_squeeze(&mut pattern, &mut state);
+	pattern
+}
+
+/// The 32-byte per-party key seed the dealer squeezes for party 0, recomputed
+/// through the public fips202 API in the exact absorb/squeeze order of
+/// `generate_with_dealer`: absorb the dealer seed, `[K, L]`, and the `(t, n)`
+/// policy binding, then squeeze rho (public matrix seed, discarded) followed
+/// by party 0's key seed.
+pub fn dealer_party0_seed_pattern(seed: &[u8; 32], threshold: u32, parties: u32) -> [u8; 32] {
+	use qp_rusty_crystals_threshold::params::{K, L};
+
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, seed);
+	fips202::shake256_absorb(&mut state, &[K as u8, L as u8]);
+	fips202::shake256_absorb(&mut state, &threshold.to_le_bytes());
+	fips202::shake256_absorb(&mut state, &parties.to_le_bytes());
+	fips202::shake256_finalize(&mut state);
+	let mut rho = [0u8; 32];
+	fips202::shake256_squeeze(&mut rho, &mut state);
+	let mut key0 = [0u8; 32];
+	fips202::shake256_squeeze(&mut key0, &mut state);
+	key0
+}

--- a/threshold/tests/dealer_stack_zeroization.rs
+++ b/threshold/tests/dealer_stack_zeroization.rs
@@ -1,0 +1,116 @@
+//! Regression test (security review): the trusted-dealer keygen must not
+//! leave plaintext copies of per-party key seeds in dead stack memory.
+//!
+//! The companion heap test (`heap_zeroization.rs`) catches secret-bearing
+//! heap blocks freed unwiped, but cannot see stack residue. This probe covers
+//! the stack side of the same dealer findings: `generate_with_dealer` squeezes
+//! each party's 32-byte key seed, holds the set in a `Zeroizing` vector, and
+//! copies one seed into each `PrivateKeyShare` — every one of those copies
+//! passes through stack temporaries (the squeeze-loop local, the by-value
+//! argument to `PrivateKeyShare::new`, compiler spills) that no drop reaches
+//! if codegen fails to elide them.
+//!
+//! Detection uses the same painted-stack technique as dilithium's
+//! `import_stack_zeroization` test: run the operation on a dedicated
+//! sentinel-painted buffer via `psm::on_stack`, then scan the buffer — which
+//! we own, so the read is sound — for party 0's key seed. The seed is
+//! high-entropy XOF output and deterministically recomputable through the
+//! public fips202 API, so the scan cannot false-positive on unrelated memory
+//! (unlike the small-valued share coefficients, which make poor scan targets).
+//! The scenario closure captures only the dealer input seed, never the
+//! pattern, so the probe machinery itself cannot plant a match.
+//!
+//! Only compiled for optimized builds (`cargo test --release`): unoptimized
+//! codegen materializes additional compiler-generated move temporaries for
+//! large by-value structs which no source-level fix can wipe, so a zero-copy
+//! assertion is only meaningful once those are elided.
+#![cfg(not(debug_assertions))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+use qp_rusty_crystals_dilithium::fips202;
+use qp_rusty_crystals_threshold::{generate_with_dealer, ThresholdConfig};
+use zeroize::Zeroize;
+
+const PAINT: u8 = 0xAA;
+// 4 MiB: comfortably above the dealer's frame (matrix A alone is K x L
+// polynomials, ~57 KiB, plus the polyvec locals).
+const STACK_BYTES: usize = 4 * 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// The 32-byte per-party key seed the dealer squeezes for party 0, recomputed
+/// through the public fips202 API in the exact absorb/squeeze order of
+/// `generate_with_dealer`: absorb the dealer seed, `[K, L]`, and the `(t, n)`
+/// policy binding, then squeeze rho (public matrix seed, discarded) followed
+/// by party 0's key seed.
+fn dealer_party0_seed_pattern(seed: &[u8; 32], threshold: u32, parties: u32) -> [u8; 32] {
+	use qp_rusty_crystals_threshold::params::{K, L};
+
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, seed);
+	fips202::shake256_absorb(&mut state, &[K as u8, L as u8]);
+	fips202::shake256_absorb(&mut state, &threshold.to_le_bytes());
+	fips202::shake256_absorb(&mut state, &parties.to_le_bytes());
+	fips202::shake256_finalize(&mut state);
+	let mut rho = [0u8; 32];
+	fips202::shake256_squeeze(&mut rho, &mut state);
+	let mut key0 = [0u8; 32];
+	fips202::shake256_squeeze(&mut key0, &mut state);
+	key0
+}
+
+#[test]
+fn dealer_keygen_leaves_no_party_seed_copies_on_the_stack() {
+	let dealer_seed = [0x2Du8; 32];
+	let pattern = dealer_party0_seed_pattern(&dealer_seed, 2, 3);
+
+	// Sanity: the technique detects an unwiped copy. A closure that
+	// deliberately leaves the seed in a dead stack frame must be seen.
+	assert!(
+		probe_stack_for(&pattern, || {
+			let leaked: [u8; 32] = pattern;
+			core::hint::black_box(&leaked);
+		}),
+		"probe self-check: a deliberately leaked stack copy was not detected"
+	);
+
+	// Real scenario: full dealer keygen. The returned shares hold the only
+	// legitimate copies of the seeds; they live in the Vec's heap buffer and
+	// are wiped in place through a reference (so the probe itself never moves
+	// a secret and cannot smear its own copies around). Anything left in the
+	// painted region afterwards is a stack copy the dealer failed to wipe.
+	let leaked = probe_stack_for(&pattern, || {
+		let config = ThresholdConfig::new(2, 3).expect("valid config");
+		let (_pk, mut shares) =
+			generate_with_dealer(&dealer_seed, config).expect("keygen succeeds");
+		for share in shares.iter_mut() {
+			share.zeroize();
+		}
+	});
+	assert!(!leaked, "generate_with_dealer left a plaintext per-party key seed in stack memory");
+}

--- a/threshold/tests/dealer_stack_zeroization.rs
+++ b/threshold/tests/dealer_stack_zeroization.rs
@@ -26,63 +26,16 @@
 //! assertion is only meaningful once those are elided.
 #![cfg(not(debug_assertions))]
 
-use std::alloc::{alloc, dealloc, Layout};
+mod common;
 
-use qp_rusty_crystals_dilithium::fips202;
 use qp_rusty_crystals_threshold::{generate_with_dealer, ThresholdConfig};
 use zeroize::Zeroize;
 
-const PAINT: u8 = 0xAA;
+use common::{dealer_party0_seed_pattern, probe_stack_for};
+
 // 4 MiB: comfortably above the dealer's frame (matrix A alone is K x L
 // polynomials, ~57 KiB, plus the polyvec locals).
 const STACK_BYTES: usize = 4 * 1024 * 1024;
-const ALIGN: usize = 4096;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| w == pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
-
-/// The 32-byte per-party key seed the dealer squeezes for party 0, recomputed
-/// through the public fips202 API in the exact absorb/squeeze order of
-/// `generate_with_dealer`: absorb the dealer seed, `[K, L]`, and the `(t, n)`
-/// policy binding, then squeeze rho (public matrix seed, discarded) followed
-/// by party 0's key seed.
-fn dealer_party0_seed_pattern(seed: &[u8; 32], threshold: u32, parties: u32) -> [u8; 32] {
-	use qp_rusty_crystals_threshold::params::{K, L};
-
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, seed);
-	fips202::shake256_absorb(&mut state, &[K as u8, L as u8]);
-	fips202::shake256_absorb(&mut state, &threshold.to_le_bytes());
-	fips202::shake256_absorb(&mut state, &parties.to_le_bytes());
-	fips202::shake256_finalize(&mut state);
-	let mut rho = [0u8; 32];
-	fips202::shake256_squeeze(&mut rho, &mut state);
-	let mut key0 = [0u8; 32];
-	fips202::shake256_squeeze(&mut key0, &mut state);
-	key0
-}
 
 #[test]
 fn dealer_keygen_leaves_no_party_seed_copies_on_the_stack() {
@@ -92,7 +45,7 @@ fn dealer_keygen_leaves_no_party_seed_copies_on_the_stack() {
 	// Sanity: the technique detects an unwiped copy. A closure that
 	// deliberately leaves the seed in a dead stack frame must be seen.
 	assert!(
-		probe_stack_for(&pattern, || {
+		probe_stack_for(STACK_BYTES, &pattern, || {
 			let leaked: [u8; 32] = pattern;
 			core::hint::black_box(&leaked);
 		}),
@@ -104,7 +57,7 @@ fn dealer_keygen_leaves_no_party_seed_copies_on_the_stack() {
 	// are wiped in place through a reference (so the probe itself never moves
 	// a secret and cannot smear its own copies around). Anything left in the
 	// painted region afterwards is a stack copy the dealer failed to wipe.
-	let leaked = probe_stack_for(&pattern, || {
+	let leaked = probe_stack_for(STACK_BYTES, &pattern, || {
 		let config = ThresholdConfig::new(2, 3).expect("valid config");
 		let (_pk, mut shares) =
 			generate_with_dealer(&dealer_seed, config).expect("keygen succeeds");

--- a/threshold/tests/dealer_stack_zeroization.rs
+++ b/threshold/tests/dealer_stack_zeroization.rs
@@ -26,12 +26,13 @@
 //! assertion is only meaningful once those are elided.
 #![cfg(not(debug_assertions))]
 
-mod common;
+#[path = "common/stack_patterns.rs"]
+mod stack_patterns;
 
+use qp_rusty_crystals_test_utils::probe_stack_for;
 use qp_rusty_crystals_threshold::{generate_with_dealer, ThresholdConfig};
+use stack_patterns::dealer_party0_seed_pattern;
 use zeroize::Zeroize;
-
-use common::{dealer_party0_seed_pattern, probe_stack_for};
 
 // 4 MiB: comfortably above the dealer's frame (matrix A alone is K x L
 // polynomials, ~57 KiB, plus the polyvec locals).

--- a/threshold/tests/dkg_stack_zeroization.rs
+++ b/threshold/tests/dkg_stack_zeroization.rs
@@ -24,46 +24,20 @@
 //! assertion is only meaningful once those are elided.
 #![cfg(not(debug_assertions))]
 
-use std::{
-	alloc::{alloc, dealloc, Layout},
-	collections::BTreeMap,
-};
+mod common;
+
+use std::collections::BTreeMap;
 
 use qp_rusty_crystals_threshold::{
 	keygen::dkg::{Dkg, DkgAction, DkgConfig, TranscriptSigner},
 	ThresholdConfig,
 };
 
-const PAINT: u8 = 0xAA;
+use common::probe_stack_for;
+
 // 16 MiB: the DKG state machine drives keygen-scale work (K x L matrix
 // expansion, NTT chains) for three parties plus serialization buffers.
 const STACK_BYTES: usize = 16 * 1024 * 1024;
-const ALIGN: usize = 4096;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| w == pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
 
 /// Simple test signer for DKG transcript signing.
 #[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
@@ -185,7 +159,7 @@ fn dkg_leaves_no_shared_secret_copies_on_the_stack() {
 	// Sanity: the technique detects an unwiped copy. A closure that
 	// deliberately leaves K_S in a dead stack frame must be seen.
 	assert!(
-		probe_stack_for(&pattern, || {
+		probe_stack_for(STACK_BYTES, &pattern, || {
 			let leaked: [u8; 32] = pattern;
 			core::hint::black_box(&leaked);
 		}),
@@ -196,7 +170,7 @@ fn dkg_leaves_no_shared_secret_copies_on_the_stack() {
 	// stack. Every legitimate copy of K_S lives in heap-backed state that
 	// is wiped on drop (verified by heap_zeroization); anything left in the
 	// painted region is a stack copy the protocol failed to wipe.
-	let leaked = probe_stack_for(&pattern, || {
+	let leaked = probe_stack_for(STACK_BYTES, &pattern, || {
 		let _ = run_local_dkg_2of3(false);
 	});
 	assert!(!leaked, "the DKG left a plaintext subset shared secret K_S in stack memory");

--- a/threshold/tests/dkg_stack_zeroization.rs
+++ b/threshold/tests/dkg_stack_zeroization.rs
@@ -1,0 +1,203 @@
+//! Regression test (security review): a full DKG run must not leave plaintext
+//! copies of subset shared secrets K_S in dead stack memory.
+//!
+//! The companion heap test (`heap_zeroization.rs`) catches secret-bearing
+//! heap blocks freed unwiped (transport frames, map nodes, queue buffers);
+//! this probe covers the stack side. K_S is a `Copy` `[u8; 32]`, so it is
+//! duplicated onto the stack every time it is squeezed, looked up out of a
+//! map (`let Some(&shared_secret) = ...`), passed by value, or folded into a
+//! derivation — copies that no drop reaches if codegen fails to elide them.
+//!
+//! Detection uses the same painted-stack technique as the dealer probe: run
+//! all three parties of a deterministic 2-of-3 DKG to completion on a
+//! sentinel-painted stack via `psm::on_stack`, then scan the buffer — which
+//! we own, so the read is sound — for a K_S learned from an identical,
+//! unprobed first run (all randomness is SHAKE-derived from fixed per-party
+//! seeds and a fixed session nonce, so the two runs produce byte-identical
+//! secrets). The probed run never extracts K_S in harness code — capture is
+//! compiled in only for the reference run — so the probe machinery cannot
+//! plant a match itself.
+//!
+//! Only compiled for optimized builds (`cargo test --release`): unoptimized
+//! codegen materializes additional compiler-generated move temporaries for
+//! large by-value structs which no source-level fix can wipe, so a zero-copy
+//! assertion is only meaningful once those are elided.
+#![cfg(not(debug_assertions))]
+
+use std::{
+	alloc::{alloc, dealloc, Layout},
+	collections::BTreeMap,
+};
+
+use qp_rusty_crystals_threshold::{
+	keygen::dkg::{Dkg, DkgAction, DkgConfig, TranscriptSigner},
+	ThresholdConfig,
+};
+
+const PAINT: u8 = 0xAA;
+// 16 MiB: the DKG state machine drives keygen-scale work (K x L matrix
+// expansion, NTT chains) for three parties plus serialization buffers.
+const STACK_BYTES: usize = 16 * 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// Simple test signer for DKG transcript signing.
+#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
+struct TestSigner {
+	id: u32,
+}
+
+impl TranscriptSigner for TestSigner {
+	type Signature = Vec<u8>;
+	type PublicKey = u32;
+
+	fn sign(&self, hash: &[u8; 32]) -> Self::Signature {
+		let mut sig = vec![0u8; 36];
+		sig[..4].copy_from_slice(&self.id.to_le_bytes());
+		sig[4..36].copy_from_slice(hash);
+		sig
+	}
+
+	fn verify(pk: &Self::PublicKey, hash: &[u8; 32], sig: &Self::Signature) -> bool {
+		Self::verify_bytes(pk, hash, sig)
+	}
+
+	fn verify_bytes(pk: &Self::PublicKey, hash: &[u8; 32], sig: &[u8]) -> bool {
+		if sig.len() < 36 {
+			return false;
+		}
+		let sig_id = u32::from_le_bytes(sig[..4].try_into().unwrap());
+		sig_id == *pk && &sig[4..36] == hash
+	}
+
+	fn public_key(&self) -> Self::PublicKey {
+		self.id
+	}
+}
+
+/// Run a deterministic 2-of-3 DKG among three in-process parties. All
+/// randomness is SHAKE-derived from the fixed per-party seeds and session
+/// nonce, so every invocation produces byte-identical secrets and frames.
+///
+/// With `capture` set, returns a subset shared secret K_S — the last 32
+/// bytes of the first Round 1 private frame (a subset leader delivering K_S
+/// to the other member of a size-2 subset). With `capture` unset, no harness
+/// code ever touches secret frame bytes, so the run is safe to execute
+/// inside the painted-stack probe without planting the pattern itself.
+fn run_local_dkg_2of3(capture: bool) -> Option<[u8; 32]> {
+	let threshold_config = ThresholdConfig::new(2, 3).expect("valid config");
+	let participants: Vec<u32> = vec![0, 1, 2];
+	let pk_map: BTreeMap<u32, u32> = participants.iter().map(|&p| (p, p)).collect();
+	let session_nonce = [0x3Eu8; 32];
+
+	let mut dkgs: Vec<_> = participants
+		.iter()
+		.map(|&party_id| {
+			let config = DkgConfig::new(
+				threshold_config,
+				party_id,
+				participants.clone(),
+				TestSigner { id: party_id },
+				pk_map.clone(),
+			)
+			.expect("valid DKG config");
+			let mut seed = [0x90u8; 32];
+			seed[0] = party_id as u8;
+			Dkg::new(config, seed, &session_nonce)
+		})
+		.collect();
+
+	let mut queues: Vec<Vec<(u32, Vec<u8>)>> = vec![Vec::new(); participants.len()];
+	let mut ks_tail: Option<[u8; 32]> = None;
+	let mut done = vec![false; participants.len()];
+	for _ in 0..1000 {
+		if done.iter().all(|&d| d) {
+			break;
+		}
+		for i in 0..dkgs.len() {
+			if done[i] {
+				continue;
+			}
+			for (from, data) in std::mem::take(&mut queues[i]) {
+				dkgs[i].message(from, data).expect("message is processed");
+			}
+			match dkgs[i].poke().expect("poke succeeds") {
+				DkgAction::Wait => {},
+				DkgAction::SendMany(data) =>
+					for (j, queue) in queues.iter_mut().enumerate() {
+						if j != i {
+							queue.push((i as u32, data.clone()));
+						}
+					},
+				DkgAction::SendPrivate(to, mut data) => {
+					// Round 1 private frames carry K_S; the serialized tail
+					// is the secret itself. Only the reference run extracts
+					// it — the probed run must never copy secret bytes into
+					// harness stack frames.
+					if capture && ks_tail.is_none() && data.len() >= 32 {
+						ks_tail = Some(data[data.len() - 32..].try_into().unwrap());
+					}
+					queues[to as usize].push((i as u32, std::mem::take(&mut *data)));
+				},
+				DkgAction::Return(_output) => {
+					done[i] = true;
+				},
+			}
+		}
+	}
+	assert!(done.iter().all(|&d| d), "DKG must complete");
+	if capture {
+		Some(ks_tail.expect("a Round 1 private frame was exchanged"))
+	} else {
+		None
+	}
+}
+
+#[test]
+fn dkg_leaves_no_shared_secret_copies_on_the_stack() {
+	// Reference run (unprobed): learn the K_S the probed run must wipe.
+	let pattern = run_local_dkg_2of3(true).expect("reference run captures K_S");
+
+	// Sanity: the technique detects an unwiped copy. A closure that
+	// deliberately leaves K_S in a dead stack frame must be seen.
+	assert!(
+		probe_stack_for(&pattern, || {
+			let leaked: [u8; 32] = pattern;
+			core::hint::black_box(&leaked);
+		}),
+		"probe self-check: a deliberately leaked stack copy was not detected"
+	);
+
+	// Real scenario: the identical DKG run, end to end, on the painted
+	// stack. Every legitimate copy of K_S lives in heap-backed state that
+	// is wiped on drop (verified by heap_zeroization); anything left in the
+	// painted region is a stack copy the protocol failed to wipe.
+	let leaked = probe_stack_for(&pattern, || {
+		let _ = run_local_dkg_2of3(false);
+	});
+	assert!(!leaked, "the DKG left a plaintext subset shared secret K_S in stack memory");
+}

--- a/threshold/tests/dkg_stack_zeroization.rs
+++ b/threshold/tests/dkg_stack_zeroization.rs
@@ -24,16 +24,13 @@
 //! assertion is only meaningful once those are elided.
 #![cfg(not(debug_assertions))]
 
-mod common;
-
 use std::collections::BTreeMap;
 
+use qp_rusty_crystals_test_utils::probe_stack_for;
 use qp_rusty_crystals_threshold::{
 	keygen::dkg::{Dkg, DkgAction, DkgConfig, TranscriptSigner},
 	ThresholdConfig,
 };
-
-use common::probe_stack_for;
 
 // 16 MiB: the DKG state machine drives keygen-scale work (K x L matrix
 // expansion, NTT chains) for three parties plus serialization buffers.

--- a/threshold/tests/heap_zeroization.rs
+++ b/threshold/tests/heap_zeroization.rs
@@ -28,7 +28,6 @@ use std::{
 	sync::Mutex,
 };
 
-use qp_rusty_crystals_dilithium::fips202;
 use qp_rusty_crystals_threshold::{
 	derive_dkg_contribution, generate_with_dealer,
 	keygen::dkg::{
@@ -39,6 +38,7 @@ use qp_rusty_crystals_threshold::{
 };
 
 mod common;
+use common::{dealer_party0_seed_pattern, hyperball_stream_pattern};
 
 /// The 32-byte pattern the allocator currently scans for. Updated between
 /// scenarios (only while scanning is off, so `try_lock` in the hook never
@@ -144,51 +144,6 @@ fn share_with_planted_coefficients() -> PrivateKeyShare {
 	let tail = blob.len() - 32;
 	blob[tail..].copy_from_slice(&share_coefficient_pattern());
 	borsh::from_slice(&blob).expect("planted share re-imports")
-}
-
-/// First 32 bytes of the SHAKE256 stream `sample_hyperball` squeezes into its
-/// scratch buffer for iteration 0 of `round1_commit_with_seed(ssid, seed)`.
-/// Recomputed here through the public fips202 API, mirroring the derivation in
-/// `protocol/signing.rs` (iteration 0 leaves the seed unmodified).
-fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, seed);
-	fips202::shake256_absorb(&mut state, ssid);
-	fips202::shake256_absorb(&mut state, b"rho_prime");
-	fips202::shake256_absorb(&mut state, &[0u8]);
-	fips202::shake256_finalize(&mut state);
-	let mut iter_rho_prime = [0u8; 64];
-	fips202::shake256_squeeze(&mut iter_rho_prime, &mut state);
-
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, b"H");
-	fips202::shake256_absorb(&mut state, &iter_rho_prime);
-	fips202::shake256_absorb(&mut state, &0u16.to_le_bytes());
-	fips202::shake256_finalize(&mut state);
-	let mut pattern = [0u8; 32];
-	fips202::shake256_squeeze(&mut pattern, &mut state);
-	pattern
-}
-
-/// The 32-byte per-party key seed the dealer squeezes for party 0, recomputed
-/// through the public fips202 API in the exact absorb/squeeze order of
-/// `generate_with_dealer`: absorb the dealer seed, `[K, L]`, and the `(t, n)`
-/// policy binding, then squeeze rho (public matrix seed, discarded) followed
-/// by party 0's key seed.
-fn dealer_party0_seed_pattern(seed: &[u8; 32], threshold: u32, parties: u32) -> [u8; 32] {
-	use qp_rusty_crystals_threshold::params::{K, L};
-
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, seed);
-	fips202::shake256_absorb(&mut state, &[K as u8, L as u8]);
-	fips202::shake256_absorb(&mut state, &threshold.to_le_bytes());
-	fips202::shake256_absorb(&mut state, &parties.to_le_bytes());
-	fips202::shake256_finalize(&mut state);
-	let mut rho = [0u8; 32];
-	fips202::shake256_squeeze(&mut rho, &mut state);
-	let mut key0 = [0u8; 32];
-	fips202::shake256_squeeze(&mut key0, &mut state);
-	key0
 }
 
 /// Run a deterministic 2-of-2 -> 2-of-2 resharing locally and return the new

--- a/threshold/tests/heap_zeroization.rs
+++ b/threshold/tests/heap_zeroization.rs
@@ -170,6 +170,27 @@ fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
 	pattern
 }
 
+/// The 32-byte per-party key seed the dealer squeezes for party 0, recomputed
+/// through the public fips202 API in the exact absorb/squeeze order of
+/// `generate_with_dealer`: absorb the dealer seed, `[K, L]`, and the `(t, n)`
+/// policy binding, then squeeze rho (public matrix seed, discarded) followed
+/// by party 0's key seed.
+fn dealer_party0_seed_pattern(seed: &[u8; 32], threshold: u32, parties: u32) -> [u8; 32] {
+	use qp_rusty_crystals_threshold::params::{K, L};
+
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, seed);
+	fips202::shake256_absorb(&mut state, &[K as u8, L as u8]);
+	fips202::shake256_absorb(&mut state, &threshold.to_le_bytes());
+	fips202::shake256_absorb(&mut state, &parties.to_le_bytes());
+	fips202::shake256_finalize(&mut state);
+	let mut rho = [0u8; 32];
+	fips202::shake256_squeeze(&mut rho, &mut state);
+	let mut key0 = [0u8; 32];
+	fips202::shake256_squeeze(&mut key0, &mut state);
+	key0
+}
+
 /// Run a deterministic 2-of-2 -> 2-of-2 resharing locally and return the new
 /// share of party 0 plus the last 32 bytes of the first Round 4 transport
 /// frame (raw sub-share s2 coefficients). All seeds are fixed, and the leader
@@ -447,6 +468,27 @@ fn secret_intermediates_are_wiped_before_their_heap_memory_is_freed() {
 		dkg_ks_pattern,
 		|| {
 			let _ = run_local_dkg_2of3();
+		},
+	);
+
+	// Scenario 7: dealer per-party key seeds (party_keys Vec).
+	// generate_with_dealer squeezes each party's 32-byte key seed into a
+	// Vec<[u8; 32]> and copies one into each returned PrivateKeyShare. The
+	// returned shares wipe their copy on drop, but the dealer-side Vec used
+	// to be a plain vector freed unwiped at function return, leaving every
+	// party's seed in allocator memory — contradicting the dealer's
+	// documented obligation to delete all distributed secret material. The
+	// derivation is deterministic, so the pattern (party 0's seed) is
+	// recomputed independently through the public XOF API.
+	let dealer_seed = [0x64u8; 32];
+	assert_no_secret_bearing_free(
+		"generate_with_dealer (party_keys buffer)",
+		dealer_party0_seed_pattern(&dealer_seed, 2, 3),
+		|| {
+			let config = ThresholdConfig::new(2, 3).expect("valid config");
+			let (_pk, shares) =
+				generate_with_dealer(&dealer_seed, config).expect("keygen succeeds");
+			drop(shares);
 		},
 	);
 }

--- a/threshold/tests/heap_zeroization.rs
+++ b/threshold/tests/heap_zeroization.rs
@@ -38,7 +38,9 @@ use qp_rusty_crystals_threshold::{
 };
 
 mod common;
-use common::{dealer_party0_seed_pattern, hyperball_stream_pattern};
+#[path = "common/stack_patterns.rs"]
+mod stack_patterns;
+use stack_patterns::{dealer_party0_seed_pattern, hyperball_stream_pattern};
 
 /// The 32-byte pattern the allocator currently scans for. Updated between
 /// scenarios (only while scanning is off, so `try_lock` in the hook never

--- a/threshold/tests/signing_stack_zeroization.rs
+++ b/threshold/tests/signing_stack_zeroization.rs
@@ -26,65 +26,15 @@
 //! assertion is only meaningful once those are elided.
 #![cfg(not(debug_assertions))]
 
-use std::alloc::{alloc, dealloc, Layout};
+mod common;
 
-use qp_rusty_crystals_dilithium::fips202;
 use qp_rusty_crystals_threshold::{generate_with_dealer, ThresholdConfig, ThresholdSigner};
 
-const PAINT: u8 = 0xAA;
+use common::{hyperball_stream_pattern, probe_stack_for};
+
 // 16 MiB: Round 1 drives hyperball rejection sampling across all commitment
 // iterations plus the packing of the commitment hash input.
 const STACK_BYTES: usize = 16 * 1024 * 1024;
-const ALIGN: usize = 4096;
-
-/// Run `f` on a freshly painted stack buffer, then scan the buffer for
-/// `pattern` and return whether it was found.
-fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
-	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
-	unsafe {
-		let base = alloc(layout);
-		assert!(!base.is_null(), "probe stack allocation failed");
-		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
-
-		psm::on_stack(base, STACK_BYTES, f);
-
-		let region = std::slice::from_raw_parts(base, STACK_BYTES);
-		let offsets: Vec<usize> = region
-			.windows(pattern.len())
-			.enumerate()
-			.filter(|(_, w)| w == pattern)
-			.map(|(i, _)| i)
-			.collect();
-		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
-		let found = !offsets.is_empty();
-		dealloc(base, layout);
-		found
-	}
-}
-
-/// First 32 bytes of the SHAKE256 stream `sample_hyperball` squeezes for
-/// iteration 0 of `round1_commit_with_seed(ssid, seed)`. Recomputed here
-/// through the public fips202 API, mirroring the derivation in
-/// `protocol/signing.rs` (iteration 0 leaves the seed unmodified).
-fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, seed);
-	fips202::shake256_absorb(&mut state, ssid);
-	fips202::shake256_absorb(&mut state, b"rho_prime");
-	fips202::shake256_absorb(&mut state, &[0u8]);
-	fips202::shake256_finalize(&mut state);
-	let mut iter_rho_prime = [0u8; 64];
-	fips202::shake256_squeeze(&mut iter_rho_prime, &mut state);
-
-	let mut state = fips202::KeccakState::default();
-	fips202::shake256_absorb(&mut state, b"H");
-	fips202::shake256_absorb(&mut state, &iter_rho_prime);
-	fips202::shake256_absorb(&mut state, &0u16.to_le_bytes());
-	fips202::shake256_finalize(&mut state);
-	let mut pattern = [0u8; 32];
-	fips202::shake256_squeeze(&mut pattern, &mut state);
-	pattern
-}
 
 #[test]
 fn round1_leaves_no_mask_stream_copies_on_the_stack() {
@@ -100,7 +50,7 @@ fn round1_leaves_no_mask_stream_copies_on_the_stack() {
 	// deliberately leaves the stream prefix in a dead stack frame must be
 	// seen.
 	assert!(
-		probe_stack_for(&pattern, || {
+		probe_stack_for(STACK_BYTES, &pattern, || {
 			let leaked: [u8; 32] = pattern;
 			core::hint::black_box(&leaked);
 		}),
@@ -111,7 +61,7 @@ fn round1_leaves_no_mask_stream_copies_on_the_stack() {
 	// samples is retained (in zeroizing state) for the later rounds; the raw
 	// stream the sampler consumed must not survive anywhere in the frames
 	// Round 1 used.
-	let leaked = probe_stack_for(&pattern, || {
+	let leaked = probe_stack_for(STACK_BYTES, &pattern, || {
 		signer
 			.round1_commit_with_seed(&sign_ssid, &round1_seed)
 			.expect("round 1 commit succeeds");

--- a/threshold/tests/signing_stack_zeroization.rs
+++ b/threshold/tests/signing_stack_zeroization.rs
@@ -1,0 +1,120 @@
+//! Regression test (security review): threshold signing must not leave the
+//! per-signature mask randomness in dead stack memory.
+//!
+//! Round 1 (`round1_commit_with_seed`) squeezes a SHAKE stream and rejection-
+//! samples it into the hyperball mask y. That raw stream is the most
+//! dangerous transient in the whole signing flow: y itself never leaves the
+//! signer, but the Round 3 response z = y + c*s is published, so anyone who
+//! recovers y from process memory recovers the secret share s. The stream's
+//! raw bytes exist only during Round 1 sampling — later rounds handle y and s
+//! in coefficient form inside `ZeroizeOnDrop` polyvecs — so Round 1 is where
+//! stack residue of this secret can occur, and what this probe targets. The
+//! companion heap test (`heap_zeroization.rs`, scenario 3) covers the same
+//! stream's heap-side scratch buffer.
+//!
+//! Detection uses the same painted-stack technique as the dealer and DKG
+//! probes: run Round 1 on a sentinel-painted stack via `psm::on_stack`, then
+//! scan the buffer — which we own, so the read is sound — for the first 32
+//! bytes of the iteration-0 mask stream, recomputed independently through the
+//! public fips202 API. The signer is constructed outside the probe and the
+//! scenario closure captures only references, so the probe machinery cannot
+//! plant the pattern itself.
+//!
+//! Only compiled for optimized builds (`cargo test --release`): unoptimized
+//! codegen materializes additional compiler-generated move temporaries for
+//! large by-value structs which no source-level fix can wipe, so a zero-copy
+//! assertion is only meaningful once those are elided.
+#![cfg(not(debug_assertions))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+use qp_rusty_crystals_dilithium::fips202;
+use qp_rusty_crystals_threshold::{generate_with_dealer, ThresholdConfig, ThresholdSigner};
+
+const PAINT: u8 = 0xAA;
+// 16 MiB: Round 1 drives hyperball rejection sampling across all commitment
+// iterations plus the packing of the commitment hash input.
+const STACK_BYTES: usize = 16 * 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8; 32], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// First 32 bytes of the SHAKE256 stream `sample_hyperball` squeezes for
+/// iteration 0 of `round1_commit_with_seed(ssid, seed)`. Recomputed here
+/// through the public fips202 API, mirroring the derivation in
+/// `protocol/signing.rs` (iteration 0 leaves the seed unmodified).
+fn hyperball_stream_pattern(ssid: &[u8; 32], seed: &[u8; 32]) -> [u8; 32] {
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, seed);
+	fips202::shake256_absorb(&mut state, ssid);
+	fips202::shake256_absorb(&mut state, b"rho_prime");
+	fips202::shake256_absorb(&mut state, &[0u8]);
+	fips202::shake256_finalize(&mut state);
+	let mut iter_rho_prime = [0u8; 64];
+	fips202::shake256_squeeze(&mut iter_rho_prime, &mut state);
+
+	let mut state = fips202::KeccakState::default();
+	fips202::shake256_absorb(&mut state, b"H");
+	fips202::shake256_absorb(&mut state, &iter_rho_prime);
+	fips202::shake256_absorb(&mut state, &0u16.to_le_bytes());
+	fips202::shake256_finalize(&mut state);
+	let mut pattern = [0u8; 32];
+	fips202::shake256_squeeze(&mut pattern, &mut state);
+	pattern
+}
+
+#[test]
+fn round1_leaves_no_mask_stream_copies_on_the_stack() {
+	let config = ThresholdConfig::new(2, 3).expect("valid config");
+	let (pk, shares) = generate_with_dealer(&[7u8; 32], config).expect("keygen succeeds");
+	let mut signer =
+		ThresholdSigner::new(shares.into_iter().next().unwrap(), pk, config).expect("signer");
+	let sign_ssid = [0x5Cu8; 32];
+	let round1_seed = [0x33u8; 32];
+	let pattern = hyperball_stream_pattern(&sign_ssid, &round1_seed);
+
+	// Sanity: the technique detects an unwiped copy. A closure that
+	// deliberately leaves the stream prefix in a dead stack frame must be
+	// seen.
+	assert!(
+		probe_stack_for(&pattern, || {
+			let leaked: [u8; 32] = pattern;
+			core::hint::black_box(&leaked);
+		}),
+		"probe self-check: a deliberately leaked stack copy was not detected"
+	);
+
+	// Real scenario: Round 1 commitment on the painted stack. The mask y it
+	// samples is retained (in zeroizing state) for the later rounds; the raw
+	// stream the sampler consumed must not survive anywhere in the frames
+	// Round 1 used.
+	let leaked = probe_stack_for(&pattern, || {
+		signer
+			.round1_commit_with_seed(&sign_ssid, &round1_seed)
+			.expect("round 1 commit succeeds");
+	});
+	assert!(!leaked, "round 1 left the raw mask stream in stack memory");
+}

--- a/threshold/tests/signing_stack_zeroization.rs
+++ b/threshold/tests/signing_stack_zeroization.rs
@@ -26,11 +26,12 @@
 //! assertion is only meaningful once those are elided.
 #![cfg(not(debug_assertions))]
 
-mod common;
+#[path = "common/stack_patterns.rs"]
+mod stack_patterns;
 
+use qp_rusty_crystals_test_utils::probe_stack_for;
 use qp_rusty_crystals_threshold::{generate_with_dealer, ThresholdConfig, ThresholdSigner};
-
-use common::{hyperball_stream_pattern, probe_stack_for};
+use stack_patterns::hyperball_stream_pattern;
 
 // 16 MiB: Round 1 drives hyperball rejection sampling across all commitment
 // iterations plus the packing of the commitment hash input.


### PR DESCRIPTION
# Security review round: timing, zeroization, protocol liveness, and API hardening

Works through a batch of security-review findings across `dilithium`,
`hdwallet`, and `threshold`. Every accepted finding got a regression test
first (red), then a fix (green); findings we assessed as invalid or
already-mitigated are documented where the reviewer would look next.

## Depends on

**`qp-poseidon` PR "Wipe the sponge state after hashing"** (branch
`illuzen/zeroization`). This branch temporarily points `qp-poseidon-core` at
that local branch via `[patch.crates-io]` — the wormhole stack probe needs
the hasher to stop leaving digest copies in dead stack frames. Before merge,
replace the patch with the released `=3.0.3` pin.

## Constant-time comparisons

- `WormholePair::eq` compared secret bytes with short-circuiting `==`, a
  timing oracle against the secret. All three fields now compare through a
  branchless `ct_eq_32` primitive (exposed as `SensitiveBytes32::ct_eq`),
  combined with non-short-circuiting `&`. Covered by a `dudect` bench and a
  unit test pinning that every field participates in equality.

## Zeroization: painted-stack probes and the leaks they caught

New release-mode regression tests paint a stack buffer (`psm`), run an
operation on it, and scan for secret residue afterwards. Rust moves are
copies that leave the moved-from slot dead but never dropped, so
`ZeroizeOnDrop` alone cannot reach them — these probes pin the codegen.

Probes added: trusted dealer, DKG (subset shared secret), threshold signing
Round 1 (mask randomness), dilithium keygen + signing, `SensitiveBytes`
constructors, wormhole pair generation, and the derived-key contribution
digest. A heap-scanner scenario for the dealer was added to the existing
allocator-hook test.

Leaks found and fixed:

- **Dealer**: per-party seeds sat in a plain `Vec` and share coefficients in
  unwiped locals; the dead non-NTT aggregate `s1_total` was removed outright.
- **Dilithium signing/keygen**: `unpack_secret_key_for_signing` returned the
  unpacked key by value (dead copy of `K`); `Keypair::generate` left two dead
  copies of the packed secret key. Both now use out-parameter /
  tail-construction shapes.
- **`SensitiveBytes{32,64}` constructors**: returning the named local left
  the secret in the constructor's frame; they now `mem::replace` out of a
  zeroed slot.
- **Wormhole**: the secret crossed four by-value boundaries. `into_bytes` is
  removed from `SensitiveBytes` (extracting the inner `Copy` array recreates
  every hazard the wrapper prevents), the unused `WormholePair::verify` is
  removed, and derivation now borrows the secret and swaps it into the pair.
- **Derived-key contribution**: the 64-byte secret-share digest (which
  reproduces a party's DKG contribution for any tweak) was returned by value
  and held in a plain local; now squeezed into a caller-provided `Zeroizing`
  buffer.

## Threshold protocol hardening

- **Round 3 intake gate**: wrong-length Round 3 responses used to occupy the
  sender's first-wins slot and only surface later as an unattributable
  `combine()` failure. They are now rejected at receive time.
- **DKG Round 4 liveness**: a malicious party could abort the session after
  all four rounds by appending one extra valid-but-non-led subset mask to its
  broadcast. Verification now skips subsets the sender does not lead, exactly
  as the aggregation step would.
- **`DkgConfig::new`** now rejects a local signer whose public key does not
  match the key registered for `my_party_id` — previously this misconfig
  surfaced as peers rejecting the Round 4 transcript signature.
- **Key-import DoS**: `from_bytes` ran keygen-scale public-key re-derivation
  before the cheap coefficient range check; the order is now reversed so
  garbage inputs are rejected early.
- **`poly_pack_w`** OR-ed bits into its buffer, silently relying on callers
  to pre-zero it; it now clears the buffer itself.

## Documentation corrections

- **Transport contract**: `DilithiumSignProtocol::message` now documents that
  `from` must be the transport-authenticated identity, and why unauthenticated
  transports degrade to DoS only.
- **DKG integrity model**: partial-key η-binding requires an honest subset
  member; documented as a secure-with-abort known limitation (module docs and
  keygen README) rather than papered over.
- **`derivation.rs`** claimed the legacy `key` field is derived from public
  inputs and "provides no secrecy" — inverted since the v2 derivations bind
  it to the secret shares. Docs now mark it secret (never log or expose) and
  keep the correct rationale for not binding contributions to it: pre-v2
  shares carry a public-derived `key`, so the polynomials are the only
  binding sound for every share vintage.

## API hardening

- `WormholePair` fields are now private with read-only accessors
  (`address()`, `first_hash()`, `secret()`), making the
  "address/first_hash are derived from secret" invariant structural. No
  external consumer touched the fields directly.

## Testing

- Full workspace suites pass in both debug and release (probes are
  release-only by design).
- KATs and golden vectors unchanged throughout — no derivation, hash, or
  wire-format behavior changed except the documented intake rejections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches secret handling, signing/keygen, DKG, and threshold wire behavior across the crypto stack; wrong zeroization or intake logic could leak keys or change protocol completion, though KATs/golden vectors are reported unchanged aside from documented rejections.
> 
> **Overview**
> This PR implements a security-review pass across **dilithium**, **hdwallet**, and **threshold**, with regressions added before each fix. It temporarily **`[patch.crates-io]`** `qp-poseidon-core` to a local branch that wipes sponge state after hashing (needed for wormhole stack probes); that patch should be dropped once **=3.0.3** is released.
> 
> **Constant-time and sensitive APIs:** Adds **`ct_eq_32`** and **`SensitiveBytes32::ct_eq`**; **`WormholePair::PartialEq`** now folds all fields with non-short-circuiting `&`. **`SensitiveBytes`** constructors use in-place fill + **`mem::replace`**; **`into_bytes`** is removed. **`WormholePair`** fields are private with accessors; **`verify`** is removed in favor of re-derivation.
> 
> **Zeroization:** Signing/keygen and wormhole paths avoid by-value moves of secrets (out-parameters, tail construction, borrow-and-swap). Dealer holds party seeds in **`Zeroizing<Vec<_>>`** and wipes share copy locals; DKG contribution digest is written into a caller **`Zeroizing`** buffer. Release-only **painted-stack** tests (`psm`) cover dealer, DKG, signing Round 1, dilithium keygen/signing, sensitive-byte constructors, and wormhole generation.
> 
> **Threshold protocol:** Rejects malformed **Round 3** responses at intake; **DKG Round 4** ignores partial PKs for subsets the sender does not lead; **`DkgConfig::new`** fails if the local signer key mismatches the registered map entry; secret-key import runs a cheap coefficient range check before keygen-scale re-derivation; **`poly_pack_w`** zeroes its output buffer.
> 
> **Docs:** Transport contract for **`DilithiumSignProtocol::message`** (`from` must be authenticated); DKG partial-key η-binding documented as secure-with-abort; derivation docs corrected for the **`key`** field and share vintage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e41dd9a56abff4e1fa8a15d5a3b7f98dff8557f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->