### PR TITLE
ci: Automate dilithium version bump to dilithium-v4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "5872607e25ea4ee5fb37e64bf1462168e1a36a4e719cdc8a105533c708253918"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hex-literal = { version = "=0.4.1", default-features = false }
 libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.1.0", default-features = false }
-qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.0.0", default-features = false }
+qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.1.0", default-features = false }
 qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "4.0.0", default-features = false }
 qp-rusty-crystals-test-utils = { path = "./test-utils" }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=3.0.0", default-features = false }

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-dilithium"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of CRYSTALS-Dilithium digital signature scheme"


### PR DESCRIPTION
Automated dilithium version bump for release dilithium-v4.1.0.

https://github.com/Quantus-Network/qp-rusty-crystals/actions/runs/30799482514

Triggered by workflow run: minor

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bump with no cryptographic or logic changes in the diff; risk is limited to consumers pinning the new crate version.
> 
> **Overview**
> Automated release prep for **dilithium-v4.1.0**: bumps the `qp-rusty-crystals-dilithium` crate from **4.0.0** to **4.1.0** in `dilithium/Cargo.toml`, aligns the workspace path dependency in the root `Cargo.toml`, and refreshes the locked package entry in `Cargo.lock`.
> 
> There are **no source or API changes** in this diff—only crate version metadata for the post-quantum Dilithium implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b8b849bae73e188f0f481538ef764eab765105c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->