### PR TITLE
Security review round: secret custody on the heap, the stack, and the public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,23 +86,49 @@ jobs:
             cargo test --locked -p qp-rusty-crystals-hdwallet --no-default-features --features "std,$variant"
             echo "::endgroup::"
           done
-      # The stack-zeroization guard is gated to optimized builds
+      # The stack-zeroization guards are gated to optimized builds
       # (#![cfg(not(debug_assertions))]): debug codegen materializes compiler
       # temporaries of the secret key that no source-level fix can wipe, so the
-      # debug `cargo test` above compiles this file to zero tests. The property
-      # it guards is entirely a function of codegen, making it the test most
-      # likely to silently regress on a toolchain bump — run it in release, and
-      # fail if zero tests ran so a gating/rename change can't turn the guard
-      # back into documentation.
+      # debug `cargo test` above compiles these files to zero tests. The
+      # property they guard is entirely a function of codegen, making them the
+      # tests most likely to silently regress on a toolchain bump — run every
+      # probe in release (security review: only the import probe used to run,
+      # leaving the sign/keygen/hedge and all threshold/hdwallet probes
+      # unexecuted by any job), and fail per probe if zero tests ran so a
+      # gating/rename change can't turn a guard back into documentation.
+      # Dilithium probes run --all-features, which stamps every ML-DSA
+      # parameter set into the binary; threshold/hdwallet probes run under the
+      # default (priority) set, matching what ships.
       - name: Optimized-build regression tests (stack zeroization)
         run: |
           set -o pipefail
-          cargo test --release --locked -p qp-rusty-crystals-dilithium --all-features \
-            --test import_stack_zeroization 2>&1 | tee stack-zeroization.log
-          grep -Eq "test result: ok\. [1-9][0-9]* passed" stack-zeroization.log || {
-            echo "::error::stack-zeroization tests were filtered out (0 tests ran)"
-            exit 1
+          run_probe() {
+            echo "::group::$*"
+            cargo test --release --locked "$@" 2>&1 | tee stack-zeroization.log
+            grep -Eq "test result: ok\. [1-9][0-9]* passed" stack-zeroization.log || {
+              echo "::error::stack-zeroization probe ($*) was filtered out (0 tests ran)"
+              exit 1
+            }
+            echo "::endgroup::"
           }
+          for probe in import_stack_zeroization sign_stack_zeroization sensitive_bytes_stack_zeroization; do
+            run_probe -p qp-rusty-crystals-dilithium --all-features --test "$probe"
+          done
+          for probe in dkg_stack_zeroization signing_stack_zeroization dealer_stack_zeroization; do
+            run_probe -p qp-rusty-crystals-threshold --test "$probe"
+          done
+          # Release-gated unit test inside the threshold lib (painted-stack
+          # probe over the derivation digest).
+          run_probe -p qp-rusty-crystals-threshold --lib shares_digest_never_survives_derivation
+          # The two mnemonic heap probes also run in the debug job, but the
+          # word-pointer scrub in generate_mnemonic is plain (safe) stores
+          # ahead of a free — exactly what dead-store elimination targets —
+          # so they must additionally pass under optimized codegen.
+          for probe in bip39_stack_zeroization entropy_stack_zeroization \
+              hderive_stack_zeroization wormhole_stack_zeroization \
+              mnemonic_heap_zeroization mnemonic_word_pointer_zeroization; do
+            run_probe -p qp-rusty-crystals-hdwallet --test "$probe"
+          done
 
   no-std-build:
     name: 📦 no_std Build (wasm32v1-none)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "psm",
  "qp-rusty-crystals-dilithium",
  "qp-rusty-crystals-test-utils",
+ "qp-rusty-crystals-threshold",
  "rand",
  "zeroize",
 ]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ use qp_rusty_crystals_hdwallet::{generate_mnemonic, HDLattice};
 let mut seed = [0u8; 32];
 getrandom::getrandom(&mut seed).expect("Failed to generate seed");
 
-// Generate mnemonic
+// Generate mnemonic (returned as a self-wiping Zeroizing<String>)
 let mnemonic = generate_mnemonic((&mut seed).into())?;
 
 // Create HD wallet

--- a/dilithium/README.md
+++ b/dilithium/README.md
@@ -71,7 +71,7 @@ assert!(is_valid);
 ### Hedged Signing (Deterministic with Entropy)
 
 ```rust
-use qp_rusty_crystals_dilithium::ml_dsa_87;
+use qp_rusty_crystals_dilithium::{ml_dsa_87, SensitiveBytes32};
 
 let mut entropy = [0u8; 32];
 getrandom::getrandom(&mut entropy).expect("Failed to generate entropy");
@@ -81,9 +81,12 @@ let message = b"Message to sign";
 
 let mut hedge_entropy = [0u8; 32];
 getrandom::getrandom(&mut hedge_entropy).expect("Failed to generate hedge entropy");
+// Move the hedge into a self-wiping wrapper (this zeroes `hedge_entropy`);
+// `sign` borrows it, so no unwiped copy of the randomizer is left behind.
+let hedge = SensitiveBytes32::new(&mut hedge_entropy);
 
 let signature = keypair
-	.sign(message, None, Some(hedge_entropy))
+	.sign(message, None, Some(&hedge))
 	.expect("Signing should succeed");
 let is_valid = keypair.verify(message, signature.as_slice(), None);
 assert!(is_valid);

--- a/dilithium/src/acvp.rs
+++ b/dilithium/src/acvp.rs
@@ -122,10 +122,14 @@ macro_rules! acvp_for {
 						let message = hexs(test, "message");
 						let sk = fixed::<SECRETKEYBYTES>(&hexs(test, "sk"), "sk");
 						let expected_sig = hexs(test, "signature");
+						// Move the vector's rnd into a self-wiping wrapper:
+						// `signature_var` borrows the hedge instead of taking
+						// it by value (see `prepare_signing_context`).
 						let hedge = if deterministic {
 							None
 						} else {
-							Some(fixed::<32>(&hexs(test, "rnd"), "rnd"))
+							let mut rnd = fixed::<32>(&hexs(test, "rnd"), "rnd");
+							Some(crate::SensitiveBytes32::new(&mut rnd))
 						};
 
 						let mut sig = [0u8; SIGNBYTES];
@@ -144,7 +148,7 @@ macro_rules! acvp_for {
 							PUBLICKEYBYTES,
 							SECRETKEYBYTES,
 							SIGNBYTES,
-						>(&mut sig, &[], &message, &sk, hedge);
+						>(&mut sig, &[], &message, &sk, hedge.as_ref());
 
 						assert_eq!(
 							sig.as_slice(),

--- a/dilithium/src/frontend.rs
+++ b/dilithium/src/frontend.rs
@@ -272,11 +272,19 @@ macro_rules! define_ml_dsa {
 			///   byte-reproducible signatures are required, especially when key-blob storage
 			///   integrity cannot be guaranteed (see [`SecretKey::from_bytes`] on the unvalidatable
 			///   `K`).
+			///
+			/// The hedge is taken as a borrowed `SensitiveBytes32` rather than bare
+			/// bytes (security review): building the wrapper (via `SensitiveBytes32::new`)
+			/// wipes the caller's raw buffer, the wrapper zeroizes itself on drop, and
+			/// signing only ever *borrows* the bytes — so no unwiped `Copy` of `rnd` is
+			/// smeared through parameter slots on the call chain. A recovered `rnd` plus
+			/// a compromised `K` reconstructs ρ' and enables the known-mask attack
+			/// hedging is meant to prevent.
 			pub fn sign(
 				&self,
 				msg: &[u8],
 				ctx: Option<&[u8]>,
-				hedge: Option<[u8; SEEDBYTES]>,
+				hedge: Option<&$crate::SensitiveBytes32>,
 			) -> Result<Signature, SignatureError> {
 				self.secret.sign(msg, ctx, hedge)
 			}
@@ -363,12 +371,13 @@ macro_rules! define_ml_dsa {
 			/// Compute a signature for a given message.
 			///
 			/// See [`Keypair::sign`] for the argument contract, in particular the
-			/// deterministic-vs-hedged trade-off of `hedge`.
+			/// deterministic-vs-hedged trade-off of `hedge` and why it is passed
+			/// as a borrowed self-wiping wrapper.
 			pub fn sign(
 				&self,
 				msg: &[u8],
 				ctx: Option<&[u8]>,
-				hedge: Option<[u8; SEEDBYTES]>,
+				hedge: Option<&$crate::SensitiveBytes32>,
 			) -> Result<Signature, SignatureError> {
 				if msg.len() > MAX_MESSAGE_SIZE {
 					return Err(SignatureError::MessageTooLong);
@@ -499,8 +508,8 @@ macro_rules! basic_variant_tests {
 			let msg = b"ctx";
 			let h1 = basic_test_entropy();
 			let h2 = basic_test_entropy();
-			let s1 = keys.sign(msg, Some(b"a"), Some(h1.0)).unwrap();
-			let s2 = keys.sign(msg, Some(b"a"), Some(h2.0)).unwrap();
+			let s1 = keys.sign(msg, Some(b"a"), Some(&h1)).unwrap();
+			let s2 = keys.sign(msg, Some(b"a"), Some(&h2)).unwrap();
 			assert_ne!(s1, s2);
 			assert!(keys.verify(msg, &s1, Some(b"a")));
 			assert!(!keys.verify(msg, &s1, Some(b"b")));

--- a/dilithium/src/ml_dsa_87.rs
+++ b/dilithium/src/ml_dsa_87.rs
@@ -32,7 +32,7 @@ mod tests {
 		let mut entropy = get_random_bytes();
 		let keys = Keypair::generate(&mut entropy);
 		let hedge = get_random_bytes();
-		let sig = keys.sign(&msg, None, Some(hedge.0)).unwrap();
+		let sig = keys.sign(&msg, None, Some(&hedge)).unwrap();
 		assert!(keys.verify(&msg, &sig, None));
 	}
 
@@ -42,7 +42,7 @@ mod tests {
 		let mut entropy = get_random_bytes();
 		let keys = Keypair::generate(&mut entropy);
 		let hedge = get_random_bytes();
-		let sig = keys.sign(&msg, None, Some(hedge.0)).unwrap();
+		let sig = keys.sign(&msg, None, Some(&hedge)).unwrap();
 		assert!(keys.verify(&msg, &sig, None));
 	}
 
@@ -55,7 +55,7 @@ mod tests {
 
 		// Sign with context "test1"
 		let ctx1 = b"test1";
-		let sig = keys.sign(&msg, Some(ctx1), Some(hedge.0)).unwrap();
+		let sig = keys.sign(&msg, Some(ctx1), Some(&hedge)).unwrap();
 
 		// Try to verify with different context "test2" - should fail
 		let ctx2 = b"test2";

--- a/dilithium/src/polyvec.rs
+++ b/dilithium/src/polyvec.rs
@@ -208,8 +208,16 @@ pub fn ntt<const N: usize>(v: &mut Polyvec<N>) {
 }
 
 /// Inverse NTT and multiplication by 2^{32} of polynomials
-/// in vector of length N. Input coefficients need to be less
-/// than 2*Q.
+/// in vector of length N.
+///
+/// # Preconditions
+///
+/// Input coefficients must be less than Q in absolute value — the same
+/// contract as the per-polynomial [`poly::invntt_tomont`] this delegates to
+/// (this doc previously promised `< 2*Q`, which can overflow the inverse
+/// butterflies; security review). Checked there with `debug_assert!`.
+/// Forward-NTT output (which can reach 8*Q) must be brought back into range
+/// with [`reduce`] before being passed here.
 pub fn invntt_tomont<const N: usize>(v: &mut Polyvec<N>) {
 	for i in 0..N {
 		poly::invntt_tomont(&mut v.vec[i]);
@@ -512,6 +520,21 @@ mod tests {
 				);
 			}
 		}
+	}
+
+	/// The wrapper's documented contract must match the per-polynomial
+	/// implementation it delegates to: coefficients below Q in absolute
+	/// value. The doc previously promised `< 2*Q` (security review); a
+	/// coefficient in `[Q, 2*Q)` — permitted by that stale contract — must
+	/// fail loudly wherever debug assertions are on rather than silently
+	/// overflowing the inverse butterflies in release builds.
+	#[test]
+	#[cfg(debug_assertions)]
+	#[should_panic(expected = "invntt_tomont precondition violated")]
+	fn invntt_tomont_rejects_coefficients_between_q_and_2q() {
+		let mut v = Polyvec::<L>::default();
+		v.vec[0].coeffs[0] = params::Q; // in [Q, 2*Q): allowed by the old doc
+		invntt_tomont(&mut v);
 	}
 
 	#[test]

--- a/dilithium/src/sign.rs
+++ b/dilithium/src/sign.rs
@@ -389,16 +389,23 @@ fn prepare_signing_context<const K: usize, const L: usize>(
 	unpacked_sk: &UnpackedSecretKey<K, L>,
 	domain_prefix: &[u8],
 	message: &[u8],
-	hedge_randomness: Option<[u8; params::SEEDBYTES]>,
+	hedge_randomness: Option<&SensitiveBytes32>,
 ) -> SigningContext {
 	let message_hash_mu =
 		derive_message_hash(&unpacked_sk.public_key_hash_tr, domain_prefix, message);
 
-	let mut hedge_bytes = hedge_randomness.unwrap_or([0u8; params::SEEDBYTES]);
+	// The hedge `rnd` is only ever *borrowed* out of the caller's
+	// self-wiping wrapper (security review): the previous by-value
+	// `Option<[u8; SEEDBYTES]>` plumbing smeared bare `Copy` duplicates of
+	// rnd through every parameter slot on the call chain, none of which any
+	// zeroize call could reach. rnd feeds ρ' = H(K || rnd || μ), so a
+	// recovered rnd plus a compromised K reconstructs the mask seed — the
+	// exact known-mask attack hedging exists to prevent. Deterministic mode
+	// (FIPS 204) absorbs rnd = 0^32, which is public.
+	const ZERO_RND: [u8; params::SEEDBYTES] = [0u8; params::SEEDBYTES];
+	let hedge_bytes = hedge_randomness.map_or(&ZERO_RND, SensitiveBytes32::as_bytes);
 	let mut signing_entropy_rho_prime =
-		derive_mask_seed(&unpacked_sk.private_key_seed, &hedge_bytes, &message_hash_mu);
-
-	hedge_bytes.zeroize();
+		derive_mask_seed(&unpacked_sk.private_key_seed, hedge_bytes, &message_hash_mu);
 
 	let public_seed_rho = unpacked_sk.public_seed_rho;
 
@@ -566,7 +573,7 @@ pub(crate) fn signature_var<
 	domain_prefix: &[u8],
 	message: &[u8],
 	secret_key_bytes: &[u8; SK],
-	hedge: Option<[u8; params::SEEDBYTES]>,
+	hedge: Option<&SensitiveBytes32>,
 ) {
 	const {
 		assert_sign_params::<K, L, ETA, GAMMA1, GAMMA2, OMEGA, CD, PZ, W1, KW1, PK, SK, SIG>();
@@ -777,7 +784,7 @@ fn signature(
 	domain_prefix: &[u8],
 	message: &[u8],
 	secret_key_bytes: &[u8; params::SECRETKEYBYTES],
-	hedge: Option<[u8; params::SEEDBYTES]>,
+	hedge: Option<&SensitiveBytes32>,
 ) {
 	signature_var::<
 		{ params::K },
@@ -854,7 +861,7 @@ mod tests {
 		let msg = get_random_msg();
 		let mut sig = [0u8; crate::params::SIGNBYTES];
 		let hedge = get_random_bytes();
-		super::signature(&mut sig, &[], &msg, &sk, Some(hedge.0));
+		super::signature(&mut sig, &[], &msg, &sk, Some(&hedge));
 		assert!(super::verify(&sig, &[], &msg, &pk));
 	}
 
@@ -917,8 +924,8 @@ mod tests {
 
 		let hedge = get_random_bytes();
 
-		super::signature(&mut sig1, &[], msg, &sk, Some(hedge.0));
-		super::signature(&mut sig2, &[], msg, &sk, Some(hedge.0));
+		super::signature(&mut sig1, &[], msg, &sk, Some(&hedge));
+		super::signature(&mut sig2, &[], msg, &sk, Some(&hedge));
 
 		// Deterministic signing should produce identical signatures
 		assert_eq!(sig1, sig2);
@@ -939,8 +946,8 @@ mod tests {
 		let hedge1 = get_random_bytes();
 		let hedge2 = get_random_bytes();
 
-		super::signature(&mut sig1, &[], msg, &sk, Some(hedge1.0));
-		super::signature(&mut sig2, &[], msg, &sk, Some(hedge2.0));
+		super::signature(&mut sig1, &[], msg, &sk, Some(&hedge1));
+		super::signature(&mut sig2, &[], msg, &sk, Some(&hedge2));
 
 		// Hedged signing should produce different signatures (with high probability)
 		assert_ne!(sig1, sig2);

--- a/dilithium/tests/sign_stack_zeroization.rs
+++ b/dilithium/tests/sign_stack_zeroization.rs
@@ -96,6 +96,25 @@ macro_rules! sign_stack_zeroization_tests {
 					core::hint::black_box(&sig);
 				});
 
+				// Scenario B2 (security review): *hedged* signing must not
+				// leave the caller's hedge randomness `rnd` in stack memory.
+				// ρ' = H(K || rnd || μ), so an attacker who recovers rnd from
+				// dead stack memory and also obtains K can reconstruct the
+				// mask seed and mount the known-mask attack on z = y + c*s1 —
+				// defeating exactly the K-compromise protection hedging is
+				// for. The wrapper is built outside the probe (like the
+				// keygen seed holders) so the closure captures only
+				// references and cannot plant a match itself. Distinctive
+				// pattern for the same reason as SEED.
+				let hedge_pattern: [u8; 32] = *b"hedge-randomness-stack-pattern!!";
+				let mut hedge_raw = hedge_pattern;
+				let hedge = qp_rusty_crystals_dilithium::SensitiveBytes32::new(&mut hedge_raw);
+				let sign_leaked_hedge = probe_stack_for(super::STACK_BYTES, &hedge_pattern, || {
+					let sig =
+						keypair.sign(message, None, Some(&hedge)).expect("signing succeeds");
+					core::hint::black_box(&sig);
+				});
+
 				// Scenario C: key generation. Same seed => identical key, so
 				// the reference patterns apply. The seed holder is built
 				// outside the probe (the closure captures only a reference),
@@ -127,6 +146,10 @@ macro_rules! sign_stack_zeroization_tests {
 
 				assert!(!sign_leaked_k, "signing left the signing key K in stack memory");
 				assert!(!sign_leaked_s1, "signing left a packed secret-key copy in stack memory");
+				assert!(
+					!sign_leaked_hedge,
+					"hedged signing left the hedge randomness rnd in stack memory"
+				);
 				assert!(!keygen_leaked_k, "key generation left the signing key K in stack memory");
 				assert!(
 					!keygen_leaked_s1,

--- a/dilithium/tests/sign_stack_zeroization.rs
+++ b/dilithium/tests/sign_stack_zeroization.rs
@@ -110,8 +110,7 @@ macro_rules! sign_stack_zeroization_tests {
 				let mut hedge_raw = hedge_pattern;
 				let hedge = qp_rusty_crystals_dilithium::SensitiveBytes32::new(&mut hedge_raw);
 				let sign_leaked_hedge = probe_stack_for(super::STACK_BYTES, &hedge_pattern, || {
-					let sig =
-						keypair.sign(message, None, Some(&hedge)).expect("signing succeeds");
+					let sig = keypair.sign(message, None, Some(&hedge)).expect("signing succeeds");
 					core::hint::black_box(&sig);
 				});
 

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -40,6 +40,10 @@ sha2 = { version = "0.10", default-features = false }
 getrandom = { workspace = true, features = ["js"] }
 
 [dev-dependencies]
+# Same bip39 instance as the library: the word-pointer heap-zeroization test
+# reconstructs the fat-pointer sequence into bip39's static word list to scan
+# freed blocks for it.
+bip39.workspace = true
 hex-literal.workspace = true
 rand.workspace = true
 rand_core.workspace = true

--- a/hdwallet/README.md
+++ b/hdwallet/README.md
@@ -50,11 +50,12 @@ qp-rusty-crystals-hdwallet = "3.1"
 ```rust
 use qp_rusty_crystals_hdwallet::{derive_key_from_mnemonic, generate_mnemonic};
 
-// Generate secure entropy for a new mnemonic
+// Generate secure entropy for a new mnemonic. The phrase is returned as a
+// self-wiping `Zeroizing<String>`: its heap contents are zeroized on drop.
 let mut entropy = [0u8; 32];
 getrandom::getrandom(&mut entropy).expect("Failed to generate entropy");
 let mnemonic = generate_mnemonic((&mut entropy).into())?;
-println!("Mnemonic: {}", mnemonic);
+println!("Mnemonic: {}", mnemonic.as_str());
 
 // Derive an ML-DSA-87 keypair at a BIP-44 path
 let keypair = derive_key_from_mnemonic(&mnemonic, None, "m/44'/189189'/0'/0'/0'")?;

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -419,15 +419,28 @@ fn check_derivation_path(path: &str) -> Result<(), HDLatticeError> {
 /// This function takes ownership of the entropy for security (move semantics).
 /// The entropy parameter is zeroized before returning.
 ///
+/// The phrase is returned inside a [`Zeroizing`] wrapper (security review):
+/// the recovery phrase yields the entire HD wallet, so it must not outlive
+/// its logical lifetime in freed heap memory. A plain `String` return left
+/// erasure to the caller with no type-level hint; `Zeroizing<String>` wipes
+/// the backing allocation when the caller drops it. (Moving the wrapper only
+/// copies the pointer/len/cap triple — the secret heap contents are never
+/// duplicated — so returning it by value is safe, unlike fixed-size secret
+/// arrays, which are wiped in place via out-parameters elsewhere in this
+/// crate.) The heap-zeroization regression test pins this.
+///
 /// # Security Note
 /// Always use cryptographically secure random entropy (e.g., from `getrandom::getrandom()`).
 /// Never use predictable strings, timestamps, or user input as entropy sources.
-pub fn generate_mnemonic(entropy: SensitiveBytes32) -> Result<String, HDLatticeError> {
+pub fn generate_mnemonic(entropy: SensitiveBytes32) -> Result<Zeroizing<String>, HDLatticeError> {
 	// Create mnemonic from entropy
 	let mnemonic = Mnemonic::from_entropy(entropy.as_bytes())
 		.map_err(|e| HDLatticeError::MnemonicDerivationFailed(e.to_string()))?;
 
-	let result = mnemonic.words().collect::<Vec<&str>>().join(" ");
+	// `join` allocates the phrase exactly once (the Vec holds `&str`
+	// references into the static word list, not copies), and moving the
+	// String into `Zeroizing::new` transfers the same allocation.
+	let result = Zeroizing::new(mnemonic.words().collect::<Vec<&str>>().join(" "));
 
 	// entropy is automatically zeroized when it drops
 

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -24,10 +24,7 @@
 extern crate alloc;
 
 use crate::hderive::ExtendedPrivKey;
-use alloc::{
-	string::{String, ToString},
-	vec::Vec,
-};
+use alloc::string::{String, ToString};
 use bip39::{Language, Mnemonic};
 use core::str::FromStr;
 #[cfg(feature = "ml-dsa-87")]
@@ -437,10 +434,29 @@ pub fn generate_mnemonic(entropy: SensitiveBytes32) -> Result<Zeroizing<String>,
 	let mnemonic = Mnemonic::from_entropy(entropy.as_bytes())
 		.map_err(|e| HDLatticeError::MnemonicDerivationFailed(e.to_string()))?;
 
-	// `join` allocates the phrase exactly once (the Vec holds `&str`
-	// references into the static word list, not copies), and moving the
-	// String into `Zeroizing::new` transfers the same allocation.
-	let result = Zeroizing::new(mnemonic.words().collect::<Vec<&str>>().join(" "));
+	// Build the phrase directly into the Zeroizing-owned String (security
+	// review): the previous `words().collect::<Vec<&str>>().join(" ")`
+	// parked 24 fat pointers into bip39's *static* word list in a heap
+	// buffer that `join` freed unwiped. The word-list addresses are fixed
+	// per process image, so that pointer sequence decodes right back to
+	// the phrase — an alternate representation the byte-level phrase probe
+	// cannot see (the word-pointer heap-zeroization test pins it).
+	//
+	// The first pass computes the exact phrase length so the single
+	// allocation never grows: an under-sized String would reallocate while
+	// appending and strand unwiped partial-phrase prefixes in freed
+	// memory, trading one leak for another.
+	let word_bytes: usize = mnemonic.words().map(str::len).sum();
+	let phrase_len = word_bytes + mnemonic.words().count().saturating_sub(1);
+
+	let mut result = Zeroizing::new(String::with_capacity(phrase_len));
+	for (i, word) in mnemonic.words().enumerate() {
+		if i > 0 {
+			result.push(' ');
+		}
+		result.push_str(word);
+	}
+	debug_assert_eq!(result.len(), phrase_len, "phrase length precomputation must be exact");
 
 	// entropy is automatically zeroized when it drops
 

--- a/hdwallet/src/lib.rs
+++ b/hdwallet/src/lib.rs
@@ -24,7 +24,10 @@
 extern crate alloc;
 
 use crate::hderive::ExtendedPrivKey;
-use alloc::string::{String, ToString};
+use alloc::{
+	string::{String, ToString},
+	vec::Vec,
+};
 use bip39::{Language, Mnemonic};
 use core::str::FromStr;
 #[cfg(feature = "ml-dsa-87")]
@@ -434,29 +437,33 @@ pub fn generate_mnemonic(entropy: SensitiveBytes32) -> Result<Zeroizing<String>,
 	let mnemonic = Mnemonic::from_entropy(entropy.as_bytes())
 		.map_err(|e| HDLatticeError::MnemonicDerivationFailed(e.to_string()))?;
 
-	// Build the phrase directly into the Zeroizing-owned String (security
-	// review): the previous `words().collect::<Vec<&str>>().join(" ")`
-	// parked 24 fat pointers into bip39's *static* word list in a heap
-	// buffer that `join` freed unwiped. The word-list addresses are fixed
-	// per process image, so that pointer sequence decodes right back to
-	// the phrase — an alternate representation the byte-level phrase probe
-	// cannot see (the word-pointer heap-zeroization test pins it).
-	//
-	// The first pass computes the exact phrase length so the single
-	// allocation never grows: an under-sized String would reallocate while
-	// appending and strand unwiped partial-phrase prefixes in freed
-	// memory, trading one leak for another.
-	let word_bytes: usize = mnemonic.words().map(str::len).sum();
-	let phrase_len = word_bytes + mnemonic.words().count().saturating_sub(1);
+	// Collect the word pointers in one tight pass, then `join` — do NOT
+	// stream `words()` straight into a growing String: keeping that
+	// iterator (which borrows the mnemonic's secret word-index buffer)
+	// alive across String appends made release codegen spill an unwiped
+	// copy of the index array into a dead stack slot (caught by the bip39
+	// stack probe). `join` allocates the phrase exactly once and moving it
+	// into `Zeroizing::new` transfers the same allocation.
+	let mut words: Vec<&str> = mnemonic.words().collect();
+	let result = Zeroizing::new(words.join(" "));
 
-	let mut result = Zeroizing::new(String::with_capacity(phrase_len));
-	for (i, word) in mnemonic.words().enumerate() {
-		if i > 0 {
-			result.push(' ');
-		}
-		result.push_str(word);
+	// The Vec buffer now holds 24 fat pointers into bip39's *static* word
+	// list. The addresses are fixed per process image, so the freed pointer
+	// sequence decodes right back to the phrase — an alternate
+	// representation the byte-level phrase probe cannot see (the
+	// word-pointer heap-zeroization test pins it). Scrub the buffer in
+	// place before the Vec frees it by overwriting every slot with the
+	// empty string (a valid `&str`, so no unsafe needed). Plain stores
+	// right before a deallocation are candidates for dead-store
+	// elimination, so `black_box` forces the compiler to assume the buffer
+	// is observed after the overwrite; the word-pointer heap probe runs in
+	// CI against both debug and optimized builds to pin that this scrub
+	// actually reaches memory.
+	for word in words.iter_mut() {
+		*word = "";
 	}
-	debug_assert_eq!(result.len(), phrase_len, "phrase length precomputation must be exact");
+	core::hint::black_box(&mut words);
+	drop(words);
 
 	// entropy is automatically zeroized when it drops
 

--- a/hdwallet/src/tests.rs
+++ b/hdwallet/src/tests.rs
@@ -21,8 +21,6 @@ mod hdwallet_tests {
 	#[cfg(test)]
 	extern crate std;
 	#[cfg(test)]
-	use std::dbg;
-	#[cfg(test)]
 	use std::println;
 
 	/// Test helper: stretch a known-valid mnemonic into a fresh seed.
@@ -58,14 +56,14 @@ mod hdwallet_tests {
 	fn test_mnemonic_creation() {
 		let mut entropy = [43u8; 32];
 
-		// Test generating new mnemonic
-		let mnemonic = dbg!(generate_mnemonic((&mut entropy).into()).unwrap());
+		// Test generating new mnemonic (returned inside a Zeroizing wrapper)
+		let mnemonic = generate_mnemonic((&mut entropy).into()).unwrap();
 		assert_eq!(mnemonic.split_whitespace().count(), 24);
 
 		// Test creating seeds from mnemonic - demonstrate explicit copying
-		let seed1 = seed_from(mnemonic.clone(), None);
-		let seed2 = seed_from(mnemonic.clone(), None);
-		let seed3 = seed_from(mnemonic.clone(), Some("password"));
+		let seed1 = seed_from(mnemonic.to_string(), None);
+		let seed2 = seed_from(mnemonic.to_string(), None);
+		let seed3 = seed_from(mnemonic.to_string(), Some("password"));
 
 		// Seeds from same mnemonic should be identical
 		assert_eq!(
@@ -96,7 +94,7 @@ mod hdwallet_tests {
 		);
 
 		// Derive a different path - need a fresh seed since seed1 was already consumed
-		let seed_for_derive = seed_from(mnemonic.clone(), None);
+		let seed_for_derive = seed_from(mnemonic.to_string(), None);
 		let derived_key = derive_key_from_seed(seed_for_derive, "m/0'/2147483647'/1'").unwrap();
 		assert_ne!(
 			master_key1.secret().to_bytes(),
@@ -143,9 +141,9 @@ mod hdwallet_tests {
 				rng.fill_bytes(&mut seed);
 				let mnemonic = generate_mnemonic((&mut seed).into()).unwrap();
 				let path = generate_random_path();
-				let seed = seed_from(mnemonic.clone(), None);
+				let seed = seed_from(mnemonic.to_string(), None);
 				let k = derive_key_from_seed(seed, &path).unwrap();
-				(k, mnemonic, path)
+				(k, mnemonic.to_string(), path)
 			})
 			.collect()
 	}
@@ -585,7 +583,7 @@ mod hdwallet_tests {
 
 		// Use the wrapped data - this should move it
 		let mnemonic = generate_mnemonic(sensitive_entropy).unwrap();
-		let seed_from_mnemonic = seed_from(mnemonic, None);
+		let seed_from_mnemonic = seed_from(mnemonic.to_string(), None);
 		let _key = derive_key_from_seed(sensitive_seed, "m/44'/0'/0'/0'/0'").unwrap();
 
 		// After this point, sensitive_entropy and sensitive_seed should be consumed

--- a/hdwallet/tests/mnemonic_heap_zeroization.rs
+++ b/hdwallet/tests/mnemonic_heap_zeroization.rs
@@ -1,0 +1,89 @@
+//! Regression test (security review): the mnemonic phrase returned by
+//! `generate_mnemonic` must not survive in freed heap memory after the caller
+//! drops it.
+//!
+//! `generate_mnemonic` used to return the recovery phrase as a plain
+//! `String`, which does not zeroize its backing allocation on drop. The crate's
+//! security model keeps every other secret (entropy, seeds, keys) inside
+//! self-zeroizing wrappers, so a caller had no type-level hint that the one
+//! secret that yields the *entire* wallet — the 24-word phrase — was their job
+//! to erase. Returning `Zeroizing<String>` closes that custody gap: moving the
+//! wrapper only copies the (ptr, len, cap) triple, and the heap contents are
+//! wiped before the allocation is released.
+//!
+//! Detection uses the same technique as `wormhole_zeroization.rs`: a global
+//! allocator that scans every block for the phrase bytes at `dealloc` time
+//! (the block is still valid inside the hook, so the scan is sound). This file
+//! contains exactly one test so no unrelated concurrent allocations can race
+//! the scanner.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	sync::OnceLock,
+};
+
+use qp_rusty_crystals_hdwallet::{generate_mnemonic, SensitiveBytes32};
+
+/// Deterministic entropy: generation is deterministic in the entropy, so a
+/// reference run (scanner off) reproduces the exact phrase bytes to scan for.
+const ENTROPY: [u8; 32] = *b"mnemonic-heap-zeroize-pattern-32";
+
+/// The generated phrase, learned from the reference run.
+static PHRASE_PATTERN: OnceLock<Vec<u8>> = OnceLock::new();
+
+static SCANNING: AtomicBool = AtomicBool::new(false);
+static PHRASE_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+
+struct SecretScanningAllocator;
+
+unsafe impl GlobalAlloc for SecretScanningAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		if SCANNING.load(Ordering::SeqCst) {
+			if let Some(pattern) = PHRASE_PATTERN.get() {
+				if layout.size() >= pattern.len() {
+					let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+					if block.windows(pattern.len()).any(|w| w == &pattern[..]) {
+						PHRASE_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+					}
+				}
+			}
+		}
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: SecretScanningAllocator = SecretScanningAllocator;
+
+#[test]
+fn generated_mnemonic_never_survives_in_freed_heap_memory() {
+	// Reference run (scanner off) to learn the phrase bytes.
+	let mut entropy = ENTROPY;
+	let reference = generate_mnemonic(SensitiveBytes32::from(&mut entropy)).unwrap();
+	assert_eq!(reference.split_whitespace().count(), 24);
+	PHRASE_PATTERN.set(reference.as_bytes().to_vec()).expect("set once");
+	drop(reference);
+
+	// Probed run: generate the phrase and drop it, as a caller who has
+	// finished with it (e.g. displayed it once) would. Every heap block
+	// freed in this window — including the phrase's own allocation — must
+	// no longer contain the phrase bytes.
+	let mut entropy = ENTROPY;
+	SCANNING.store(true, Ordering::SeqCst);
+	let phrase = generate_mnemonic(SensitiveBytes32::from(&mut entropy)).unwrap();
+	core::hint::black_box(&phrase);
+	drop(phrase);
+	SCANNING.store(false, Ordering::SeqCst);
+
+	assert!(
+		!PHRASE_FREED_UNCLEARED.load(Ordering::SeqCst),
+		"generate_mnemonic()'s returned phrase survived in freed heap memory \
+		 after the caller dropped it; the recovery phrase yields the entire HD \
+		 wallet, so it must be zeroized before its allocation is released"
+	);
+}

--- a/hdwallet/tests/mnemonic_word_pointer_zeroization.rs
+++ b/hdwallet/tests/mnemonic_word_pointer_zeroization.rs
@@ -1,0 +1,99 @@
+//! Regression test (security review): `generate_mnemonic` must not leak the
+//! phrase through freed buffers of *word pointers* either.
+//!
+//! The phrase-byte probe (`mnemonic_heap_zeroization.rs`) only catches UTF-8
+//! copies of the phrase. But `generate_mnemonic` used to build the phrase via
+//! `mnemonic.words().collect::<Vec<&str>>().join(" ")`, which parks 24 fat
+//! pointers (address + length, 384 bytes on 64-bit) into bip39's *static*
+//! word list in a heap buffer that `join` leaves behind unwiped. The word-list
+//! addresses are fixed per process image, so the freed pointer sequence
+//! decodes right back to the phrase — an alternate representation of the same
+//! secret, invisible to a byte-level phrase scan.
+//!
+//! This probe learns the exact fat-pointer byte sequence by evaluating the
+//! same `collect` expression against the same bip39 statics (same crate
+//! instance, so identical addresses), then scans every block freed while
+//! `generate_mnemonic` runs. Same dealloc-scanning technique as the phrase
+//! probe; one test per file so no unrelated concurrent allocations race the
+//! scanner.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	sync::OnceLock,
+};
+
+use qp_rusty_crystals_hdwallet::{generate_mnemonic, SensitiveBytes32};
+
+/// Deterministic entropy: same entropy => same words => same fat-pointer
+/// sequence as inside `generate_mnemonic`.
+const ENTROPY: [u8; 32] = *b"mnemonic-word-ptr-zeroize-32-pat";
+
+/// The raw bytes of the 24 fat pointers, learned with the scanner off.
+static POINTER_PATTERN: OnceLock<Vec<u8>> = OnceLock::new();
+
+static SCANNING: AtomicBool = AtomicBool::new(false);
+static POINTERS_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+
+struct SecretScanningAllocator;
+
+unsafe impl GlobalAlloc for SecretScanningAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		if SCANNING.load(Ordering::SeqCst) {
+			if let Some(pattern) = POINTER_PATTERN.get() {
+				if layout.size() >= pattern.len() {
+					let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+					if block.windows(pattern.len()).any(|w| w == &pattern[..]) {
+						POINTERS_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+					}
+				}
+			}
+		}
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: SecretScanningAllocator = SecretScanningAllocator;
+
+#[test]
+fn generated_mnemonic_word_pointers_never_survive_in_freed_heap_memory() {
+	// Reference run (scanner off): materialize the same Vec<&'static str>
+	// the old implementation built internally and capture its raw bytes.
+	// The dev-dependency resolves to the same bip39 crate instance as the
+	// library, so the word-list statics — and hence the fat pointers — are
+	// identical.
+	let mnemonic = bip39::Mnemonic::from_entropy(&ENTROPY).expect("valid entropy");
+	let words: Vec<&'static str> = mnemonic.words().collect();
+	assert_eq!(words.len(), 24);
+	let pattern = unsafe {
+		core::slice::from_raw_parts(
+			words.as_ptr().cast::<u8>(),
+			words.len() * core::mem::size_of::<&str>(),
+		)
+	}
+	.to_vec();
+	POINTER_PATTERN.set(pattern).expect("set once");
+	drop(words); // freed with the scanner off: cannot self-trigger the probe
+
+	// Probed run: every heap block freed while generate_mnemonic runs (and
+	// while the caller drops the phrase) must not contain the pointer
+	// sequence.
+	let mut entropy = ENTROPY;
+	SCANNING.store(true, Ordering::SeqCst);
+	let phrase = generate_mnemonic(SensitiveBytes32::from(&mut entropy)).unwrap();
+	core::hint::black_box(&phrase);
+	drop(phrase);
+	SCANNING.store(false, Ordering::SeqCst);
+
+	assert!(
+		!POINTERS_FREED_UNCLEARED.load(Ordering::SeqCst),
+		"generate_mnemonic() freed a buffer still holding the word fat-pointer \
+		 sequence; the bip39 word-list addresses are fixed statics, so the \
+		 pointer sequence decodes back to the full recovery phrase"
+	);
+}

--- a/tests/src/sign_integration_tests.rs
+++ b/tests/src/sign_integration_tests.rs
@@ -6,9 +6,10 @@ use qp_rusty_crystals_hdwallet::{
 use rand::{Rng, RngExt};
 
 /// Test helper: stretch a known-valid mnemonic into a fresh seed.
-fn seed_from(mnemonic: String) -> SensitiveBytes64 {
+fn seed_from(mnemonic: &str) -> SensitiveBytes64 {
 	let mut seed = SensitiveBytes64::zeroed();
-	mnemonic_to_seed(mnemonic, None, &mut seed).expect("Failed to create seed from mnemonic");
+	mnemonic_to_seed(mnemonic.to_string(), None, &mut seed)
+		.expect("Failed to create seed from mnemonic");
 	seed
 }
 
@@ -25,7 +26,7 @@ fn test_sign() {
 
 	// Step 1: Generate a random mnemonic and derive Dilithium keypair
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let seed = seed_from(mnemonic);
+	let seed = seed_from(&mnemonic);
 	let dilithium_keypair =
 		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
@@ -47,7 +48,7 @@ fn test_sign_multiple_messages() {
 	rand::rng().fill_bytes(&mut entropy);
 
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let seed = seed_from(mnemonic);
+	let seed = seed_from(&mnemonic);
 	let dilithium_keypair =
 		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
@@ -73,7 +74,7 @@ fn test_hedged_vs_deterministic_signing() {
 	rand::rng().fill_bytes(&mut entropy);
 
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let seed = seed_from(mnemonic);
+	let seed = seed_from(&mnemonic);
 	let dilithium_keypair =
 		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
@@ -114,8 +115,8 @@ fn test_cross_keypair_verification_fails() {
 	let mnemonic2 =
 		generate_mnemonic((&mut entropy2).into()).expect("Failed to generate mnemonic 2");
 
-	let seed1 = seed_from(mnemonic1);
-	let seed2 = seed_from(mnemonic2);
+	let seed1 = seed_from(&mnemonic1);
+	let seed2 = seed_from(&mnemonic2);
 
 	let keypair1 =
 		derive_key_from_seed(seed1, "m/44'/0'/0'/0'/0'").expect("Failed to derive key 1");
@@ -142,7 +143,7 @@ fn test_corrupted_signature_fails() {
 	rand::rng().fill_bytes(&mut entropy);
 
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let seed = seed_from(mnemonic);
+	let seed = seed_from(&mnemonic);
 	let dilithium_keypair =
 		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 
@@ -188,8 +189,8 @@ fn test_same_seed_produces_same_keypair() {
 	// Same seed should produce same mnemonic
 	assert_eq!(mnemonic1, mnemonic2);
 
-	let seed1 = seed_from(mnemonic1);
-	let seed2 = seed_from(mnemonic2);
+	let seed1 = seed_from(&mnemonic1);
+	let seed2 = seed_from(&mnemonic2);
 
 	let keypair1 =
 		derive_key_from_seed(seed1, "m/44'/0'/0'/0'/0'").expect("Failed to derive key 1");
@@ -215,7 +216,7 @@ fn test_stress_multiple_signatures() {
 	rand::rng().fill_bytes(&mut entropy);
 
 	let mnemonic = generate_mnemonic((&mut entropy).into()).expect("Failed to generate mnemonic");
-	let seed = seed_from(mnemonic);
+	let seed = seed_from(&mnemonic);
 	let dilithium_keypair =
 		derive_key_from_seed(seed, "m/44'/0'/0'/0'/0'").expect("Failed to derive key");
 

--- a/tests/src/sign_integration_tests.rs
+++ b/tests/src/sign_integration_tests.rs
@@ -1,7 +1,7 @@
 // tests/sign_integration_tests.rs
 
 use qp_rusty_crystals_hdwallet::{
-	derive_key_from_seed, generate_mnemonic, mnemonic_to_seed, SensitiveBytes64,
+	derive_key_from_seed, generate_mnemonic, mnemonic_to_seed, SensitiveBytes32, SensitiveBytes64,
 };
 use rand::{Rng, RngExt};
 
@@ -87,11 +87,11 @@ fn test_hedged_vs_deterministic_signing() {
 	// Deterministic signatures should be identical
 	assert_eq!(sig1_det, sig2_det, "Deterministic signatures should be identical");
 
-	// Test hedged signing
-	let hedge1 = get_random_bytes();
-	let hedge2 = get_random_bytes();
-	let sig1_hedge = dilithium_keypair.sign(message, None, Some(hedge1)).unwrap();
-	let sig2_hedge = dilithium_keypair.sign(message, None, Some(hedge2)).unwrap();
+	// Test hedged signing (the hedge is borrowed from a self-wiping wrapper)
+	let hedge1 = SensitiveBytes32::new(&mut get_random_bytes());
+	let hedge2 = SensitiveBytes32::new(&mut get_random_bytes());
+	let sig1_hedge = dilithium_keypair.sign(message, None, Some(&hedge1)).unwrap();
+	let sig2_hedge = dilithium_keypair.sign(message, None, Some(&hedge2)).unwrap();
 
 	// Hedged signatures should be different (with very high probability)
 	assert_ne!(sig1_hedge, sig2_hedge, "Hedged signatures should be different");

--- a/tests/src/verify_integration_tests.rs
+++ b/tests/src/verify_integration_tests.rs
@@ -93,7 +93,10 @@ fn verify_test_vector<K, FGen, FFromBytes>(
 
 	let mut hedge = [0u8; 32];
 	assert!(drbg.randombytes(&mut hedge, 32).is_ok());
-	let our_signature = keypair.sign_msg(&test.msg, Some(hedge));
+	// Move the DRBG output into a self-wiping wrapper (zeroes `hedge`);
+	// `sign` borrows the hedge instead of taking it by value.
+	let hedge = SensitiveBytes32::new(&mut hedge);
+	let our_signature = keypair.sign_msg(&test.msg, Some(&hedge));
 	assert_eq!(
 		our_signature.as_slice(),
 		nist_signature,
@@ -158,7 +161,7 @@ trait HasNistKatApi {
 	fn public_bytes(&self) -> Vec<u8>;
 	fn secret_bytes(&self) -> Vec<u8>;
 	fn verify_msg(&self, msg: &[u8], sig: &[u8]) -> bool;
-	fn sign_msg(&self, msg: &[u8], hedge: Option<[u8; 32]>) -> Vec<u8>;
+	fn sign_msg(&self, msg: &[u8], hedge: Option<&SensitiveBytes32>) -> Vec<u8>;
 }
 
 macro_rules! impl_has_nist_kat_api {
@@ -176,7 +179,7 @@ macro_rules! impl_has_nist_kat_api {
 				self.verify(msg, sig, None)
 			}
 
-			fn sign_msg(&self, msg: &[u8], hedge: Option<[u8; 32]>) -> Vec<u8> {
+			fn sign_msg(&self, msg: &[u8], hedge: Option<&SensitiveBytes32>) -> Vec<u8> {
 				self.sign(msg, None, hedge).expect("Signing should succeed").to_vec()
 			}
 		}

--- a/threshold/Cargo.toml
+++ b/threshold/Cargo.toml
@@ -36,6 +36,12 @@ rand = { workspace = true }
 # directly by the unit-test probe in `derivation.rs`).
 psm = "=0.1.31"
 qp-rusty-crystals-test-utils = { workspace = true }
+# Self-referential dev-dependency: enables the internal-test-helpers feature
+# for this crate's own test builds only, so the adversary-simulation
+# integration tests can forge/tamper secret-bearing wire types while the
+# production API keeps them opaque. Path-only dev-dependencies are stripped
+# on publish.
+qp-rusty-crystals-threshold = { path = ".", features = ["internal-test-helpers"] }
 
 [features]
 default = ["ml-dsa-87", "std"]
@@ -43,6 +49,10 @@ std = ["zeroize/std"]
 ml-dsa-44 = ["qp-rusty-crystals-dilithium/ml-dsa-44"]
 ml-dsa-65 = ["qp-rusty-crystals-dilithium/ml-dsa-65"]
 ml-dsa-87 = ["qp-rusty-crystals-dilithium/ml-dsa-87"]
+# Test-only escape hatches (doc(hidden) constructors/accessors) for
+# secret-bearing resharing wire types, used by this crate's own
+# adversary-simulation tests. NEVER enable in production builds.
+internal-test-helpers = []
 
 [[bench]]
 name = "threshold_benchmarks"

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -292,7 +292,16 @@ struct DkgMessageBuffer {
 	/// Round 1 private messages received while still in Initialized phase.
 	/// Key is (from_party_id, subset_mask) to allow multiple subsets per sender.
 	/// Messages are validated before buffering to prevent DoS via invalid subset masks.
-	round1_privates: BTreeMap<(ParticipantId, SubsetMask), Round1Private>,
+	///
+	/// Values are boxed (security review hardening): B-tree node splits move
+	/// entries bytewise between nodes, leaving stale copies in the source
+	/// slots beyond the live length, where the drop-time wipe (live entries
+	/// only) cannot reach them before the node is freed. Supported committees
+	/// (n <= 6) cap this map at 10 entries — inside a single 11-entry node,
+	/// so no split can occur today — but boxing keeps K_S at a stable heap
+	/// address wiped in place on drop, so the invariant does not silently
+	/// break if larger committees are ever enabled (`SubsetMask` allows 16).
+	round1_privates: BTreeMap<(ParticipantId, SubsetMask), Box<Round1Private>>,
 	/// Round 2 broadcasts received while still in Round 1.
 	round2: BTreeMap<ParticipantId, Round2Broadcast>,
 	/// Round 3 broadcasts received while still in Round 1-2.
@@ -320,7 +329,11 @@ impl DkgMessageBuffer {
 	/// Callers MUST validate the message before buffering (subset_mask validity,
 	/// sender is leader, receiver is member). This function does not validate.
 	fn buffer_round1_private(&mut self, msg: Round1Private) {
-		self.round1_privates.entry((msg.from_party_id, msg.subset_mask)).or_insert(msg);
+		// Boxed so map rebalancing relocates pointers, not K_S bytes (see the
+		// field's doc comment). A rejected duplicate drops the box, wiping it.
+		self.round1_privates
+			.entry((msg.from_party_id, msg.subset_mask))
+			.or_insert_with(|| Box::new(msg));
 	}
 
 	/// Buffer a Round 2 broadcast for later processing.
@@ -347,7 +360,9 @@ impl DkgMessageBuffer {
 	}
 
 	/// Take all buffered Round 1 private messages.
-	fn take_round1_privates(&mut self) -> BTreeMap<(ParticipantId, SubsetMask), Round1Private> {
+	fn take_round1_privates(
+		&mut self,
+	) -> BTreeMap<(ParticipantId, SubsetMask), Box<Round1Private>> {
 		mem::take(&mut self.round1_privates)
 	}
 
@@ -1085,11 +1100,12 @@ impl<S: TranscriptSigner> Dkg<S> {
 			}
 		}
 
-		// Drain buffered Round 1 private messages with validation. Iterate by
-		// mutable reference rather than by value: consuming the map would move
-		// each Copy `Round1Private` out while leaving its K_S bytes intact in
-		// the freed map nodes. Every entry — including ones discarded by
-		// validation — is wiped in place before the map is dropped.
+		// Drain buffered Round 1 private messages with validation. The values
+		// are boxed, so the map nodes hold only pointers; iterate by mutable
+		// reference and wipe every entry — including ones discarded by
+		// validation — in place before the map is dropped (each box's
+		// ZeroizeOnDrop would also cover this; the explicit sweep keeps the
+		// wipe visible and unconditional).
 		let mut buffered_privates = self.message_buffer.take_round1_privates();
 		for (&(from_party_id, subset_mask), private) in buffered_privates.iter_mut() {
 			// Validate subset_mask is valid

--- a/threshold/src/keygen/dkg/protocol.rs
+++ b/threshold/src/keygen/dkg/protocol.rs
@@ -471,7 +471,16 @@ pub struct Dkg<S: TranscriptSigner> {
 	/// Round 1 private messages awaiting delivery, held as zeroizing
 	/// [`Round1Private`] structs (not pre-serialized byte buffers) so the queued
 	/// K_S material is wiped on drop rather than left in a freed `Vec<u8>`.
-	pending_privates: Vec<(ParticipantId, Round1Private)>,
+	///
+	/// Each private is boxed (security review): `Vec` growth copies elements
+	/// bytewise into a new buffer and frees the old one without dropping or
+	/// wiping the source slots, so storing `Round1Private` inline stranded
+	/// K_S in freed buffers whenever the queue reallocated (`ZeroizeOnDrop`
+	/// only wipes live elements in their final resting place). With a box per
+	/// element the vector's buffer holds only pointers, and the secret lives
+	/// at a stable heap address that is wiped in place when the box drops.
+	/// The realloc regression test pins this.
+	pending_privates: Vec<(ParticipantId, Box<Round1Private>)>,
 	/// Buffer for messages that arrive before we're ready to process them.
 	message_buffer: DkgMessageBuffer,
 }
@@ -553,10 +562,12 @@ impl<S: TranscriptSigner> Dkg<S> {
 
 	/// Pop the next queued Round 1 private without leaving K_S behind.
 	///
-	/// `Vec::pop` alone moves the element out but leaves its bytes intact in
-	/// the buffer beyond the shrunken length, where the drop-time wipe (which
-	/// only covers live elements) cannot reach them. Clone the element out and
-	/// wipe the slot in place before shrinking.
+	/// The queue elements are boxed, so `Vec::pop` moves only the pointer;
+	/// the stale slot beyond the shrunken length holds no secret bytes. The
+	/// private is *cloned* out of the box rather than moved (`*boxed` would
+	/// relocate the value and free the box's allocation unwiped); dropping
+	/// the box then wipes the heap copy in place (`ZeroizeOnDrop`) before
+	/// the allocation is released.
 	///
 	/// Known residual (heap is covered, stack is not): the clone returned
 	/// here moves by value through `poke` into `serialize_round1_private`,
@@ -569,13 +580,10 @@ impl<S: TranscriptSigner> Dkg<S> {
 	/// probe; tracked as follow-up, not covered by the heap-zeroization
 	/// tests.
 	fn pop_pending_private(&mut self) -> Option<(ParticipantId, Round1Private)> {
-		let (to, private) = {
-			let (to, slot) = self.pending_privates.last_mut()?;
-			let out = (*to, slot.clone());
-			slot.zeroize();
-			out
-		};
-		self.pending_privates.pop();
+		let (to, boxed) = self.pending_privates.pop()?;
+		let private = (*boxed).clone();
+		// `boxed` drops here: ZeroizeOnDrop wipes the boxed copy in place
+		// before its allocation is freed.
 		Some((to, private))
 	}
 
@@ -1167,7 +1175,9 @@ impl<S: TranscriptSigner> Dkg<S> {
 						};
 						// Queue the zeroizing struct; serialize only when popped for
 						// sending, so K_S is never parked in a plain byte buffer.
-						self.pending_privates.push((party, private));
+						// Boxed so queue growth relocates pointers, not K_S bytes
+						// (see the field's doc comment).
+						self.pending_privates.push((party, Box::new(private)));
 					}
 				}
 			}

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -1552,6 +1552,28 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		Ok(Action::SendPrivate(to_party, data))
 	}
 
+	/// Buffer a dealer's Round 4 private sub-share message, first-message-wins.
+	///
+	/// Content verification (commitment match, coefficient bounds) is
+	/// deliberately deferred to Round 5: it needs the dealer's Round 3
+	/// commitments, which may legitimately arrive *after* the Round 4
+	/// private message on an out-of-order transport.
+	///
+	/// First-wins without pre-verification is safe under the crate's
+	/// documented transport requirements (sender-authenticated channels,
+	/// see the module docs), and is the anti-equivocation choice
+	/// (security review):
+	/// - an attacker cannot occupy another party's slot, because it cannot send with a forged
+	///   `from` on an authenticated transport;
+	/// - an honest dealer sends exactly one Round 4 message per recipient, so there is never an
+	///   honest "correction" for a duplicate to drop (benign retransmits carry identical content
+	///   and are idempotent);
+	/// - a malicious dealer poisoning *its own* slot is no stronger than withholding: deferred
+	///   verification fails with the dealer attributed (`DealerDeliveryFailed`) and the session
+	///   aborts for a restart, exactly like a dealer that goes silent (see README);
+	/// - replace-on-later-message policies would be *worse*: they would let a dealer observe
+	///   protocol traffic and swap its contribution adaptively. First-wins pins each sender to a
+	///   single contribution.
 	fn handle_round4_message(&mut self, from: ParticipantId, msg: ResharingRound4Message) {
 		if matches!(self.state, ResharingState::Done | ResharingState::Failed(_)) {
 			return;
@@ -1565,8 +1587,15 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		if msg.to_party_id != self.config.my_party_id() {
 			return;
 		}
-		// Reject duplicates from the same dealer.
+		// Reject duplicates from the same dealer. Logged for observability
+		// only; the content is not compared (it is secret share material —
+		// a retransmit is indistinguishable from equivocation here, and
+		// either way the stored first message stays authoritative).
 		if self.round4_messages.contains_key(&from) {
+			log::debug!(
+				"Resharing: ignoring duplicate Round 4 message from dealer {} (first-message-wins)",
+				from
+			);
 			return;
 		}
 		self.round4_messages.insert(from, msg);
@@ -1943,6 +1972,17 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 		Ok(Action::Return(output))
 	}
 
+	/// Buffer a new committee member's acceptance signature, first-message-wins.
+	///
+	/// First-wins without pre-verification is safe under the crate's
+	/// documented transport requirements (sender-authenticated channels)
+	/// and pins each attester to a single signature (security review): an
+	/// attacker cannot occupy another party's slot, an honest member sends
+	/// exactly one accept (retransmits are identical and idempotent), and a
+	/// member poisoning its own slot with a garbage signature is no
+	/// stronger than withholding its accept — `AcceptWaiting` fails with
+	/// that party attributed, where a withheld accept stalls the session
+	/// instead. Both need the same recovery: a restart.
 	fn handle_accept_message(&mut self, from: ParticipantId, msg: ResharingAccept) {
 		if matches!(self.state, ResharingState::Done | ResharingState::Failed(_)) {
 			return;
@@ -1952,7 +1992,17 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 			return;
 		}
 		// First message wins; duplicates ignored (matches other rounds).
-		if self.accepts.contains_key(&from) {
+		// Signatures are public values, so a differing duplicate can be
+		// safely detected and surfaced: it is evidence of sender
+		// equivocation (or transport misbehavior), not a benign retransmit.
+		if let Some(stored) = self.accepts.get(&from) {
+			if *stored != msg.signature {
+				log::warn!(
+					"Resharing: party {} sent conflicting acceptance signatures \
+					 (equivocation?); keeping the first (first-message-wins)",
+					from
+				);
+			}
 			return;
 		}
 		// Signature verification is deferred to `AcceptWaiting`, where our own
@@ -3985,6 +4035,65 @@ mod tests {
 		assert!(
 			!msg.chars().any(|c| c.is_ascii_digit()),
 			"wire reason embeds digits (possible secret leak): {msg}"
+		);
+	}
+
+	/// Security review: the first-message-wins duplicate policy must hold — a
+	/// later, conflicting message from the same (transport-authenticated)
+	/// sender never displaces the stored first message, for both Round 4
+	/// sub-share deliveries and Round 6 acceptance signatures. A
+	/// replace-on-duplicate policy would let a malicious sender observe
+	/// protocol traffic and swap its contribution adaptively; see the
+	/// handler doc comments for the full argument.
+	#[test]
+	fn duplicate_round4_and_accept_messages_never_displace_the_first() {
+		let config = crate::ThresholdConfig::new(2, 3).expect("valid config");
+		let (public_key, shares) =
+			crate::keygen::generate_with_dealer(&[17u8; 32], config).expect("keygen");
+		let resharing_config = ResharingConfig::new(
+			Some(shares[1].clone()),
+			2,
+			vec![0, 1, 2],
+			2,
+			vec![0, 1, 2],
+			1,
+			public_key,
+		)
+		.expect("valid resharing config");
+		let mut protocol = ResharingProtocol::new(
+			resharing_config,
+			test_signer_config(1, &[0, 1, 2]),
+			[3u8; 32],
+			&[4u8; 32],
+			0,
+		);
+		let ssid = protocol.ssid;
+
+		// Round 4: dealer 0's first message pins its slot.
+		let mk_r4 = |coeff: i32| {
+			let mut share = NewShareData::new();
+			share.s1[0][0] = coeff;
+			let mut contributions: BTreeMap<SubsetPair, NewShareData> = BTreeMap::new();
+			contributions.insert((0b011, 0b011), share);
+			ResharingRound4Message { ssid, from_party_id: 0, to_party_id: 1, contributions }
+		};
+		protocol.handle_round4_message(0, mk_r4(7));
+		protocol.handle_round4_message(0, mk_r4(8)); // conflicting duplicate
+		let stored = protocol.round4_messages.get(&0).expect("first message stored");
+		assert_eq!(
+			stored.contributions.get(&(0b011, 0b011)).expect("contribution").s1[0][0],
+			7,
+			"a duplicate Round 4 message must not displace the first"
+		);
+
+		// Round 6: party 2's first acceptance signature pins its slot.
+		let mk_accept = |sig: Vec<u8>| ResharingAccept { ssid, party_id: 2, signature: sig };
+		protocol.handle_accept_message(2, mk_accept(vec![1, 2, 3]));
+		protocol.handle_accept_message(2, mk_accept(vec![9, 9, 9])); // conflicting duplicate
+		assert_eq!(
+			protocol.accepts.get(&2).expect("first accept stored"),
+			&vec![1, 2, 3],
+			"a duplicate acceptance must not displace the first"
 		);
 	}
 

--- a/threshold/src/resharing/protocol.rs
+++ b/threshold/src/resharing/protocol.rs
@@ -433,7 +433,15 @@ pub struct ResharingProtocol<S: TranscriptSigner> {
 	// ========================================================================
 	/// Pre-computed sub-shares we are responsible for dealing.
 	/// Keyed by `(old_subset, new_subset)`.
-	my_subshares: BTreeMap<SubsetPair, NewShareData>,
+	///
+	/// Values are `Box`ed (security review): a dealer for all subsets
+	/// containing it holds up to 150 entries at supported sizes (e.g.
+	/// 3-of-6 → 3-of-6), far past the B-tree's 11-entry node capacity, so
+	/// node splits are guaranteed — and splits copy entries byte-wise,
+	/// stranding coefficients in freed node memory beyond `ZeroizeOnDrop`'s
+	/// reach. Boxing keeps each secret in one heap home, wiped in place on
+	/// drop; node operations move only pointers.
+	my_subshares: BTreeMap<SubsetPair, Box<NewShareData>>,
 	/// Our Round 3 broadcast (commitments for subsets we deal).
 	my_round3: Option<ResharingRound3Broadcast>,
 	/// Round 3 broadcasts received from other old committee members.
@@ -454,7 +462,8 @@ pub struct ResharingProtocol<S: TranscriptSigner> {
 	round5_broadcasts: BTreeMap<ParticipantId, ResharingRound5Broadcast>,
 
 	/// Computed new shares: `new_subset -> s_J^new`. Populated in Round 5.
-	new_shares: BTreeMap<SubsetMask, NewShareData>,
+	/// Values are `Box`ed for the same node-split reason as `my_subshares`.
+	new_shares: BTreeMap<SubsetMask, Box<NewShareData>>,
 	/// Final output (cached so `take_output` can return it after Combining).
 	completed_output: Option<ResharingOutput>,
 
@@ -2053,13 +2062,17 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 				&session_seed,
 				self.old_subset_order.len(),
 			);
-			// Move each sub-share out with `mem::take` rather than
-			// `into_iter()`: consuming the Vec by value skips the elements'
-			// zeroizing drops, freeing the backing buffer with the raw
-			// coefficients still in it. Taking leaves zeros in the slots,
-			// which the Vec's (zeroizing) element drops then wipe redundantly.
+			// Move each sub-share out by swapping it into a freshly boxed
+			// zero share, rather than `into_iter()` (which would free the
+			// Vec's buffer with the raw coefficients still in it) or
+			// `mem::take` + `Box::new` (which would stage the 15 KiB secret
+			// in an unwiped stack temporary). The swap writes directly
+			// heap-to-heap, the Vec slot is left holding zeros, and the
+			// Vec's (zeroizing) element drops then wipe it redundantly.
 			for (j_mask, subshare) in new_subsets.iter().zip(subshares.iter_mut()) {
-				self.my_subshares.insert((i_mask, *j_mask), core::mem::take(subshare));
+				let mut boxed = Box::new(NewShareData::new());
+				core::mem::swap(&mut *boxed, subshare);
+				self.my_subshares.insert((i_mask, *j_mask), boxed);
 			}
 		}
 		Ok(())
@@ -2081,7 +2094,7 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 	/// This mirrors the DKG pattern (`process_round1` skips self) and removes the
 	/// implicit "network must loopback SendPrivate(self, _)" requirement.
 	fn build_pending_round4_messages(&mut self) {
-		let mut by_recipient: BTreeMap<ParticipantId, BTreeMap<SubsetPair, NewShareData>> =
+		let mut by_recipient: BTreeMap<ParticipantId, BTreeMap<SubsetPair, Box<NewShareData>>> =
 			BTreeMap::new();
 		for (pair, share) in &self.my_subshares {
 			let j_mask = pair.1;
@@ -2144,14 +2157,16 @@ impl<S: TranscriptSigner> ResharingProtocol<S> {
 				|| ResharingProtocolError::InternalError("not in new committee".into()),
 			)?;
 
-		// Collect every (I, J, dealer, r) we expect to use.
+		// Collect every (I, J, dealer, r) we expect to use. Boxed values for
+		// the same node-split reason as the `new_shares` field this map is
+		// drained into.
 		let new_subsets = &self.new_subset_order;
-		let mut s_new: BTreeMap<SubsetMask, NewShareData> = BTreeMap::new();
+		let mut s_new: BTreeMap<SubsetMask, Box<NewShareData>> = BTreeMap::new();
 		for &j_mask in new_subsets {
 			if (j_mask & (1 << my_idx)) == 0 {
 				continue;
 			}
-			s_new.insert(j_mask, NewShareData::new());
+			s_new.insert(j_mask, Box::new(NewShareData::new()));
 		}
 
 		for &i_mask in &self.old_subset_order {
@@ -3327,6 +3342,22 @@ mod tests {
 			.expect("keys cover participants")
 	}
 
+	/// Compile-time pin (security review): the share-bearing maps must keep
+	/// `Box`ed values so B-tree node splits move pointers, not coefficients —
+	/// at supported committee sizes these maps far exceed the 11-entry node
+	/// capacity, so splits (and byte-wise entry copies into freed-later
+	/// nodes) are guaranteed. If a refactor inlines the values again this
+	/// stops compiling; the heap probe in
+	/// `tests/newshare_btree_node_zeroization.rs` demonstrates the leak the
+	/// boxing prevents.
+	#[allow(dead_code)]
+	fn pin_boxed_share_maps<S: TranscriptSigner>(p: &ResharingProtocol<S>) {
+		let _: &BTreeMap<SubsetPair, Box<NewShareData>> = &p.my_subshares;
+		let _: &BTreeMap<SubsetMask, Box<NewShareData>> = &p.new_shares;
+		let _: Option<&BTreeMap<SubsetPair, Box<NewShareData>>> =
+			p.round4_messages.get(&0).map(|m| &m.contributions);
+	}
+
 	#[test]
 	fn test_generate_subset_masks() {
 		let s = generate_subset_masks(3, 2);
@@ -3647,7 +3678,7 @@ mod tests {
 		let contribution =
 			NewShareData { s1: [[coeff; N as usize]; L], s2: [[coeff; N as usize]; K] };
 		let mut contributions = BTreeMap::new();
-		contributions.insert((0b011, 0b101), contribution);
+		contributions.insert((0b011, 0b101), Box::new(contribution));
 		let msg = ResharingRound4Message {
 			// Non-marker ssid so the sanity check below matches sub-share
 			// bytes, not session metadata.
@@ -3868,8 +3899,8 @@ mod tests {
 		assert!(plus.coefficients_within_bound(SUBSHARE_COEFF_BOUND));
 		assert!(minus.coefficients_within_bound(SUBSHARE_COEFF_BOUND));
 
-		protocol.new_shares.insert(0b011, plus);
-		protocol.new_shares.insert(0b110, minus);
+		protocol.new_shares.insert(0b011, Box::new(plus));
+		protocol.new_shares.insert(0b110, Box::new(minus));
 
 		let err = protocol
 			.verify_recovered_partial_norms()
@@ -3929,7 +3960,7 @@ mod tests {
 				*c = coeff;
 			}
 		}
-		protocol.new_shares.insert(0b011, inflated);
+		protocol.new_shares.insert(0b011, Box::new(inflated));
 
 		let err = protocol.verify_stored_new_share_norms().expect_err(
 			"a stored share inflated 3x past the single-share envelope must be rejected",
@@ -3995,13 +4026,13 @@ mod tests {
 		};
 		let target_js = [0b011u16, 0b110u16];
 		for (dealer, i_masks) in [(0u32, &[0b011u16, 0b101u16][..]), (1u32, &[0b110u16][..])] {
-			let mut contributions: BTreeMap<SubsetPair, NewShareData> = BTreeMap::new();
+			let mut contributions: BTreeMap<SubsetPair, Box<NewShareData>> = BTreeMap::new();
 			let mut commitments: BTreeMap<SubsetPair, [u8; COMMITMENT_HASH_SIZE]> = BTreeMap::new();
 			for &i in i_masks {
 				for &j in &target_js {
 					let r = make(i, j);
 					commitments.insert((i, j), commit_subshare(i, j, &r));
-					contributions.insert((i, j), r);
+					contributions.insert((i, j), Box::new(r));
 				}
 			}
 			protocol.round3_broadcasts.insert(
@@ -4073,8 +4104,8 @@ mod tests {
 		let mk_r4 = |coeff: i32| {
 			let mut share = NewShareData::new();
 			share.s1[0][0] = coeff;
-			let mut contributions: BTreeMap<SubsetPair, NewShareData> = BTreeMap::new();
-			contributions.insert((0b011, 0b011), share);
+			let mut contributions: BTreeMap<SubsetPair, Box<NewShareData>> = BTreeMap::new();
+			contributions.insert((0b011, 0b011), Box::new(share));
 			ResharingRound4Message { ssid, from_party_id: 0, to_party_id: 1, contributions }
 		};
 		protocol.handle_round4_message(0, mk_r4(7));

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -786,14 +786,27 @@ impl BorshDeserialize for ResharingAccept {
 /// verifying keys of (at least) every new committee member. Only new
 /// committee members produce acceptance signatures, but every participant
 /// verifies them, so every participant needs the new committee's keys.
+///
+/// Construct via [`ResharingSignerConfig::new`]. The fields are private
+/// (security review, mirroring [`DkgConfig`](crate::keygen::dkg::DkgConfig)):
+/// the long-term transcript signer is secret-adjacent capability material,
+/// and exposing it publicly would let downstream code extract it from the
+/// config and sign arbitrary payloads with it.
+///
+/// ```compile_fail
+/// use qp_rusty_crystals_threshold::resharing::{ResharingSignerConfig, TranscriptSigner};
+/// fn steal_signer<S: TranscriptSigner>(cfg: &ResharingSignerConfig<S>) -> &S {
+///     &cfg.my_signer // ERROR: private — the signer is not exposed
+/// }
+/// ```
 #[derive(Clone)]
 pub struct ResharingSignerConfig<S: crate::keygen::dkg::TranscriptSigner> {
 	/// This party's signer for transcript acceptance (used only if this party
 	/// is in the new committee).
-	pub my_signer: S,
+	pub(crate) my_signer: S,
 	/// Verifying keys, keyed by participant ID. Must cover every new
 	/// committee member; extra entries are ignored.
-	pub verifying_keys: BTreeMap<ParticipantId, S::PublicKey>,
+	pub(crate) verifying_keys: BTreeMap<ParticipantId, S::PublicKey>,
 }
 
 impl<S: crate::keygen::dkg::TranscriptSigner> ResharingSignerConfig<S> {
@@ -1138,6 +1151,18 @@ pub type SubsetPair = (SubsetMask, SubsetMask);
 ///
 /// Transmitting this message over an unencrypted channel exposes sub-shares to
 /// eavesdroppers and compromises the threshold scheme's security.
+///
+/// The routing metadata (`ssid`, `from_party_id`, `to_party_id`) is public,
+/// but the `contributions` map carries the plaintext sub-shares and is
+/// therefore not part of the public API (security review): the protocol
+/// fills and consumes it internally, and downstream code has no legitimate
+/// reason to inspect it.
+///
+/// ```compile_fail
+/// fn read_subshares(msg: &qp_rusty_crystals_threshold::resharing::ResharingRound4Message) {
+///     let _ = &msg.contributions; // ERROR: private — sub-shares are opaque
+/// }
+/// ```
 #[derive(Clone, BorshSerialize)]
 pub struct ResharingRound4Message {
 	/// Session identifier binding this message to the resharing session.
@@ -1147,7 +1172,18 @@ pub struct ResharingRound4Message {
 	/// Party ID of the recipient.
 	pub to_party_id: ParticipantId,
 	/// Per-`(old_subset, new_subset)` contributions destined for the recipient.
-	pub contributions: BTreeMap<SubsetPair, NewShareData>,
+	pub(crate) contributions: BTreeMap<SubsetPair, NewShareData>,
+}
+
+/// Test-only escape hatch for the crate's adversary-simulation tests
+/// (replacing or stripping a dealer's in-flight contributions). See
+/// [`NewShareData`]'s test helpers for the gating rationale.
+#[cfg(feature = "internal-test-helpers")]
+impl ResharingRound4Message {
+	#[doc(hidden)]
+	pub fn testing_contributions_mut(&mut self) -> &mut BTreeMap<SubsetPair, NewShareData> {
+		&mut self.contributions
+	}
 }
 
 impl BorshDeserialize for ResharingRound4Message {
@@ -1197,12 +1233,52 @@ impl fmt::Debug for ResharingRound4Message {
 }
 
 /// New share data for a specific subset.
+///
+/// The coefficient arrays are secret share material and are deliberately
+/// not part of the public API (security review): exposing them invited
+/// downstream code to read, log, or retain plaintext copies outside the
+/// value's `ZeroizeOnDrop` lifecycle. The crate's convention (see
+/// [`crate::PrivateKeyShare`]) is that share-bearing types are opaque to
+/// consumers; the protocol constructs, verifies, and consumes them
+/// internally.
+///
+/// ```compile_fail
+/// fn read_coefficients(share: &qp_rusty_crystals_threshold::resharing::NewShareData) -> i32 {
+///     share.s1[0][0] // ERROR: `s1` is private — sub-shares are opaque
+/// }
+/// ```
 #[derive(Clone, BorshSerialize, BorshDeserialize, Zeroize, ZeroizeOnDrop)]
 pub struct NewShareData {
 	/// Share of s1 polynomial vector (exactly L polynomials).
-	pub s1: [[i32; N as usize]; L],
+	pub(crate) s1: [[i32; N as usize]; L],
 	/// Share of s2 polynomial vector (exactly K polynomials).
-	pub s2: [[i32; N as usize]; K],
+	pub(crate) s2: [[i32; N as usize]; K],
+}
+
+/// Test-only escape hatches for the crate's adversary-simulation tests
+/// (forging malicious sub-shares, recomputing commitments over them).
+/// Gated behind the non-default `internal-test-helpers` feature — enabled
+/// only for this crate's own test builds via a self-referential
+/// dev-dependency — and hidden from docs. Not a stable API.
+#[cfg(feature = "internal-test-helpers")]
+impl NewShareData {
+	#[doc(hidden)]
+	pub fn testing_from_coefficients(
+		s1: [[i32; N as usize]; L],
+		s2: [[i32; N as usize]; K],
+	) -> Self {
+		Self { s1, s2 }
+	}
+
+	#[doc(hidden)]
+	pub fn testing_s1(&self) -> &[[i32; N as usize]; L] {
+		&self.s1
+	}
+
+	#[doc(hidden)]
+	pub fn testing_s2(&self) -> &[[i32; N as usize]; K] {
+		&self.s2
+	}
 }
 
 impl NewShareData {

--- a/threshold/src/resharing/types.rs
+++ b/threshold/src/resharing/types.rs
@@ -1172,7 +1172,16 @@ pub struct ResharingRound4Message {
 	/// Party ID of the recipient.
 	pub to_party_id: ParticipantId,
 	/// Per-`(old_subset, new_subset)` contributions destined for the recipient.
-	pub(crate) contributions: BTreeMap<SubsetPair, NewShareData>,
+	///
+	/// Values are `Box`ed (security review): at supported committee sizes a
+	/// recipient's map holds up to 100 entries — far past the B-tree's
+	/// 11-entry node capacity — and node splits copy entries byte-wise
+	/// between nodes, stranding sub-share coefficients in freed node memory
+	/// beyond the reach of `ZeroizeOnDrop` (which only wipes live values).
+	/// Boxing keeps each secret in exactly one heap allocation that is wiped
+	/// in place on drop; node operations move only pointers. Borsh
+	/// serializes `Box<T>` transparently, so the wire format is unchanged.
+	pub(crate) contributions: BTreeMap<SubsetPair, Box<NewShareData>>,
 }
 
 /// Test-only escape hatch for the crate's adversary-simulation tests
@@ -1181,7 +1190,7 @@ pub struct ResharingRound4Message {
 #[cfg(feature = "internal-test-helpers")]
 impl ResharingRound4Message {
 	#[doc(hidden)]
-	pub fn testing_contributions_mut(&mut self) -> &mut BTreeMap<SubsetPair, NewShareData> {
+	pub fn testing_contributions_mut(&mut self) -> &mut BTreeMap<SubsetPair, Box<NewShareData>> {
 		&mut self.contributions
 	}
 }
@@ -1204,7 +1213,9 @@ impl BorshDeserialize for ResharingRound4Message {
 		let mut contributions = BTreeMap::new();
 		for _ in 0..len {
 			let key = SubsetPair::deserialize_reader(reader)?;
-			let value = NewShareData::deserialize_reader(reader)?;
+			// Boxed straight away so the B-tree nodes hold pointers, not
+			// inline secrets (see the field docs).
+			let value = Box::new(NewShareData::deserialize_reader(reader)?);
 			contributions.insert(key, value);
 		}
 

--- a/threshold/tests/dkg_pending_privates_realloc_zeroization.rs
+++ b/threshold/tests/dkg_pending_privates_realloc_zeroization.rs
@@ -1,0 +1,207 @@
+//! Regression test (security review): growth of the DKG `pending_privates`
+//! queue must never free a buffer that still contains subset shared secrets.
+//!
+//! The queue held `(ParticipantId, Round1Private)` values in a plain `Vec`.
+//! `Round1Private` is `ZeroizeOnDrop`, but that only wipes live elements in
+//! their final resting place: when a `Vec` grows it copies its elements
+//! bytewise into a new buffer and frees the old one without any drop or wipe,
+//! so every reallocation stranded a buffer full of K_S values in freed heap
+//! memory — past the reach of `pop_pending_private`'s slot wipe and the
+//! `Drop`-time sweep, which both only touch the live buffer.
+//!
+//! The existing `heap_zeroization.rs` DKG scenario could not see this: its
+//! 2-of-3 run queues at most 2 privates per party, within the `Vec`'s minimum
+//! non-zero capacity of 4 for ~76-byte elements, so no reallocation ever
+//! happened. This test runs a deterministic 2-of-5 DKG in which party 0 leads
+//! four subsets of size 4 and queues 12 privates, forcing reallocations.
+//!
+//! Detection follows the established technique: a global allocator scans every
+//! freed block — still valid inside the `dealloc` hook, so the read is sound —
+//! for any K_S learned from an identical reference run (the protocol's
+//! randomness is SHAKE-derived from the fixed seeds, so runs are
+//! byte-identical). This file contains exactly one test so no unrelated
+//! concurrent allocations can race the scanner.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	collections::BTreeMap,
+	sync::Mutex,
+};
+
+use qp_rusty_crystals_threshold::{
+	keygen::dkg::{Dkg, DkgAction, DkgConfig, TranscriptSigner},
+	ThresholdConfig,
+};
+use zeroize::Zeroizing;
+
+/// All K_S values observed in the reference run (one per (leader, subset)
+/// private delivery; 32 bytes each). Only written while scanning is off, so
+/// `try_lock` in the hook never contends and never misses.
+static PATTERNS: Mutex<Vec<[u8; 32]>> = Mutex::new(Vec::new());
+static SCANNING: AtomicBool = AtomicBool::new(false);
+static SECRET_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+static LEAK_SIZE: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+
+struct SecretScanningAllocator;
+
+unsafe impl GlobalAlloc for SecretScanningAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		if SCANNING.load(Ordering::SeqCst) && layout.size() >= 32 {
+			if let Ok(patterns) = PATTERNS.try_lock() {
+				let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+				if block.windows(32).any(|w| patterns.iter().any(|p| w == p)) {
+					SECRET_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+					LEAK_SIZE.store(layout.size(), Ordering::SeqCst);
+				}
+			}
+		}
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: SecretScanningAllocator = SecretScanningAllocator;
+
+/// Simple test signer for DKG transcript signing (mirrors the DKG unit-test
+/// signer).
+#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
+struct TestSigner {
+	id: u32,
+}
+
+impl TranscriptSigner for TestSigner {
+	type Signature = Vec<u8>;
+	type PublicKey = u32;
+
+	fn sign(&self, hash: &[u8; 32]) -> Self::Signature {
+		let mut sig = vec![0u8; 36];
+		sig[..4].copy_from_slice(&self.id.to_le_bytes());
+		sig[4..36].copy_from_slice(hash);
+		sig
+	}
+
+	fn verify(pk: &Self::PublicKey, hash: &[u8; 32], sig: &Self::Signature) -> bool {
+		Self::verify_bytes(pk, hash, sig)
+	}
+
+	fn verify_bytes(pk: &Self::PublicKey, hash: &[u8; 32], sig: &[u8]) -> bool {
+		if sig.len() < 36 {
+			return false;
+		}
+		let sig_id = u32::from_le_bytes(sig[..4].try_into().unwrap());
+		sig_id == *pk && &sig[4..36] == hash
+	}
+
+	fn public_key(&self) -> Self::PublicKey {
+		self.id
+	}
+}
+
+/// Run a deterministic 2-of-5 DKG locally, returning every K_S observed on
+/// the wire (the last 32 bytes of each Round 1 private frame). With n=5 and
+/// t=2, subsets have size n-t+1 = 4; party 0 is the leader (lowest id) of all
+/// C(4,3) = 4 subsets containing it and queues 4 x 3 = 12 privates, driving
+/// the queue through at least one reallocation.
+///
+/// The collected secrets are themselves kept leak-free so the scanner only
+/// sees the protocol's behavior: the collection Vec is allocated at its exact
+/// final size (its own growth would free unwiped intermediate buffers) and
+/// wrapped in `Zeroizing` (its drop in the scanned run must wipe the copies).
+fn run_local_dkg_2of5() -> Zeroizing<Vec<[u8; 32]>> {
+	let threshold_config = ThresholdConfig::new(2, 5).expect("valid config");
+	let participants: Vec<u32> = vec![0, 1, 2, 3, 4];
+	let pk_map: BTreeMap<u32, u32> = participants.iter().map(|&p| (p, p)).collect();
+	let session_nonce = [0x4Du8; 32];
+
+	let mut dkgs: Vec<_> = participants
+		.iter()
+		.map(|&party_id| {
+			let config = DkgConfig::new(
+				threshold_config,
+				party_id,
+				participants.clone(),
+				TestSigner { id: party_id },
+				pk_map.clone(),
+			)
+			.expect("valid DKG config");
+			let mut seed = [0xB2u8; 32];
+			seed[0] = party_id as u8;
+			Dkg::new(config, seed, &session_nonce)
+		})
+		.collect();
+
+	let mut queues: Vec<Vec<(u32, Vec<u8>)>> = vec![Vec::new(); participants.len()];
+	// Exactly 15 private deliveries occur (see the assertion below).
+	let mut ks_values: Zeroizing<Vec<[u8; 32]>> = Zeroizing::new(Vec::with_capacity(15));
+	let mut done = vec![false; participants.len()];
+	for _ in 0..1000 {
+		if done.iter().all(|&d| d) {
+			break;
+		}
+		for i in 0..dkgs.len() {
+			if done[i] {
+				continue;
+			}
+			for (from, data) in std::mem::take(&mut queues[i]) {
+				dkgs[i].message(from, data).expect("message is processed");
+			}
+			match dkgs[i].poke().expect("poke succeeds") {
+				DkgAction::Wait => {},
+				DkgAction::SendMany(data) =>
+					for (j, queue) in queues.iter_mut().enumerate() {
+						if j != i {
+							queue.push((i as u32, data.clone()));
+						}
+					},
+				DkgAction::SendPrivate(to, mut data) => {
+					// Round 1 private frames carry K_S; the serialized tail
+					// is the secret itself.
+					if data.len() >= 32 {
+						ks_values.push(data[data.len() - 32..].try_into().unwrap());
+					}
+					queues[to as usize].push((i as u32, std::mem::take(&mut *data)));
+				},
+				DkgAction::Return(_output) => {
+					done[i] = true;
+				},
+			}
+		}
+	}
+	assert!(done.iter().all(|&d| d), "DKG must complete");
+	// 5 subsets x 3 recipients = 15 private deliveries, 12 of them queued by
+	// party 0 — well past the queue's initial capacity of 4.
+	assert_eq!(
+		ks_values.len(),
+		15,
+		"test setup: expected party 0 to queue 12 of 15 private deliveries"
+	);
+	ks_values
+}
+
+#[test]
+fn pending_privates_queue_growth_never_frees_unwiped_ks() {
+	// Reference run (scanner off) to learn every K_S this deterministic
+	// session produces. The static keeps plain copies, but it is never
+	// deallocated, so the scanner cannot be tripped by it.
+	let patterns = run_local_dkg_2of5();
+	*PATTERNS.lock().unwrap() = patterns.to_vec();
+	drop(patterns);
+
+	SECRET_FREED_UNCLEARED.store(false, Ordering::SeqCst);
+	SCANNING.store(true, Ordering::SeqCst);
+	let _ = run_local_dkg_2of5();
+	SCANNING.store(false, Ordering::SeqCst);
+
+	assert!(
+		!SECRET_FREED_UNCLEARED.load(Ordering::SeqCst),
+		"a heap block ({} bytes) still containing a subset shared secret K_S was \
+		 freed without being zeroized; growth of the pending_privates queue must \
+		 not strand secrets in freed buffers",
+		LEAK_SIZE.load(Ordering::SeqCst)
+	);
+}

--- a/threshold/tests/newshare_btree_node_zeroization.rs
+++ b/threshold/tests/newshare_btree_node_zeroization.rs
@@ -1,0 +1,124 @@
+//! Regression test (security review): `NewShareData` values stored in the
+//! resharing B-tree maps must not leave sub-share coefficients in freed node
+//! memory.
+//!
+//! The resharing protocol parks sub-shares in `BTreeMap`s — `my_subshares`
+//! and the per-recipient Round 4 `contributions` maps. Unlike the DKG's
+//! `round1_privates` buffer (where supported committee sizes keep the map
+//! under the 11-entry node capacity), these maps blow far past it at
+//! supported sizes: in a 3-of-6 → 3-of-6 reshare, `designated_dealer_for`
+//! picks the lowest active member of each subset, so party 0 deals for all
+//! C(5,2) = 10 old subsets containing it across C(6,4) = 15 new subsets —
+//! 150 `my_subshares` entries — and a single recipient's `contributions` map
+//! gets 10 × 10 = 100. Node splits are therefore *guaranteed*, and splits
+//! move entries byte-wise between nodes: `ZeroizeOnDrop` wipes live values,
+//! but the stale copies left behind by node operations are freed unwiped
+//! when the nodes are released.
+//!
+//! This probe mirrors the map shape with the crate's real `NewShareData`
+//! (via the `internal-test-helpers` constructor): insert 100 entries with
+//! distinctive coefficients, drop the map, and scan every freed block for a
+//! window of a mid-map entry's coefficient bytes. With values stored inline
+//! it trips; with `Box<NewShareData>` values (the protocol's representation)
+//! node operations move only pointers and the box wipes in place on drop.
+//! One test per file so unrelated concurrent allocations cannot race the
+//! scanner.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	collections::BTreeMap,
+	sync::OnceLock,
+};
+
+use qp_rusty_crystals_threshold::{
+	params::{K, L, N},
+	resharing::{NewShareData, SubsetPair},
+};
+
+const N_USIZE: usize = N as usize;
+
+/// How many entries the probe inserts: one recipient's Round 4
+/// `contributions` map in a 3-of-6 → 3-of-6 reshare holds exactly this many.
+const ENTRIES: u16 = 100;
+
+/// The entry whose coefficient bytes the scanner looks for. Mid-map, so it
+/// sits in a node that participates in splits as the map grows.
+const TARGET: u16 = 57;
+
+/// Distinctive per-entry coefficient: high bytes are a marker, low bytes the
+/// entry index, so a match cannot come from unrelated memory noise.
+const fn coeff(idx: u16) -> i32 {
+	0x11A5_0000_u32 as i32 | idx as i32
+}
+
+/// 64 bytes = 16 consecutive coefficients of the target entry.
+static COEFF_PATTERN: OnceLock<Vec<u8>> = OnceLock::new();
+
+static SCANNING: AtomicBool = AtomicBool::new(false);
+static COEFFS_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+
+struct SecretScanningAllocator;
+
+unsafe impl GlobalAlloc for SecretScanningAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		unsafe { System.alloc(layout) }
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		if SCANNING.load(Ordering::SeqCst) {
+			if let Some(pattern) = COEFF_PATTERN.get() {
+				if layout.size() >= pattern.len() {
+					let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+					if block.windows(pattern.len()).any(|w| w == &pattern[..]) {
+						COEFFS_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+					}
+				}
+			}
+		}
+		unsafe { System.dealloc(ptr, layout) }
+	}
+}
+
+#[global_allocator]
+static ALLOCATOR: SecretScanningAllocator = SecretScanningAllocator;
+
+fn make_share(idx: u16) -> NewShareData {
+	let c = coeff(idx);
+	NewShareData::testing_from_coefficients([[c; N_USIZE]; L], [[c; N_USIZE]; K])
+}
+
+#[test]
+fn subshare_btree_nodes_never_free_unwiped_coefficients() {
+	let mut pattern = Vec::with_capacity(64);
+	for _ in 0..16 {
+		pattern.extend_from_slice(&coeff(TARGET).to_le_bytes());
+	}
+	COEFF_PATTERN.set(pattern).expect("set once");
+
+	// Same shape as the protocol's share maps (`my_subshares`, Round 4
+	// `contributions`, `new_shares`): `Box`ed values, so node operations
+	// move only pointers. Storing `NewShareData` inline here instead
+	// reproduces the leak this test exists to prevent (stale coefficients
+	// in freed nodes); a compile-time pin in the protocol's unit tests
+	// keeps the real fields boxed. Keys are (old_subset, new_subset)
+	// pairs; their exact values are irrelevant to node mechanics.
+	SCANNING.store(true, Ordering::SeqCst);
+	{
+		let mut map: BTreeMap<SubsetPair, Box<NewShareData>> = BTreeMap::new();
+		for idx in 0..ENTRIES {
+			map.insert((idx, idx), Box::new(make_share(idx)));
+		}
+		core::hint::black_box(&map);
+		// Drop: node blocks are freed; each box wipes its NewShareData in
+		// place (ZeroizeOnDrop) before its allocation is released.
+	}
+	SCANNING.store(false, Ordering::SeqCst);
+
+	assert!(
+		!COEFFS_FREED_UNCLEARED.load(Ordering::SeqCst),
+		"a freed B-tree node still held NewShareData coefficient bytes; \
+		 node splits copy entries byte-wise, so sub-shares stored inline \
+		 survive in freed node memory despite ZeroizeOnDrop on live values"
+	);
+}

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -1700,8 +1700,7 @@ fn test_resharing_detects_round2_payload_mismatch() {
 		};
 		let modified = match msg {
 			ResharingMessage::Round4(mut m) => {
-				if m.from_party_id == 0
-					&& m.testing_contributions_mut().contains_key(&target_pair)
+				if m.from_party_id == 0 && m.testing_contributions_mut().contains_key(&target_pair)
 				{
 					m.testing_contributions_mut().insert(target_pair, bogus_r_capt.clone());
 				}
@@ -1782,8 +1781,7 @@ fn test_resharing_detects_consistent_dealer_tamper_at_t_equals_n() {
 				}
 			},
 			ResharingMessage::Round4(mut m) => {
-				if m.from_party_id == 0
-					&& m.testing_contributions_mut().contains_key(&target_pair)
+				if m.from_party_id == 0 && m.testing_contributions_mut().contains_key(&target_pair)
 				{
 					m.testing_contributions_mut().insert(target_pair, bogus_r_capt.clone());
 					ResharingMessage::Round4(m)

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -1584,14 +1584,14 @@ fn forge_consistent_commitment(i_mask: u16, j_mask: u16, r: &NewShareData) -> [u
 	fips202::shake256_absorb(&mut state, &i_mask.to_le_bytes());
 	fips202::shake256_absorb(&mut state, &j_mask.to_le_bytes());
 	let mut buf: Vec<u8> = Vec::new();
-	for poly in &r.s1 {
+	for poly in r.testing_s1() {
 		buf.clear();
 		for c in poly {
 			buf.extend_from_slice(&c.to_le_bytes());
 		}
 		fips202::shake256_absorb(&mut state, &buf);
 	}
-	for poly in &r.s2 {
+	for poly in r.testing_s2() {
 		buf.clear();
 		for c in poly {
 			buf.extend_from_slice(&c.to_le_bytes());
@@ -1686,7 +1686,8 @@ fn test_resharing_detects_round2_payload_mismatch() {
 	}
 
 	let target_pair = (0b011u16, 0b011u16);
-	let bogus_r = NewShareData { s1: [[99i32; N_USIZE]; L], s2: [[13i32; N_USIZE]; K] };
+	let bogus_r =
+		NewShareData::testing_from_coefficients([[99i32; N_USIZE]; L], [[13i32; N_USIZE]; K]);
 
 	let bogus_r_capt = bogus_r.clone();
 	let tamper: TamperFn = Box::new(move |sender, _recipient, data| {
@@ -1699,8 +1700,10 @@ fn test_resharing_detects_round2_payload_mismatch() {
 		};
 		let modified = match msg {
 			ResharingMessage::Round4(mut m) => {
-				if m.from_party_id == 0 && m.contributions.contains_key(&target_pair) {
-					m.contributions.insert(target_pair, bogus_r_capt.clone());
+				if m.from_party_id == 0
+					&& m.testing_contributions_mut().contains_key(&target_pair)
+				{
+					m.testing_contributions_mut().insert(target_pair, bogus_r_capt.clone());
 				}
 				ResharingMessage::Round4(m)
 			},
@@ -1755,7 +1758,8 @@ fn test_resharing_detects_consistent_dealer_tamper_at_t_equals_n() {
 		old_shares.insert(share.party_id(), share.clone());
 	}
 
-	let bogus_r = NewShareData { s1: [[42i32; N_USIZE]; L], s2: [[7i32; N_USIZE]; K] };
+	let bogus_r =
+		NewShareData::testing_from_coefficients([[42i32; N_USIZE]; L], [[7i32; N_USIZE]; K]);
 	let target_pair = (0b01u16, 0b10u16);
 	let bogus_commit = forge_consistent_commitment(target_pair.0, target_pair.1, &bogus_r);
 
@@ -1778,8 +1782,10 @@ fn test_resharing_detects_consistent_dealer_tamper_at_t_equals_n() {
 				}
 			},
 			ResharingMessage::Round4(mut m) => {
-				if m.from_party_id == 0 && m.contributions.contains_key(&target_pair) {
-					m.contributions.insert(target_pair, bogus_r_capt.clone());
+				if m.from_party_id == 0
+					&& m.testing_contributions_mut().contains_key(&target_pair)
+				{
+					m.testing_contributions_mut().insert(target_pair, bogus_r_capt.clone());
 					ResharingMessage::Round4(m)
 				} else {
 					ResharingMessage::Round4(m)
@@ -2978,7 +2984,8 @@ fn test_resharing_aborts_on_round4_omission() {
 			// Strip all contributions from the Round 4 message
 			if let ResharingMessage::Round4(mut r4) = msg {
 				*dropped_count_clone.borrow_mut() += 1;
-				r4.contributions.clear(); // Empty contributions = dealer didn't deliver
+				// Empty contributions = dealer didn't deliver
+				r4.testing_contributions_mut().clear();
 				return borsh::to_vec(&ResharingMessage::Round4(r4))
 					.expect("re-serialize tampered msg");
 			}

--- a/threshold/tests/resharing_tests.rs
+++ b/threshold/tests/resharing_tests.rs
@@ -1702,7 +1702,8 @@ fn test_resharing_detects_round2_payload_mismatch() {
 			ResharingMessage::Round4(mut m) => {
 				if m.from_party_id == 0 && m.testing_contributions_mut().contains_key(&target_pair)
 				{
-					m.testing_contributions_mut().insert(target_pair, bogus_r_capt.clone());
+					m.testing_contributions_mut()
+						.insert(target_pair, Box::new(bogus_r_capt.clone()));
 				}
 				ResharingMessage::Round4(m)
 			},
@@ -1783,7 +1784,8 @@ fn test_resharing_detects_consistent_dealer_tamper_at_t_equals_n() {
 			ResharingMessage::Round4(mut m) => {
 				if m.from_party_id == 0 && m.testing_contributions_mut().contains_key(&target_pair)
 				{
-					m.testing_contributions_mut().insert(target_pair, bogus_r_capt.clone());
+					m.testing_contributions_mut()
+						.insert(target_pair, Box::new(bogus_r_capt.clone()));
 					ResharingMessage::Round4(m)
 				} else {
 					ResharingMessage::Round4(m)


### PR DESCRIPTION
# Security review round: secret custody on the heap, the stack, and the public API

Works through the latest batch of security-review findings. Every item was first
verified against the code; where a leak was reproducible a failing (red) test was
written before the fix, and every fix ships with a regression test that pins the
new behavior. Two findings were assessed as not exploitable under the documented
threat model and are addressed with documentation, logging, and pinning tests
instead of behavior changes.

## Fixes

### hdwallet: `generate_mnemonic` returned the recovery phrase as a plain `String`

The 24-word BIP-39 phrase is root secret material, but the API handed it to
callers with no erasure obligation, so it could persist in freed heap memory
after drop. It now returns `Zeroizing<String>`; the phrase is joined directly
into the single allocation the wrapper owns and wipes.

- **Red test:** a heap-scanning global allocator that greps freed blocks for the
  mnemonic pattern (`hdwallet/tests/mnemonic_heap_zeroization.rs`) — failed
  before, green after.
- **Breaking change:** callers now receive `Zeroizing<String>`; use `.as_str()`
  / deref. READMEs and tests updated.

### threshold: DKG `pending_privates` queue stranded K_S in freed `Vec` buffers

`Round1Private` is `ZeroizeOnDrop`, but `Vec` reallocation copies elements
byte-wise and frees the old buffer without wiping it, so queued subset secrets
K_S survived in dead heap blocks. Elements are now `Box`ed: growth moves only
pointers, and each secret has exactly one heap home that is zeroized in place on
drop.

- **Red test:** a 2-of-5 DKG under a freed-memory-scanning allocator
  (`threshold/tests/dkg_pending_privates_realloc_zeroization.rs`) — failed
  before, green after.

### threshold: DKG `round1_privates` buffer hardened against B-tree node splits

Same class of hazard as above: `BTreeMap` rebalancing copies entries byte-wise
between nodes. Values are now `Box`ed so node operations move pointers only. No
red test was possible — supported committee sizes keep the map below the node-
split threshold — so this one is defense-in-depth.

### dilithium: hedged signing passed the randomizer `rnd` as bare `Copy` bytes

The hedge crossed four by-value `Option<[u8; 32]>` parameter slots on the
signing chain with only the innermost copy zeroized. A recovered `rnd` plus a
compromised nonce seed `K` reconstructs `ρ' = H(K || rnd || μ)` and enables the
known-mask attack hedging exists to prevent. The hedge is now threaded as
`Option<&SensitiveBytes32>` end to end (matching `Keypair::generate`'s
convention): the caller's raw buffer is wiped when the wrapper is built, signing
only ever borrows the bytes, and deterministic mode absorbs a public zero block.

- **Test note:** the release-mode painted-stack probe gained a hedged scenario.
  It did *not* fail against the old code on the tested target (the optimizer
  happened to keep the copies out of dead stack memory), so this fix removes a
  codegen-dependent hazard and an API-custody gap rather than a demonstrated
  leak; the probe stays as a regression test. ACVP and NIST KAT vectors confirm
  signatures are byte-identical.
- **Breaking change:** `sign(msg, ctx, hedge)` now takes
  `Option<&SensitiveBytes32>`. README examples updated.

### threshold: resharing wire types exposed plaintext shares and the signer

`NewShareData.s1/.s2`, `ResharingRound4Message.contributions`, and
`ResharingSignerConfig.my_signer`/`.verifying_keys` were `pub`, letting
downstream code read, log, or retain plaintext sub-shares (and extract the
long-term transcript signer) outside their `ZeroizeOnDrop` lifecycle. All are
now `pub(crate)`, matching the `PrivateKeyShare` opacity convention;
`ResharingSignerConfig::new` (which all callers already used) is the only
construction path.

- **Pinned by:** `compile_fail` doctests on all three types (the red-test
  equivalent for API exposure — they compile, and thus fail, against the old
  code).
- The crate's own adversary-simulation tests keep forge/tamper access through
  `#[doc(hidden)]` helpers gated behind the non-default `internal-test-helpers`
  feature, enabled only for the crate's own test builds via a self-referential
  dev-dependency. Caveat: the types keep their public Borsh impls (wire
  format), so a determined consumer can still serialize to extract bytes — this
  closes the accidental path, not a hard boundary.

### dilithium: `polyvec::invntt_tomont` documented an unsafe precondition

The wrapper's docs promised inputs `< 2*Q` are fine, but the underlying
`poly::invntt_tomont` requires `|c| < Q`; coefficients in `[Q, 2Q)` can overflow
the i32 inverse butterflies in release builds and silently corrupt the
polynomial. In-crate callers already reduce below Q, so this was a contract fix:
docs corrected to the stricter bound, pinned by a `#[should_panic]` test on the
debug assertion.

## Assessed, no behavior change

### threshold: resharing first-message-wins buffering (Round 4 / accepts)

The review flagged that `handle_round4_message` and `handle_accept_message`
buffer the first message per sender without content verification, so a bad
first message occupies the slot. Under the crate's documented
sender-authenticated transport requirement, that scenario reduces to a sender
poisoning *its own* slot — no stronger than withholding (attributed abort and
restart) — while replace-on-duplicate would enable adaptive equivocation.
First-wins is therefore the anti-equivocation policy, kept and made explicit:
both handlers now document the argument, dropped duplicates are logged (warning
level when accept signatures conflict, which is observable equivocation), and a
regression test pins that duplicates never displace the first message.

## Testing

- Full workspace suite passes (unit, integration, doctests).
- Release-mode painted-stack probes pass for all three ML-DSA parameter sets.
- Heap-scanning allocator tests cover the mnemonic and DKG queue fixes.
- ACVP sigGen/keyGen/sigVer and NIST KAT vectors pass unchanged, confirming no
  cryptographic behavior drift.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches signing hedge custody, mnemonic return type, and threshold secret buffering with public API breaks; cryptographic behavior is pinned by ACVP/KAT and new zeroization tests.
> 
> **Overview**
> Security-review hardening across signing, HD wallet, and threshold protocols, with regression tests and **breaking API changes** where callers must adopt self-wiping wrappers.
> 
> **ML-DSA (dilithium):** Hedged signing now takes `Option<&SensitiveBytes32>` end-to-end instead of copying `rnd` through the call chain; README, ACVP, KAT, and integration tests updated. `polyvec::invntt_tomont` docs now require `|c| < Q` (not `< 2*Q`), with a debug `should_panic` test. Release stack probe adds a hedged-signing scenario.
> 
> **hdwallet:** `generate_mnemonic` returns `Zeroizing<String>` so the recovery phrase is wiped on drop; new heap-scanning test in `mnemonic_heap_zeroization.rs`.
> 
> **threshold:** DKG queues/buffers store `Round1Private` in `Box`es so `Vec`/`BTreeMap` growth does not free unwiped K_S; new 2-of-5 realloc heap test. Resharing makes sub-shares and signer config `pub(crate)` with `internal-test-helpers` for adversary tests; first-message-wins duplicate policy documented and pinned by unit test.
> 
> **Assessed (no behavior change):** Round 4 / accept buffering stays first-wins with logging on conflicting accepts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1713bcfcc3c635d0a16fd41b9ee4340a4e8a909a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->