### PR TITLE
ci: Automate hdwallet version bump to hdwallet-v4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libm = { version = "=0.2.11" }
 log = { version = "=0.4.29", default-features = false }
 qp-poseidon-core = { version = "=3.1.0", default-features = false }
 qp-rusty-crystals-dilithium = { path = "./dilithium", version = "4.1.0", default-features = false }
-qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "4.0.0", default-features = false }
+qp-rusty-crystals-hdwallet = { path = "./hdwallet", version = "4.1.0", default-features = false }
 qp-rusty-crystals-test-utils = { path = "./test-utils" }
 qp-rusty-crystals-threshold = { path = "./threshold", version = "=3.0.0", default-features = false }
 rand = { version = "=0.10.1", default-features = false, features = ["std_rng", "thread_rng"] }

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-rusty-crystals-hdwallet"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of HD wallet functionality with post-quantum cryptography"


### PR DESCRIPTION
Automated hdwallet version bump for release **hdwallet-v4.1.0**.

- `qp-rusty-crystals-hdwallet` **4.0.0 → 4.1.0**
- Depends on **qp-rusty-crystals-dilithium 4.1.0** (workspace, already published)
- Depends on **qp-poseidon-core 3.1.0** (already on master)

No source changes — version metadata only so crates.io reverse-deps can pick up poseidon 3.1.0 + dilithium 4.1.0.

Type: minor (aligned with dilithium 4.1.0)